### PR TITLE
Ensure avatar generation progress dialog is rendered

### DIFF
--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -232,6 +232,7 @@ class AdminDashboard(QWidget):
         progress.setWindowModality(Qt.WindowModality.WindowModal)
         progress.setValue(0)
         progress.show()
+        QApplication.processEvents()
 
         def cb(done: int, _total: int) -> None:
             progress.setValue(done)


### PR DESCRIPTION
## Summary
- Process Qt events after showing the player avatar generation progress dialog so it is drawn before heavy processing

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d00314798832eac11aff0bf3b99a1