### PR TITLE
Keep splash screen visible until login completes

### DIFF
--- a/ui/login_window.py
+++ b/ui/login_window.py
@@ -14,10 +14,14 @@ USER_FILE = os.path.abspath(
 )
 
 class LoginWindow(QWidget):
-    def __init__(self):
+    def __init__(self, splash=None):
         super().__init__()
         self.setWindowTitle("UBL Login")
         self.setGeometry(100, 100, 300, 150)
+
+        # Keep a reference to the splash screen so it can be closed after
+        # successful authentication.
+        self.splash = splash
 
         self.username_input = QLineEdit()
         self.username_input.setPlaceholderText("Username")
@@ -77,6 +81,11 @@ class LoginWindow(QWidget):
         # Display the dashboard in a maximized window so standard window
         # controls (minimize, maximize, close) are available.
         self.dashboard.showMaximized()
+
+        # Close the splash screen once the dashboard is displayed
+        if self.splash:
+            self.splash.close()
+
         self.close()
 
 if __name__ == "__main__":

--- a/ui/splash_screen.py
+++ b/ui/splash_screen.py
@@ -43,7 +43,9 @@ class SplashScreen(QWidget):
         self.login_window = None
 
     def open_login(self):
-        """Show the login window and hide the splash screen."""
-        self.login_window = LoginWindow()
+        """Show the login window while keeping the splash visible."""
+        # Disable the button to prevent spawning multiple login windows
+        self.login_button.setEnabled(False)
+
+        self.login_window = LoginWindow(self)
         self.login_window.show()
-        self.hide()


### PR DESCRIPTION
## Summary
- Keep splash screen visible when opening login dialog and disable Start Game button to avoid duplicates
- Pass splash screen into LoginWindow and close it after a successful login

## Testing
- `pytest`
- `QT_QPA_PLATFORM=offscreen timeout 5s python main.py` *(fails: No module named 'PyQt6')*
- `pip install PyQt6` *(fails: Could not find a version that satisfies the requirement PyQt6)*

------
https://chatgpt.com/codex/tasks/task_e_689d08a9d9d8832e99bdb725e59e5700