### PR TITLE
Improve avatar generation init progress reporting

### DIFF
--- a/tests/test_ubl_avatar_init_progress.py
+++ b/tests/test_ubl_avatar_init_progress.py
@@ -1,0 +1,81 @@
+"""Tests for initialisation progress in SDXL avatar generation."""
+
+import sys
+import types
+
+from utils.ubl_avatar_generator import INIT_STEPS, generate_player_avatars_sdxl
+
+
+def test_init_progress_advances(monkeypatch, tmp_path):
+    """Ensure progress callback advances during initialisation."""
+
+    class DummyImage:
+        def resize(self, size, resample=None):
+            return self
+
+        def save(self, path):
+            return None
+
+    # Provide stub modules for heavy dependencies
+    pil_module = types.ModuleType("PIL")
+    pil_image_module = types.ModuleType("PIL.Image")
+    pil_image_module.open = lambda path: DummyImage()
+    pil_image_module.LANCZOS = 0
+    pil_module.Image = pil_image_module
+    monkeypatch.setitem(sys.modules, "PIL", pil_module)
+    monkeypatch.setitem(sys.modules, "PIL.Image", pil_image_module)
+
+    class DummyCache:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get(self, *args, **kwargs):
+            return None
+
+        def set(self, *args, **kwargs):
+            pass
+
+        def close(self):
+            pass
+
+    diskcache_module = types.ModuleType("diskcache")
+    diskcache_module.Cache = DummyCache
+    monkeypatch.setitem(sys.modules, "diskcache", diskcache_module)
+
+    class DummyPipe:
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            return cls()
+
+        def to(self, device):
+            return self
+
+        def __call__(self, prompt):
+            class R:
+                images = [DummyImage()]
+
+            return R()
+
+    diffusers_module = types.ModuleType("diffusers")
+    diffusers_module.StableDiffusionXLPipeline = DummyPipe
+    monkeypatch.setitem(sys.modules, "diffusers", diffusers_module)
+
+    torch_module = types.ModuleType("torch")
+    torch_module.cuda = types.SimpleNamespace(is_available=lambda: False)
+    torch_module.float16 = "float16"
+    monkeypatch.setitem(sys.modules, "torch", torch_module)
+
+    calls = []
+
+    generate_player_avatars_sdxl(
+        out_dir=str(tmp_path),
+        players={},
+        teams=[],
+        progress_callback=lambda done, total: calls.append((done, total)),
+    )
+
+    assert calls[0] == (0, INIT_STEPS)
+    # Final call reflects completed initialisation with no players processed
+    assert calls[-1] == (INIT_STEPS, INIT_STEPS)
+    assert len(calls) == INIT_STEPS + 1
+

--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -26,6 +26,7 @@ from utils.roster_loader import load_roster
 from utils.player_loader import load_players_from_csv
 from utils.team_loader import load_teams
 from utils.user_manager import add_user, load_users, update_user
+from utils.ubl_avatar_generator import INIT_STEPS
 from models.trade import Trade
 import csv
 import os
@@ -224,11 +225,12 @@ class AdminDashboard(QWidget):
             player_ids.update(roster.act + roster.aaa + roster.low)
 
         total = sum(1 for pid in player_ids if pid in players)
+        overall_total = total + INIT_STEPS
         progress = QProgressDialog(
             "Generating player avatars...",
             "Cancel",
             0,
-            total,
+            overall_total,
             self,
         )
         progress.setWindowTitle("Generating Avatars")


### PR DESCRIPTION
## Summary
- track SDXL model initialisation steps with `INIT_STEPS`
- extend avatar generation progress bar to include initialisation
- add regression test for SDXL avatar initialisation progress

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d0aa345e4832e9ae840a0bf2427ab