### PR TITLE
Fix pitching staff autofill by using pitcher role

### DIFF
--- a/ui/pitching_editor.py
+++ b/ui/pitching_editor.py
@@ -53,7 +53,12 @@ class PitchingEditor(QDialog):
                 for row in csv.DictReader(f):
                     pid = row["player_id"].strip()
                     name = f"{row['first_name']} {row['last_name']} ({row['primary_position']})"
-                    players[pid] = {"name": name, "primary_position": row["primary_position"]}
+                    players[pid] = {
+                        "name": name,
+                        "primary_position": row["primary_position"],
+                        "role": row.get("role", ""),
+                        "endurance": row.get("endurance", ""),
+                    }
         return players
 
     def get_act_level_ids(self):


### PR DESCRIPTION
## Summary
- include pitcher role and endurance when loading players so get_role works
- restores users file after accidental modification

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d1f46b38c832eb5f3d66d1a1d5353