### PR TITLE
feat: enlarge standings dialog

### DIFF
--- a/ui/standings_window.py
+++ b/ui/standings_window.py
@@ -10,11 +10,15 @@ class StandingsWindow(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle("Standings")
+        # Expand the dialog so the standings HTML can be viewed without scrolling
+        self.setGeometry(100, 100, 1000, 800)
 
         layout = QVBoxLayout(self)
 
         viewer = QTextEdit()
         viewer.setReadOnly(True)
+        # Ensure the text area grows with the dialog
+        viewer.setMinimumHeight(760)
 
         base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
         html_path = os.path.join(base_dir, "samples", "StandingsSample.html")


### PR DESCRIPTION
## Summary
- expand standings dialog so standings HTML shows without scrolling
- size text view to match larger dialog

## Testing
- `pytest tests/test_standings_window.py -q`
- `pytest -q` *(fails: tests/test_league_creator.py::test_create_league_generates_files: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_689d22c55e00832e9f135cf62febc895