### PR TITLE
Improve pitching staff autofill logic

### DIFF
--- a/tests/test_pitching_autofill.py
+++ b/tests/test_pitching_autofill.py
@@ -1,0 +1,36 @@
+from utils.pitching_autofill import autofill_pitching_staff
+
+
+def test_autofill_prefers_sp_and_low_endurance_closer():
+    players = [
+        ("sp1", {"role": "SP", "endurance": 80}),
+        ("sp2", {"role": "SP", "endurance": 70}),
+        ("sp3", {"role": "SP", "endurance": 60}),
+        ("rp1", {"role": "RP", "endurance": 55}),
+        ("rp2", {"role": "RP", "endurance": 45}),
+        ("rp3", {"role": "RP", "endurance": 35}),
+        ("rp4", {"role": "RP", "endurance": 25}),
+        ("rp5", {"role": "RP", "endurance": 15}),
+        ("rp6", {"role": "RP", "endurance": 5}),
+    ]
+
+    assignments = autofill_pitching_staff(players)
+
+    # Starters should be filled with SPs when available
+    assert assignments["SP1"] == "sp1"
+    assert assignments["SP2"] == "sp2"
+    assert assignments["SP3"] == "sp3"
+    # Not enough SPs for SP4/SP5; highest-endurance RPs fill in
+    assert assignments["SP4"] == "rp1"
+    assert assignments["SP5"] == "rp2"
+
+    # Bullpen: long/middle/setup use remaining highest-endurance RPs
+    assert assignments["LR"] == "rp3"
+    assert assignments["MR"] == "rp4"
+    assert assignments["SU"] == "rp5"
+
+    # Closer should get the lowest-endurance RP
+    assert assignments["CL"] == "rp6"
+
+    # Ensure each pitcher is used only once
+    assert len(set(assignments.values())) == len(assignments)

--- a/ui/pitching_editor.py
+++ b/ui/pitching_editor.py
@@ -2,6 +2,7 @@ from PyQt6.QtWidgets import QDialog, QLabel, QVBoxLayout, QGridLayout, QComboBox
 import os
 import csv
 from utils.pitcher_role import get_role
+from utils.pitching_autofill import autofill_pitching_staff
 
 class PitchingEditor(QDialog):
     def __init__(self, team_id):
@@ -107,16 +108,20 @@ class PitchingEditor(QDialog):
                                     break
 
     def autofill_staff(self):
-        available = [pid for pid, pdata in self.players_dict.items()
-                     if pid in self.act_ids and get_role(pdata)]
-        used = set()
-        for role in self.roles:
-            dropdown = self.pitcher_dropdowns[role]
+        available = [
+            (pid, pdata)
+            for pid, pdata in self.players_dict.items()
+            if pid in self.act_ids and get_role(pdata)
+        ]
+        assignments = autofill_pitching_staff(available)
+        for role, dropdown in self.pitcher_dropdowns.items():
+            pid = assignments.get(role)
+            if pid is None:
+                dropdown.setCurrentIndex(-1)
+                continue
             for i in range(dropdown.count()):
-                pid = dropdown.itemData(i)
-                if pid not in used:
+                if dropdown.itemData(i) == pid:
                     dropdown.setCurrentIndex(i)
-                    used.add(pid)
                     break
 
     def clear_staff(self):

--- a/utils/pitching_autofill.py
+++ b/utils/pitching_autofill.py
@@ -1,0 +1,84 @@
+"""Utilities for assigning pitchers to staff roles.
+
+This module provides logic used by the ``PitchingEditor`` UI to automatically
+assign available pitchers to staff roles in a sensible manner.  Starters are
+chosen for the rotation before relievers, and relievers are distributed to the
+bullpen with closers favoring low endurance arms.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Tuple
+
+from .pitcher_role import get_role
+
+# Type aliases for clarity
+PlayerEntry = Tuple[str, dict]
+Assignments = Dict[str, str]
+
+
+def autofill_pitching_staff(players: Iterable[PlayerEntry]) -> Assignments:
+    """Return a mapping of pitching roles to player IDs.
+
+    Parameters
+    ----------
+    players:
+        An iterable of ``(player_id, data)`` pairs where ``data`` is a mapping
+        containing at least ``endurance`` and attributes usable by
+        :func:`utils.pitcher_role.get_role`.
+
+    The algorithm prefers starting pitchers (``SP``) for the rotation.  If
+    there are not enough starters, the highest-endurance relievers are used to
+    fill any remaining rotation spots.  Bullpen roles are then assigned using
+    the remaining relievers, with the long reliever getting the highest
+    endurance and the closer getting the lowest endurance.
+    """
+
+    # Separate starters and relievers, capturing endurance as an int
+    sps: list[tuple[str, int]] = []
+    rps: list[tuple[str, int]] = []
+    for pid, pdata in players:
+        role = get_role(pdata)
+        if not role:
+            continue
+        try:
+            endurance = int(pdata.get("endurance", 0))
+        except (TypeError, ValueError):
+            endurance = 0
+        if role == "SP":
+            sps.append((pid, endurance))
+        else:
+            rps.append((pid, endurance))
+
+    # Order by endurance descending for easier selection
+    sps.sort(key=lambda x: x[1], reverse=True)
+    rps.sort(key=lambda x: x[1], reverse=True)
+
+    assignment: Assignments = {}
+
+    # Fill the starting rotation (SP1-SP5)
+    for i in range(5):
+        if sps:
+            pid, _ = sps.pop(0)
+        elif rps:
+            # Fall back to highest-endurance reliever if short on starters
+            pid, _ = rps.pop(0)
+        else:
+            break
+        assignment[f"SP{i + 1}"] = pid
+
+    # Bullpen roles use remaining relievers.
+    if rps:
+        pid, _ = rps.pop(0)
+        assignment["LR"] = pid  # Long reliever prefers high endurance
+    if rps:
+        pid, _ = rps.pop(0)
+        assignment["MR"] = pid  # Middle reliever
+    if rps:
+        pid, _ = rps.pop(0)
+        assignment["SU"] = pid  # Setup
+    if rps:
+        pid, _ = rps.pop(-1)
+        assignment["CL"] = pid  # Closer prefers low endurance
+
+    return assignment


### PR DESCRIPTION
## Summary
- improve pitching staff autofill to prefer starters and assign bullpen roles logically
- add `autofill_pitching_staff` helper and corresponding unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d23dadc34832ea46c49f4565d7b7c