### PR TITLE
Resize dashboards and persist splash

### DIFF
--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -36,7 +36,9 @@ class AdminDashboard(QWidget):
     def __init__(self):
         super().__init__()
         self.setWindowTitle("Admin Dashboard")
-        self.setGeometry(200, 200, 500, 300)
+        # Use a modest default size so the dashboard doesn't fill the screen
+        # when launched.
+        self.setGeometry(200, 200, 800, 600)
 
         layout = QVBoxLayout()
         layout.setContentsMargins(20, 20, 20, 20)

--- a/ui/login_window.py
+++ b/ui/login_window.py
@@ -78,13 +78,12 @@ class LoginWindow(QWidget):
             QMessageBox.warning(self, "Error", "Unrecognized role.")
             return
 
-        # Display the dashboard in a maximized window so standard window
-        # controls (minimize, maximize, close) are available.
-        self.dashboard.showMaximized()
+        # Show the dashboard at its default size rather than maximized so it
+        # doesn't dominate the entire screen.
+        self.dashboard.show()
 
-        # Close the splash screen once the dashboard is displayed
-        if self.splash:
-            self.splash.close()
+        # Keep the splash screen visible in the background until the
+        # application exits.
 
         self.close()
 

--- a/ui/owner_dashboard.py
+++ b/ui/owner_dashboard.py
@@ -79,7 +79,9 @@ class OwnerDashboard(QWidget):
         self.team = teams.get(team_id)
 
         # Window
-        self.setGeometry(200, 200, 900, 650)
+        # Open slightly smaller than full screen so multiple windows can be
+        # visible at once.
+        self.setGeometry(200, 200, 1000, 700)
         self.setWindowTitle(f"Owner Dashboard - {team_id}")
 
         bold = QFont()


### PR DESCRIPTION
## Summary
- Ensure owner and admin dashboards launch in windowed mode with modest default sizes
- Keep splash screen visible for the entire application session
- Restore original users data file

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d249dfe74832e851cb9b9744fa3f3