### PR TITLE
Add PIL import for avatar creation script

### DIFF
--- a/images/create_avatar.py
+++ b/images/create_avatar.py
@@ -1,4 +1,5 @@
 from avatars import generate_player_headshot, pil_to_qpixmap
+from PIL import Image
 
 img = generate_player_headshot(
     player_name="Brian Pleasant",


### PR DESCRIPTION
## Summary
- import Pillow's `Image` module in `images/create_avatar.py` to support image resizing

## Testing
- `pytest -q`
- `python images/create_avatar.py` *(fails: ModuleNotFoundError: No module named 'PIL')*
- `pip install Pillow` *(fails: Could not find a version that satisfies the requirement Pillow)*

------
https://chatgpt.com/codex/tasks/task_e_689d24aab5d0832eaeb3b101b61a2e3e