### PR TITLE
Enable owner trade dialog and notifications

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import random
+
+
+def pytest_sessionstart(session):
+    """Ensure a non-deterministic RNG for tests depending on randomness."""
+    random.seed()

--- a/tests/test_trade_utils.py
+++ b/tests/test_trade_utils.py
@@ -1,0 +1,33 @@
+import tempfile
+import random
+
+from models.trade import Trade
+from utils.trade_utils import get_pending_trades, load_trades, save_trade
+
+# Reseed RNG so earlier tests that modify random state don't influence later ones
+random.seed()
+
+
+def test_save_trade_updates_existing(tmp_path):
+    path = tmp_path / "trades.csv"
+    t = Trade("1", "A", "B", ["p1"], ["p2"])
+    save_trade(t, str(path))
+    trades = load_trades(str(path))
+    assert len(trades) == 1
+    assert trades[0].status == "pending"
+
+    t.status = "accepted"
+    save_trade(t, str(path))
+    trades = load_trades(str(path))
+    assert len(trades) == 1
+    assert trades[0].status == "accepted"
+
+
+def test_get_pending_trades(tmp_path):
+    path = tmp_path / "trades.csv"
+    save_trade(Trade("1", "A", "B", ["p1"], ["p2"]), str(path))
+    save_trade(Trade("2", "C", "A", ["p3"], ["p4"]), str(path))
+    save_trade(Trade("3", "D", "A", ["p5"], ["p6"], status="accepted"), str(path))
+    pending = get_pending_trades("A", str(path))
+    assert len(pending) == 1
+    assert pending[0].trade_id == "2"

--- a/ui/owner_dashboard.py
+++ b/ui/owner_dashboard.py
@@ -35,12 +35,14 @@ from ui.transactions_window import TransactionsWindow
 from ui.team_settings_dialog import TeamSettingsDialog
 from ui.standings_window import StandingsWindow
 from ui.schedule_window import ScheduleWindow
+from ui.trade_dialog import TradeDialog
 from utils.roster_loader import load_roster, save_roster
 from utils.player_loader import load_players_from_csv
 from utils.news_reader import read_latest_news
 from utils.free_agent_finder import find_free_agents
 from utils.team_loader import load_teams, save_team_settings
 from utils.pitcher_role import get_role
+from utils.trade_utils import get_pending_trades
 
 
 def _hex_to_rgb(value: str) -> tuple[int, int, int]:
@@ -207,6 +209,13 @@ class OwnerDashboard(QWidget):
         self.load_news_feed()
         self.update_roster_count_display()
         self.update_window_title()
+        pending = get_pending_trades(self.team_id)
+        if pending:
+            QMessageBox.information(
+                self,
+                "Pending Trades",
+                f"You have {len(pending)} pending trade(s). Open Trade Center to respond.",
+            )
 
     def apply_team_colors(self):
         """Apply the team's color scheme to the dashboard."""
@@ -376,7 +385,7 @@ class OwnerDashboard(QWidget):
             QMessageBox.critical(self, "Error", f"Failed to save roster: {e}")
 
     def open_trade_dialog(self):
-        QMessageBox.information(self, "Trade", "Open trade dialog (placeholder).")
+        TradeDialog(self.team_id, self).exec()
 
     def sign_free_agent(self):
         try:

--- a/ui/trade_dialog.py
+++ b/ui/trade_dialog.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from models.trade import Trade
+from utils.player_loader import load_players_from_csv
+from utils.roster_loader import load_roster, save_roster
+from utils.team_loader import load_teams
+from utils.trade_utils import get_pending_trades, save_trade
+
+import uuid
+
+
+class TradeDialog(QDialog):
+    """Dialog allowing an owner to propose and respond to trades."""
+
+    def __init__(self, team_id: str, parent=None):
+        super().__init__(parent)
+        self.team_id = team_id
+        self.players = {p.player_id: p for p in load_players_from_csv("data/players.csv")}
+
+        self.setWindowTitle("Trade Center")
+        self.resize(600, 400)
+
+        tabs = QTabWidget()
+        tabs.addTab(self._build_new_trade_tab(), "New Trade")
+        tabs.addTab(self._build_incoming_tab(), "Incoming")
+
+        layout = QVBoxLayout()
+        layout.addWidget(tabs)
+        self.setLayout(layout)
+
+    # --- New trade tab -------------------------------------------------
+    def _build_new_trade_tab(self) -> QWidget:
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+
+        layout.addWidget(QLabel("Trade with:"))
+        self.team_dropdown = QComboBox()
+        teams = [t.team_id for t in load_teams() if t.team_id != self.team_id]
+        self.team_dropdown.addItems(teams)
+        self.team_dropdown.currentTextChanged.connect(self._refresh_receive_list)
+        layout.addWidget(self.team_dropdown)
+
+        layout.addWidget(QLabel("Players to Give"))
+        self.give_list = QListWidget()
+        self.give_list.setSelectionMode(QListWidget.SelectionMode.MultiSelection)
+        roster = load_roster(self.team_id)
+        for pid in roster.act:
+            self.give_list.addItem(self._make_player_item(pid))
+        layout.addWidget(self.give_list)
+
+        layout.addWidget(QLabel("Players to Receive"))
+        self.receive_list = QListWidget()
+        self.receive_list.setSelectionMode(QListWidget.SelectionMode.MultiSelection)
+        layout.addWidget(self.receive_list)
+        self._refresh_receive_list(self.team_dropdown.currentText())
+
+        submit_btn = QPushButton("Submit Trade")
+        submit_btn.clicked.connect(self._submit_trade)
+        layout.addWidget(submit_btn)
+
+        return widget
+
+    def _make_player_item(self, pid: str) -> QListWidgetItem:
+        p = self.players.get(pid)
+        label = f"{p.first_name} {p.last_name} ({pid})" if p else pid
+        item = QListWidgetItem(label)
+        item.setData(Qt.ItemDataRole.UserRole, pid)
+        return item
+
+    def _refresh_receive_list(self, team_id: str):
+        self.receive_list.clear()
+        if not team_id:
+            return
+        roster = load_roster(team_id)
+        for pid in roster.act:
+            self.receive_list.addItem(self._make_player_item(pid))
+
+    def _submit_trade(self):
+        to_team = self.team_dropdown.currentText()
+        give_items = self.give_list.selectedItems()
+        recv_items = self.receive_list.selectedItems()
+        if not to_team or not give_items or not recv_items:
+            QMessageBox.warning(self, "Incomplete", "Select players to trade.")
+            return
+        give_ids = [i.data(Qt.ItemDataRole.UserRole) for i in give_items]
+        recv_ids = [i.data(Qt.ItemDataRole.UserRole) for i in recv_items]
+        trade = Trade(
+            trade_id=uuid.uuid4().hex[:8],
+            from_team=self.team_id,
+            to_team=to_team,
+            give_player_ids=give_ids,
+            receive_player_ids=recv_ids,
+        )
+        save_trade(trade)
+        QMessageBox.information(self, "Trade Sent", f"Trade proposal sent to {to_team}.")
+        self.give_list.clearSelection()
+        self.receive_list.clearSelection()
+
+    # --- Incoming trades tab -------------------------------------------
+    def _build_incoming_tab(self) -> QWidget:
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+
+        self.incoming_list = QListWidget()
+        layout.addWidget(self.incoming_list)
+
+        btn_row = QHBoxLayout()
+        accept_btn = QPushButton("Accept")
+        reject_btn = QPushButton("Reject")
+        accept_btn.clicked.connect(lambda: self._respond_to_trade(True))
+        reject_btn.clicked.connect(lambda: self._respond_to_trade(False))
+        btn_row.addWidget(accept_btn)
+        btn_row.addWidget(reject_btn)
+        layout.addLayout(btn_row)
+
+        self._load_incoming_trades()
+        return widget
+
+    def _load_incoming_trades(self):
+        self.trade_map: Dict[str, Trade] = {}
+        self.incoming_list.clear()
+        for t in get_pending_trades(self.team_id):
+            give_names = [self.players.get(pid).last_name for pid in t.give_player_ids if pid in self.players]
+            recv_names = [self.players.get(pid).last_name for pid in t.receive_player_ids if pid in self.players]
+            summary = f"{t.trade_id}: {t.from_team} → {t.to_team} | Give: {', '.join(give_names)} | Get: {', '.join(recv_names)}"
+            self.incoming_list.addItem(summary)
+            self.trade_map[summary] = t
+
+    def _respond_to_trade(self, accept: bool):
+        selected = self.incoming_list.currentItem()
+        if not selected:
+            QMessageBox.warning(self, "No Selection", "Select a trade to respond to.")
+            return
+        trade = self.trade_map[selected.text()]
+        trade.status = "accepted" if accept else "rejected"
+        if accept:
+            self._process_trade(trade)
+        save_trade(trade)
+        QMessageBox.information(self, "Trade Updated", f"Trade {trade.trade_id} {trade.status}.")
+        self.incoming_list.takeItem(self.incoming_list.currentRow())
+
+    def _process_trade(self, trade: Trade):
+        from_roster = load_roster(trade.from_team)
+        to_roster = load_roster(trade.to_team)
+        for pid in trade.give_player_ids:
+            for roster in (from_roster, to_roster):
+                if pid in roster.act:
+                    roster.act.remove(pid)
+            to_roster.act.append(pid)
+        for pid in trade.receive_player_ids:
+            for roster in (from_roster, to_roster):
+                if pid in roster.act:
+                    roster.act.remove(pid)
+            from_roster.act.append(pid)
+        save_roster(trade.from_team, from_roster)
+        save_roster(trade.to_team, to_roster)

--- a/utils/trade_utils.py
+++ b/utils/trade_utils.py
@@ -21,18 +21,41 @@ def load_trades(file_path="data/trades_pending.csv"):
     return trades
 
 def save_trade(trade: Trade, file_path="data/trades_pending.csv"):
-    existing = load_trades(file_path)
+    """Save ``trade`` to ``file_path`` replacing any existing entry.
+
+    The previous implementation always appended a trade, which caused
+    duplicates whenever a trade was updated (e.g. when an owner accepted or
+    rejected a proposal).  We now remove any trade with the same ``trade_id``
+    before writing the updated list back to disk.
+    """
+
+    existing = [t for t in load_trades(file_path) if t.trade_id != trade.trade_id]
     existing.append(trade)
     with open(file_path, "w", newline="") as f:
-        fieldnames = ["trade_id", "from_team", "to_team", "give_player_ids", "receive_player_ids", "status"]
+        fieldnames = [
+            "trade_id",
+            "from_team",
+            "to_team",
+            "give_player_ids",
+            "receive_player_ids",
+            "status",
+        ]
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
         for t in existing:
-            writer.writerow({
-                "trade_id": t.trade_id,
-                "from_team": t.from_team,
-                "to_team": t.to_team,
-                "give_player_ids": "|".join(t.give_player_ids),
-                "receive_player_ids": "|".join(t.receive_player_ids),
-                "status": t.status
-            })
+            writer.writerow(
+                {
+                    "trade_id": t.trade_id,
+                    "from_team": t.from_team,
+                    "to_team": t.to_team,
+                    "give_player_ids": "|".join(t.give_player_ids),
+                    "receive_player_ids": "|".join(t.receive_player_ids),
+                    "status": t.status,
+                }
+            )
+
+
+def get_pending_trades(team_id: str, file_path="data/trades_pending.csv"):
+    """Return trades awaiting response for ``team_id``."""
+
+    return [t for t in load_trades(file_path) if t.to_team == team_id and t.status == "pending"]


### PR DESCRIPTION
## Summary
- Add TradeDialog for proposing and responding to trades
- Notify owners of pending trade proposals in OwnerDashboard
- Track and update trades with new utilities and tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d2c0d0f6c832ea2850e6d951315b2