### PR TITLE
Keep splash screen visible behind dashboard

### DIFF
--- a/ui/login_window.py
+++ b/ui/login_window.py
@@ -85,10 +85,11 @@ class LoginWindow(QWidget):
         # Show the dashboard at its default size rather than maximized so it
         # doesn't dominate the entire screen.
         self.dashboard.show()
+        self.dashboard.activateWindow()
 
-        # Hide the splash screen while the dashboard is active.
+        # Keep the splash screen visible behind the dashboard.
         if self.splash:
-            self.splash.hide()
+            self.splash.lower()
 
         # Close the login window now that the dashboard is displayed.
         self.close()


### PR DESCRIPTION
## Summary
- Keep splash screen visible behind dashboard windows
- Activate dashboard after login

## Testing
- `pytest` *(fails: assert 10 >= 11 in test_league_creator.py::test_create_league_generates_files)*

------
https://chatgpt.com/codex/tasks/task_e_689d2f03e3ac832ebdb33f05c4d04fab