### PR TITLE
Use PyQt6 WindowType enum for splash screen

### DIFF
--- a/ui/login_window.py
+++ b/ui/login_window.py
@@ -91,7 +91,7 @@ class LoginWindow(QWidget):
 
         # Keep the splash screen visible above the dashboard.
         if self.splash:
-            self.splash.setWindowFlag(Qt.WindowStaysOnTopHint, True)
+            self.splash.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, True)
             self.splash.show()
 
         # Close the login window now that the dashboard is displayed.


### PR DESCRIPTION
## Summary
- Use `Qt.WindowType.WindowStaysOnTopHint` so the splash screen remains on top in PyQt6

## Testing
- `pytest`
- ⚠️ Unable to run GUI-based login workflow due to missing PyQt6 dependency

------
https://chatgpt.com/codex/tasks/task_e_689e4a4f1b7c832eafba4186248fb5c6