### PR TITLE
Add physics helper and integrate into simulation

### DIFF
--- a/logic/physics.py
+++ b/logic/physics.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import random
+
+from .playbalance_config import PlayBalanceConfig
+
+
+class Physics:
+    """Helper performing simple physics related calculations.
+
+    Only a tiny subset of the original game's physics model is reproduced
+    here.  The goal is to expose enough behaviour so that unit tests can
+    validate that configuration values from :class:`PlayBalanceConfig` influence
+    gameplay.  All calculations intentionally stay very small and deterministic
+    to keep the tests predictable.
+    """
+
+    def __init__(self, config: PlayBalanceConfig, rng: random.Random | None = None) -> None:
+        self.config = config
+        self.rng = rng or random.Random()
+
+    # ------------------------------------------------------------------
+    # Player movement speed
+    # ------------------------------------------------------------------
+    def player_speed(self, sp: int) -> float:
+        """Return the movement speed for a player with ``sp`` rating."""
+
+        base = getattr(self.config, "speedBase")
+        pct = getattr(self.config, "speedPct")
+        return base + pct * sp / 100.0
+
+    # ------------------------------------------------------------------
+    # Bat speed
+    # ------------------------------------------------------------------
+    def bat_speed(self, ph: int, swing_type: str = "normal") -> float:
+        """Return bat speed for ``ph`` and ``swing_type``.
+
+        ``swing_type`` may be ``"power"``, ``"normal"``, ``"contact"`` or
+        ``"bunt"``.  Only the adjustment to the PH rating changes between the
+        types.  The returned value is expressed in miles per hour just like in
+        the original game engine.
+        """
+
+        base = getattr(self.config, "swingSpeedBase")
+        pct = getattr(self.config, "swingSpeedPHPct")
+        adjust_key = {
+            "power": "swingSpeedPowerAdjust",
+            "normal": "swingSpeedNormalAdjust",
+            "contact": "swingSpeedContactAdjust",
+            "bunt": "swingSpeedBuntAdjust",
+        }.get(swing_type, "swingSpeedNormalAdjust")
+        ph_adj = ph + getattr(self.config, adjust_key)
+        return base + pct * ph_adj / 100.0
+
+    # ------------------------------------------------------------------
+    # Swing angle
+    # ------------------------------------------------------------------
+    def swing_angle(
+        self,
+        gf: int,
+        *,
+        swing_type: str = "normal",
+        pitch_loc: str = "middle",
+    ) -> float:
+        """Return the swing angle in degrees for a player.
+
+        ``gf`` is the batter's ground/fly rating.  ``swing_type`` and
+        ``pitch_loc`` can influence the result by applying configuration based
+        adjustments.  A deterministic value is returned which keeps unit tests
+        simple and reproducible.
+        """
+
+        base = getattr(self.config, "swingAngleTenthDegreesBase")
+        rng_range = getattr(self.config, "swingAngleTenthDegreesRange")
+        # Keep deterministic: use the mid point of the range rather than a
+        # random pick.
+        angle = base + rng_range / 2.0
+
+        gf_pct = getattr(self.config, "swingAngleTenthDegreesGFPct")
+        angle += (gf - 50) * gf_pct / 100.0
+
+        if swing_type == "power":
+            angle += getattr(self.config, "swingAngleTenthDegreesPowerAdjust")
+        elif swing_type == "contact":
+            angle += getattr(self.config, "swingAngleTenthDegreesContactAdjust")
+
+        if pitch_loc == "high":
+            angle += getattr(self.config, "swingAngleTenthDegreesHighAdjust")
+        elif pitch_loc == "low":
+            angle += getattr(self.config, "swingAngleTenthDegreesLowAdjust")
+        elif pitch_loc == "outside":
+            angle += getattr(self.config, "swingAngleTenthDegreesOutsideAdjust")
+
+        return angle / 10.0
+
+
+__all__ = ["Physics"]

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -1,0 +1,126 @@
+import random
+
+from logic.simulation import GameSimulation, TeamState, BatterState
+from models.player import Player
+from models.pitcher import Pitcher
+from tests.util.pbini_factory import make_cfg
+
+
+class MockRandom(random.Random):
+    """Deterministic random generator using a predefined sequence."""
+
+    def __init__(self, values):
+        super().__init__()
+        self.values = list(values)
+
+    def random(self):  # type: ignore[override]
+        return self.values.pop(0)
+
+
+def make_player(pid: str, ph: int = 50, sp: int = 50, ch: int = 50) -> Player:
+    return Player(
+        player_id=pid,
+        first_name="F" + pid,
+        last_name="L" + pid,
+        birthdate="2000-01-01",
+        height=72,
+        weight=180,
+        bats="R",
+        primary_position="1B",
+        other_positions=[],
+        gf=50,
+        ch=ch,
+        ph=ph,
+        sp=sp,
+        pl=0,
+        vl=0,
+        sc=0,
+        fa=0,
+        arm=0,
+    )
+
+
+def make_pitcher(pid: str) -> Pitcher:
+    return Pitcher(
+        player_id=pid,
+        first_name="PF" + pid,
+        last_name="PL" + pid,
+        birthdate="2000-01-01",
+        height=72,
+        weight=180,
+        bats="R",
+        primary_position="P",
+        other_positions=[],
+        gf=50,
+        endurance=100,
+        control=50,
+        movement=50,
+        hold_runner=50,
+        fb=50,
+        cu=0,
+        cb=0,
+        sl=0,
+        si=0,
+        scb=0,
+        kn=0,
+        arm=50,
+        fa=50,
+        role="SP",
+    )
+
+
+def test_swing_result_respects_bat_speed():
+    # Low bat speed -> out
+    cfg_slow = make_cfg(swingSpeedBase=10)
+    batter1 = make_player("b1")
+    home1 = TeamState(lineup=[make_player("h1")], bench=[], pitchers=[make_pitcher("hp1")])
+    away1 = TeamState(lineup=[batter1], bench=[], pitchers=[make_pitcher("ap1")])
+    rng1 = MockRandom([0.2, 0.9])
+    sim1 = GameSimulation(home1, away1, cfg_slow, rng1)
+    outs1 = sim1.play_at_bat(away1, home1)
+    assert outs1 == 1
+    assert away1.lineup_stats["b1"].hits == 0
+
+    # High bat speed -> hit
+    cfg_fast = make_cfg(swingSpeedBase=80)
+    batter2 = make_player("b2")
+    home2 = TeamState(lineup=[make_player("h2")], bench=[], pitchers=[make_pitcher("hp2")])
+    away2 = TeamState(lineup=[batter2], bench=[], pitchers=[make_pitcher("ap2")])
+    rng2 = MockRandom([0.2, 0.9])
+    sim2 = GameSimulation(home2, away2, cfg_fast, rng2)
+    outs2 = sim2.play_at_bat(away2, home2)
+    assert outs2 == 0
+    assert away2.lineup_stats["b2"].hits == 1
+
+
+def test_runner_advancement_respects_speed():
+    batter1 = make_player("bat1", ph=80)
+    runner1 = make_player("run1", sp=50)
+    runner_state1 = BatterState(runner1)
+    home1 = TeamState(lineup=[make_player("h1")], bench=[], pitchers=[make_pitcher("hp1")])
+    away1 = TeamState(lineup=[batter1], bench=[], pitchers=[make_pitcher("ap1")])
+    away1.lineup_stats[runner1.player_id] = runner_state1
+    away1.bases[0] = runner_state1
+
+    cfg_slow = make_cfg(speedBase=10)
+    rng1 = MockRandom([0.0, 0.9])
+    sim1 = GameSimulation(home1, away1, cfg_slow, rng1)
+    outs1 = sim1.play_at_bat(away1, home1)
+    assert outs1 == 0
+    assert away1.bases[1] is runner_state1
+    assert away1.bases[2] is None
+
+    batter2 = make_player("bat2", ph=80)
+    runner2 = make_player("run2", sp=50)
+    runner_state2 = BatterState(runner2)
+    home2 = TeamState(lineup=[make_player("h2")], bench=[], pitchers=[make_pitcher("hp2")])
+    away2 = TeamState(lineup=[batter2], bench=[], pitchers=[make_pitcher("ap2")])
+    away2.lineup_stats[runner2.player_id] = runner_state2
+    away2.bases[0] = runner_state2
+
+    cfg_fast = make_cfg(speedBase=30)
+    rng2 = MockRandom([0.0, 0.9])
+    sim2 = GameSimulation(home2, away2, cfg_fast, rng2)
+    outs2 = sim2.play_at_bat(away2, home2)
+    assert outs2 == 0
+    assert away2.bases[2] is runner_state2


### PR DESCRIPTION
## Summary
- add physics helper that calculates player speed, bat speed, and swing angle from PlayBalanceConfig
- use physics helper in GameSimulation for swing resolution and runner advancement
- add tests covering swing results and baserunning when physics configuration changes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e4e985d58832e8bf60615c92c95af