### PR TITLE
Implement configurable pitcher AI with selection tests

### DIFF
--- a/logic/pitcher_ai.py
+++ b/logic/pitcher_ai.py
@@ -1,0 +1,142 @@
+"""Simplified pitcher AI used by the tests.
+
+The real game contains a fairly involved pitch selection system which takes
+into account pitch ratings, how often a pitch has been used and situational
+weights for different objectives.  The goal of this module is not to emulate
+that behaviour exactly but to provide a small, deterministic subset that
+allows tests to verify that configuration values from ``PlayBalance`` are
+respected.
+
+Only a handful of options are supported:
+
+``pitchRatVariation*``
+    Dice based variation added to the rating of each pitch before a decision is
+    made.  Each pitch is rolled separately allowing tests to influence the
+    chosen pitch via the RNG sequence.
+
+``nonEstablishedPitchTypeAdjust``
+    Adjustment applied to pitches that have not been thrown yet in the current
+    game.
+
+``primaryPitchTypeAdjust``
+    Adjustment applied to the pitcher's primary pitch which is determined as
+    the pitch with the highest base rating.
+
+``pitchObjXXCount*``
+    Weights for choosing the objective of a pitch based on the current count
+    (balls/strikes).  The objective with the highest weight is selected.  When
+    all weights are ``0`` the objective defaults to ``"establish"``.
+
+The class keeps track of which pitch types have been used for each pitcher and
+exposes the last chosen ``(pitch_type, objective)`` tuple which is useful in
+tests.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Dict, List, Set, Tuple
+
+from models.pitcher import Pitcher
+from .playbalance_config import PlayBalanceConfig
+
+# Ordering of pitch ratings on the :class:`~models.pitcher.Pitcher` model.  Only
+# pitches with a rating greater than ``0`` are considered.
+_PITCH_RATINGS: List[str] = ["fb", "sl", "cu", "cb", "si", "scb", "kn"]
+
+
+class PitcherAI:
+    """Very small pitch selection helper used by the tests."""
+
+    def __init__(self, config: PlayBalanceConfig, rng: random.Random | None = None) -> None:
+        self.config = config
+        self.rng = rng or random.Random()
+        # Track which pitches each pitcher has already thrown this game
+        self._established: Dict[str, Set[str]] = {}
+        # Cache of primary pitch type per pitcher
+        self._primary_cache: Dict[str, str] = {}
+        self.last_selection: Tuple[str, str] | None = None
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _primary_pitch(self, pitcher: Pitcher) -> str:
+        """Return the pitch type with the highest base rating."""
+
+        pid = pitcher.player_id
+        if pid not in self._primary_cache:
+            ratings = {p: getattr(pitcher, p) for p in _PITCH_RATINGS}
+            primary = max(ratings.items(), key=lambda kv: kv[1])[0]
+            self._primary_cache[pid] = primary
+        return self._primary_cache[pid]
+
+    # ------------------------------------------------------------------
+    # Pitch selection
+    # ------------------------------------------------------------------
+    def select_pitch(self, pitcher: Pitcher, *, balls: int = 0, strikes: int = 0) -> Tuple[str, str]:
+        """Return ``(pitch_type, objective)`` for the next pitch.
+
+        Only pitch types with a positive rating are considered.  The rating is
+        modified by the configuration options described in the module level
+        documentation.  The chosen pitch is marked as established for the given
+        pitcher.
+        """
+
+        available = {
+            p: getattr(pitcher, p)
+            for p in _PITCH_RATINGS
+            if getattr(pitcher, p) > 0
+        }
+        if not available:
+            raise ValueError("Pitcher has no available pitch types")
+
+        var_count = self.config.get("pitchRatVariationCount", 0)
+        var_faces = self.config.get("pitchRatVariationFaces", 0)
+        var_base = self.config.get("pitchRatVariationBase", 0)
+        non_establish = self.config.get("nonEstablishedPitchTypeAdjust", 0)
+        primary_adjust = self.config.get("primaryPitchTypeAdjust", 0)
+
+        established = self._established.setdefault(pitcher.player_id, set())
+        primary = self._primary_pitch(pitcher)
+
+        scored: Dict[str, int] = {}
+        for name, base_rating in available.items():
+            score = base_rating
+            if var_count > 0 and var_faces > 0:
+                score += var_base
+                for _ in range(var_count):
+                    score += self.rng.randint(1, var_faces)
+            if name not in established:
+                score += non_establish
+            if name == primary:
+                score += primary_adjust
+            scored[name] = score
+
+        # Choose the pitch with the highest score.  ``max`` is deterministic in
+        # case of ties, preserving the order of ``_PITCH_RATINGS``.
+        pitch_type = max(scored.items(), key=lambda kv: (kv[1], -_PITCH_RATINGS.index(kv[0])))[0]
+        established.add(pitch_type)
+
+        # Determine the pitch objective based on count specific weights
+        prefix = f"pitchObj{balls}{strikes}Count"
+        weights = {
+            "establish": self.config.get(prefix + "EstablishWeight", 0),
+            "outside": self.config.get(prefix + "OutsideWeight", 0),
+            "best": self.config.get(prefix + "BestWeight", 0),
+            "best_center": self.config.get(prefix + "BestCenterWeight", 0),
+            "fast_center": self.config.get(prefix + "FastCenterWeight", 0),
+            "plus": self.config.get(prefix + "PlusWeight", 0),
+        }
+        objective = "establish"
+        max_weight = weights[objective]
+        for obj, weight in weights.items():
+            if weight > max_weight:
+                objective = obj
+                max_weight = weight
+
+        self.last_selection = (pitch_type, objective)
+        return self.last_selection
+
+
+__all__ = ["PitcherAI"]
+

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -11,6 +11,7 @@ from logic.offensive_manager import OffensiveManager
 from logic.substitution_manager import SubstitutionManager
 from logic.playbalance_config import PlayBalanceConfig
 from logic.physics import Physics
+from logic.pitcher_ai import PitcherAI
 
 
 @dataclass
@@ -80,6 +81,7 @@ class GameSimulation:
         self.offense = OffensiveManager(config, self.rng)
         self.subs = SubstitutionManager(config, self.rng)
         self.physics = Physics(config, self.rng)
+        self.pitcher_ai = PitcherAI(config, self.rng)
         self.debug_log: List[str] = []
 
     # ------------------------------------------------------------------
@@ -150,6 +152,10 @@ class GameSimulation:
 
         pitcher_state.pitches_thrown += 1
         batter_state.at_bats += 1
+
+        # Determine pitch type and objective for the at-bat.  The information is
+        # currently only tracked for inspection in tests.
+        self.pitcher_ai.select_pitch(pitcher_state.player)
 
         outs = 0
 

--- a/tests/test_league_creator.py
+++ b/tests/test_league_creator.py
@@ -8,6 +8,7 @@ import random
 
 
 def test_create_league_generates_files(tmp_path):
+    random.seed(0)
     divisions = {"East": [("CityA", "Cats"), ("CityB", "Dogs")]}
     create_league(str(tmp_path), divisions, "Test League")
 

--- a/tests/test_offensive_manager.py
+++ b/tests/test_offensive_manager.py
@@ -16,6 +16,12 @@ class MockRandom(random.Random):
 
     def random(self):  # type: ignore[override]
         return self.values.pop(0)
+
+    def randint(self, a, b):  # type: ignore[override]
+        # ``PitcherAI`` uses ``randint`` for pitch variation which is irrelevant
+        # for these tests.  Always return the lower bound without consuming the
+        # predefined sequence.
+        return a
 def make_player(pid: str, ph: int = 50, sp: int = 50, ch: int = 50) -> Player:
     return Player(
         player_id=pid,

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -16,6 +16,11 @@ class MockRandom(random.Random):
     def random(self):  # type: ignore[override]
         return self.values.pop(0)
 
+    def randint(self, a, b):  # type: ignore[override]
+        # ``PitcherAI`` uses ``randint`` for pitch variation.  Returning the
+        # lower bound keeps the predefined sequence for ``random`` intact.
+        return a
+
 
 def make_player(pid: str, ph: int = 50, sp: int = 50, ch: int = 50) -> Player:
     return Player(

--- a/tests/test_pitcher_ai.py
+++ b/tests/test_pitcher_ai.py
@@ -1,0 +1,121 @@
+import random
+
+from logic.pitcher_ai import PitcherAI
+from models.player import Player
+from models.pitcher import Pitcher
+from tests.util.pbini_factory import make_cfg
+
+
+class SeqRandom(random.Random):
+    """Random generator that returns predefined integers."""
+
+    def __init__(self, ints: list[int], floats: list[float] | None = None):
+        super().__init__()
+        self.ints = list(ints)
+        self.floats = list(floats or [])
+
+    def randint(self, a, b):  # type: ignore[override]
+        return self.ints.pop(0)
+
+    def random(self):  # type: ignore[override]
+        if self.floats:
+            return self.floats.pop(0)
+        return 0.5
+
+
+def make_player(pid: str) -> Player:
+    return Player(
+        player_id=pid,
+        first_name="F" + pid,
+        last_name="L" + pid,
+        birthdate="2000-01-01",
+        height=72,
+        weight=180,
+        bats="R",
+        primary_position="1B",
+        other_positions=[],
+        gf=50,
+        ch=50,
+        ph=50,
+        sp=50,
+        pl=0,
+        vl=0,
+        sc=0,
+        fa=0,
+        arm=0,
+    )
+
+
+def make_pitcher(pid: str, fb: int = 50, sl: int = 49) -> Pitcher:
+    return Pitcher(
+        player_id=pid,
+        first_name="PF" + pid,
+        last_name="PL" + pid,
+        birthdate="2000-01-01",
+        height=72,
+        weight=180,
+        bats="R",
+        primary_position="P",
+        other_positions=[],
+        gf=50,
+        endurance=100,
+        control=50,
+        movement=50,
+        hold_runner=50,
+        fb=fb,
+        sl=sl,
+        cu=0,
+        cb=0,
+        si=0,
+        scb=0,
+        kn=0,
+        arm=50,
+        fa=50,
+        role="SP",
+    )
+
+
+def test_primary_pitch_adjust_affects_selection():
+    pitcher = make_pitcher("p1")
+    cfg_base = dict(
+        pitchRatVariationCount=1,
+        pitchRatVariationFaces=6,
+        pitchRatVariationBase=0,
+        nonEstablishedPitchTypeAdjust=0,
+    )
+
+    cfg1 = make_cfg(**cfg_base, primaryPitchTypeAdjust=0)
+    ai1 = PitcherAI(cfg1, SeqRandom([1, 6]))  # fb -> 1, sl -> 6
+    pitch1, _ = ai1.select_pitch(pitcher)
+    assert pitch1 == "sl"
+
+    cfg2 = make_cfg(**cfg_base, primaryPitchTypeAdjust=10)
+    ai2 = PitcherAI(cfg2, SeqRandom([1, 6]))
+    pitch2, _ = ai2.select_pitch(pitcher)
+    assert pitch2 == "fb"
+
+
+def test_pitch_objective_weights():
+    pitcher = make_pitcher("p2", sl=0)
+    cfg = make_cfg(
+        pitchRatVariationCount=1,
+        pitchRatVariationFaces=6,
+        pitchRatVariationBase=0,
+        pitchObj00CountEstablishWeight=0,
+        pitchObj00CountOutsideWeight=10,
+    )
+    ai = PitcherAI(cfg, SeqRandom([1]))
+    _, obj = ai.select_pitch(pitcher)
+    assert obj == "outside"
+
+    cfg2 = make_cfg(
+        pitchRatVariationCount=1,
+        pitchRatVariationFaces=6,
+        pitchRatVariationBase=0,
+        pitchObj00CountEstablishWeight=10,
+        pitchObj00CountOutsideWeight=0,
+    )
+    ai2 = PitcherAI(cfg2, SeqRandom([1]))
+    _, obj2 = ai2.select_pitch(pitcher)
+    assert obj2 == "establish"
+

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -21,6 +21,12 @@ class MockRandom(random.Random):
     def random(self):  # type: ignore[override]
         return self.values.pop(0)
 
+    def randint(self, a, b):  # type: ignore[override]
+        # ``PitcherAI`` uses ``randint`` for pitch variation.  Returning the
+        # lower bound keeps behaviour deterministic without consuming the
+        # predefined sequence.
+        return a
+
 
 def make_player(pid: str, ph: int = 50, sp: int = 50, ch: int = 50) -> Player:
     return Player(


### PR DESCRIPTION
## Summary
- add `PitcherAI` to vary and choose pitch types/objectives based on PlayBalance config
- hook `PitcherAI` into `GameSimulation` to determine pitch each at-bat
- verify pitch type and objective respond to configuration changes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e50d58df0832e92e6a53247d15a91