### PR TITLE
Add count-aware at-bats with walk and strikeout tracking

### DIFF
--- a/tests/test_offensive_manager.py
+++ b/tests/test_offensive_manager.py
@@ -125,7 +125,7 @@ def test_hit_and_run_chance_and_advance():
     runner_state = BatterState(runner)
     away.lineup_stats[runner.player_id] = runner_state
     away.bases[0] = runner_state
-    sim = GameSimulation(home, away, full, MockRandom([0.0, 0.0, 1.0]))
+    sim = GameSimulation(home, away, full, MockRandom([0.0, 0.0, 0.0, 0.9, 0.0, 0.9, 0.0, 0.9]))
     outs = sim.play_at_bat(away, home)
     assert outs == 1
     assert away.bases[1] is runner_state

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -80,7 +80,7 @@ def test_swing_result_respects_bat_speed():
     batter1 = make_player("b1")
     home1 = TeamState(lineup=[make_player("h1")], bench=[], pitchers=[make_pitcher("hp1")])
     away1 = TeamState(lineup=[batter1], bench=[], pitchers=[make_pitcher("ap1")])
-    rng1 = MockRandom([0.2, 0.9])
+    rng1 = MockRandom([0.0, 0.4, 0.0, 0.4, 0.0, 0.4])
     sim1 = GameSimulation(home1, away1, cfg_slow, rng1)
     outs1 = sim1.play_at_bat(away1, home1)
     assert outs1 == 1
@@ -91,7 +91,7 @@ def test_swing_result_respects_bat_speed():
     batter2 = make_player("b2")
     home2 = TeamState(lineup=[make_player("h2")], bench=[], pitchers=[make_pitcher("hp2")])
     away2 = TeamState(lineup=[batter2], bench=[], pitchers=[make_pitcher("ap2")])
-    rng2 = MockRandom([0.2, 0.9])
+    rng2 = MockRandom([0.0, 0.0, 0.9])
     sim2 = GameSimulation(home2, away2, cfg_fast, rng2)
     outs2 = sim2.play_at_bat(away2, home2)
     assert outs2 == 0
@@ -108,7 +108,7 @@ def test_runner_advancement_respects_speed():
     away1.bases[0] = runner_state1
 
     cfg_slow = make_cfg(speedBase=10)
-    rng1 = MockRandom([0.0, 0.9])
+    rng1 = MockRandom([0.0, 0.0, 0.9])
     sim1 = GameSimulation(home1, away1, cfg_slow, rng1)
     outs1 = sim1.play_at_bat(away1, home1)
     assert outs1 == 0
@@ -124,7 +124,7 @@ def test_runner_advancement_respects_speed():
     away2.bases[0] = runner_state2
 
     cfg_fast = make_cfg(speedBase=30)
-    rng2 = MockRandom([0.0, 0.9])
+    rng2 = MockRandom([0.0, 0.0, 0.9])
     sim2 = GameSimulation(home2, away2, cfg_fast, rng2)
     outs2 = sim2.play_at_bat(away2, home2)
     assert outs2 == 0

--- a/ui/exhibition_game_dialog.py
+++ b/ui/exhibition_game_dialog.py
@@ -145,13 +145,15 @@ class ExhibitionGameDialog(QDialog):
             for entry in box[key]["batting"]:
                 p = entry["player"]
                 lines.append(
-                    f"{p.first_name} {p.last_name}: {entry['h']}-{entry['ab']}, SB {entry['sb']}"
+                    f"{p.first_name} {p.last_name}: {entry['h']}-{entry['ab']}, BB {entry['bb']}, SO {entry['so']}, SB {entry['sb']}"
                 )
             if box[key]["pitching"]:
                 lines.append("PITCHING")
                 for entry in box[key]["pitching"]:
                     p = entry["player"]
-                    lines.append(f"{p.first_name} {p.last_name}: {entry['pitches']} pitches")
+                    lines.append(
+                        f"{p.first_name} {p.last_name}: {entry['pitches']} pitches, BB {entry['bb']}, SO {entry['so']}"
+                    )
             lines.append("")
 
         team_section(f"Away - {self._teams.get(away_id, away_id)}", "away")


### PR DESCRIPTION
## Summary
- Track walks, strikeouts, and pitch counts for batters and pitchers
- Drive at-bats pitch-by-pitch with count-aware AI and walk/strikeout outcomes
- Display BB/SO stats in box scores and update tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e5a09fa54832ebf525b5c15127fbc