### PR TITLE
Keep splash screen visible while dashboards are open

### DIFF
--- a/ui/login_window.py
+++ b/ui/login_window.py
@@ -90,10 +90,11 @@ class LoginWindow(QWidget):
         self.dashboard.raise_()
         self.dashboard.activateWindow()
 
-        # Hide the splash screen so the dashboard takes focus.
-        if self.splash:
-            self.splash.hide()
 
+        # Keep the splash screen visible while the dashboard is open so it
+        # behaves the same way it does when the login window is shown.  This
+        # allows the splash screen to remain in the background while users
+        # interact with the dashboard.
         # Close the login window now that the dashboard is displayed.
         self.close()
 


### PR DESCRIPTION
## Summary
- Keep splash screen visible after login so dashboards open in front but splash remains in background
- Document the splash persistence behavior in login window

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_689e5e252d20832ebdd432e7a8ccfed4