### PR TITLE
Add HTML box score rendering and save routine

### DIFF
--- a/tests/test_boxscore_html_save.py
+++ b/tests/test_boxscore_html_save.py
@@ -1,0 +1,47 @@
+import shutil
+from pathlib import Path
+
+from tests.test_simulation import make_player, make_pitcher, MockRandom
+from tests.util.pbini_factory import load_config
+
+from logic.simulation import (
+    GameSimulation,
+    TeamState,
+    generate_boxscore,
+    render_boxscore_html,
+    save_boxscore_html,
+)
+
+
+def _simulate_simple_game():
+    cfg = load_config()
+    home = TeamState(lineup=[make_player("h1")], bench=[], pitchers=[make_pitcher("hp")])
+    away = TeamState(lineup=[make_player("a1")], bench=[], pitchers=[make_pitcher("ap")])
+    rng = MockRandom([0.0, 0.9] * 100)
+    sim = GameSimulation(home, away, cfg, rng)
+    sim.simulate_game(innings=1)
+    return home, away
+
+
+def test_boxscore_html_written():
+    # Ensure a clean output directory
+    shutil.rmtree(Path("data/boxscores"), ignore_errors=True)
+
+    home, away = _simulate_simple_game()
+    box = generate_boxscore(home, away)
+    html = render_boxscore_html(box, home_name="Home", away_name="Away")
+
+    path_ex = save_boxscore_html("exhibition", html, "game_ex")
+    path_se = save_boxscore_html("season", html, "game_se")
+
+    assert Path(path_ex).is_file()
+    assert Path(path_se).is_file()
+
+    text = Path(path_ex).read_text(encoding="utf-8")
+    assert "1  2  3" in text  # score header
+    assert "Fa1 La1" in text  # away player
+    assert "Fh1 Lh1" in text  # home player
+
+    # Clean up generated files to keep repository tidy
+    shutil.rmtree(Path("data/boxscores"))
+

--- a/ui/exhibition_game_dialog.py
+++ b/ui/exhibition_game_dialog.py
@@ -14,7 +14,15 @@ import os
 from utils.team_loader import load_teams
 from utils.player_loader import load_players_from_csv
 from utils.roster_loader import load_roster
-from logic.simulation import GameSimulation, TeamState, generate_boxscore
+from datetime import datetime
+
+from logic.simulation import (
+    GameSimulation,
+    TeamState,
+    generate_boxscore,
+    render_boxscore_html,
+    save_boxscore_html,
+)
 from models.pitcher import Pitcher
 from logic.playbalance_config import PlayBalanceConfig
 
@@ -111,6 +119,13 @@ class ExhibitionGameDialog(QDialog):
             sim.simulate_game()
             box = generate_boxscore(home_state, away_state)
             text = self._format_box_score(home_id, away_id, box)
+            # Render and save an HTML version of the box score
+            html = render_boxscore_html(
+                box,
+                home_name=self._teams.get(home_id, home_id),
+                away_name=self._teams.get(away_id, away_id),
+            )
+            save_boxscore_html("exhibition", html, datetime.now().strftime("%Y%m%d_%H%M%S"))
             if sim.debug_log:
                 text += "\n\nStrategy Log:\n" + "\n".join(sim.debug_log)
             positions = sim.defense.set_field_positions()


### PR DESCRIPTION
## Summary
- render boxscore data as HTML and save to disk
- persist box score HTML in game-specific folders
- test HTML generation and file outputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e6004cc38832e8f91c153515b9443