### PR TITLE
Add derived and rate stat calculators

### DIFF
--- a/logic/stats.py
+++ b/logic/stats.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .simulation import BatterState
+
+
+def compute_batting_derived(stats: 'BatterState') -> Dict[str, float]:
+    """Return derived batting statistics from counting stats.
+
+    Parameters
+    ----------
+    stats: BatterState
+        The batter statistics to derive from.
+    """
+    tb = stats.b1 + 2 * stats.b2 + 3 * stats.b3 + 4 * stats.hr
+    xbh = stats.b2 + stats.b3 + stats.hr
+    lob = stats.lob
+    p_pa = stats.pitches / stats.pa if stats.pa else 0.0
+    return {"tb": tb, "xbh": xbh, "lob": lob, "p_pa": p_pa}
+
+
+def compute_batting_rates(stats: 'BatterState') -> Dict[str, float]:
+    """Return rate-based batting metrics."""
+    derived = compute_batting_derived(stats)
+    ab = stats.ab
+    pa = stats.pa
+    h = stats.h
+    bb = stats.bb
+    hbp = stats.hbp
+    sf = stats.sf
+    tb = derived["tb"]
+
+    avg = h / ab if ab else 0.0
+    obp_den = ab + bb + hbp + sf
+    obp = (h + bb + hbp) / obp_den if obp_den else 0.0
+    slg = tb / ab if ab else 0.0
+    ops = obp + slg
+    iso = slg - avg
+    babip_den = ab - stats.hr - stats.so + sf
+    babip = (h - stats.hr) / babip_den if babip_den else 0.0
+    bb_pct = bb / pa if pa else 0.0
+    k_pct = stats.so / pa if pa else 0.0
+    bb_k = bb / stats.so if stats.so else 0.0
+    sb_den = stats.sb + stats.cs
+    sb_pct = stats.sb / sb_den if sb_den else 0.0
+
+    return {
+        "avg": avg,
+        "obp": obp,
+        "slg": slg,
+        "ops": ops,
+        "iso": iso,
+        "babip": babip,
+        "bb_pct": bb_pct,
+        "k_pct": k_pct,
+        "bb_k": bb_k,
+        "sb_pct": sb_pct,
+    }

--- a/tests/test_stats_utils.py
+++ b/tests/test_stats_utils.py
@@ -1,0 +1,41 @@
+from tests.test_simulation import make_player
+from logic.simulation import BatterState
+from logic.stats import compute_batting_derived, compute_batting_rates
+from pytest import approx
+
+
+def test_batting_stat_helpers():
+    player = make_player("p")
+    stats = BatterState(player)
+    stats.pa = 5
+    stats.ab = 4
+    stats.h = 2
+    stats.b1 = 1
+    stats.b2 = 1
+    stats.hr = 0
+    stats.bb = 1
+    stats.hbp = 0
+    stats.sf = 0
+    stats.so = 1
+    stats.sb = 1
+    stats.cs = 1
+    stats.pitches = 20
+    stats.lob = 2
+
+    derived = compute_batting_derived(stats)
+    assert derived["tb"] == 3
+    assert derived["xbh"] == 1
+    assert derived["lob"] == 2
+    assert derived["p_pa"] == approx(4.0)
+
+    rates = compute_batting_rates(stats)
+    assert rates["avg"] == approx(0.5)
+    assert rates["obp"] == approx(0.6)
+    assert rates["slg"] == approx(0.75)
+    assert rates["ops"] == approx(1.35)
+    assert rates["iso"] == approx(0.25)
+    assert rates["babip"] == approx(2 / 3)
+    assert rates["bb_pct"] == approx(0.2)
+    assert rates["k_pct"] == approx(0.2)
+    assert rates["bb_k"] == approx(1.0)
+    assert rates["sb_pct"] == approx(0.5)


### PR DESCRIPTION
## Summary
- track pitches seen and runners left on base for each batter
- add helper functions to compute derived (TB, XBH, LOB, P/PA) and rate stats (AVG, OBP, SLG, OPS, ISO, BABIP, BB%, K%, BB/K, SB%)
- integrate computed metrics into box score generation
- update season stats after each game and add tests for calculators

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e642304e4832e9b8d9c992a6f5e21