### PR TITLE
Add advanced pitching metrics

### DIFF
--- a/logic/stats.py
+++ b/logic/stats.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Dict, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .simulation import BatterState
+    from .simulation import BatterState, PitcherState
 
 
 def compute_batting_derived(stats: 'BatterState') -> Dict[str, float]:
@@ -57,4 +57,76 @@ def compute_batting_rates(stats: 'BatterState') -> Dict[str, float]:
         "k_pct": k_pct,
         "bb_k": bb_k,
         "sb_pct": sb_pct,
+    }
+
+
+def compute_pitching_derived(stats: 'PitcherState') -> Dict[str, float]:
+    """Return derived pitching statistics from counting stats."""
+
+    ip = stats.outs / 3.0
+    cg = 1 if stats.gs and stats.gf and stats.outs >= 27 else 0
+    sho = 1 if cg and stats.r == 0 else 0
+    qs = 1 if stats.gs and stats.outs >= 18 and stats.er <= 3 else 0
+    k_minus_bb = stats.so - stats.bb
+    return {
+        "ip": ip,
+        "cg": cg,
+        "sho": sho,
+        "qs": qs,
+        "k_minus_bb": k_minus_bb,
+    }
+
+
+def compute_pitching_rates(stats: 'PitcherState') -> Dict[str, float]:
+    """Return rate-based pitching metrics."""
+
+    ip = stats.outs / 3.0
+    h9 = (stats.h * 9 / ip) if ip else 0.0
+    hr9 = (stats.hr * 9 / ip) if ip else 0.0
+    k9 = (stats.so * 9 / ip) if ip else 0.0
+    bb9 = (stats.bb * 9 / ip) if ip else 0.0
+    era = (stats.er * 9 / ip) if ip else 0.0
+    whip = ((stats.bb + stats.h) / ip) if ip else 0.0
+    k_bb = (stats.so / stats.bb) if stats.bb else 0.0
+    fip = (
+        ((13 * stats.hr) + 3 * (stats.bb + stats.hbp) - 2 * stats.so) / ip + 3.2
+        if ip
+        else 0.0
+    )
+    lob_den = stats.h + stats.bb + stats.hbp - 1.4 * stats.hr
+    lob_pct = (
+        (stats.h + stats.bb + stats.hbp - stats.r) / lob_den if lob_den else 0.0
+    )
+    fps_pct = stats.first_pitch_strikes / stats.bf if stats.bf else 0.0
+    zone_pct = stats.zone_pitches / stats.pitches_thrown if stats.pitches_thrown else 0.0
+    z_swing_pct = stats.zone_swings / stats.zone_pitches if stats.zone_pitches else 0.0
+    z_contact_pct = (
+        stats.zone_contacts / stats.zone_swings if stats.zone_swings else 0.0
+    )
+    o_zone_pitches = stats.pitches_thrown - stats.zone_pitches
+    ozone_swing_pct = (
+        stats.o_zone_swings / o_zone_pitches if o_zone_pitches else 0.0
+    )
+    ozone_contact_pct = (
+        stats.o_zone_contacts / stats.o_zone_swings if stats.o_zone_swings else 0.0
+    )
+    ozone_pct = o_zone_pitches / stats.pitches_thrown if stats.pitches_thrown else 0.0
+
+    return {
+        "h9": h9,
+        "hr9": hr9,
+        "k9": k9,
+        "bb9": bb9,
+        "era": era,
+        "whip": whip,
+        "k_bb": k_bb,
+        "fip": fip,
+        "lob_pct": lob_pct,
+        "fps_pct": fps_pct,
+        "zone_pct": zone_pct,
+        "z_swing_pct": z_swing_pct,
+        "z_contact_pct": z_contact_pct,
+        "ozone_pct": ozone_pct,
+        "ozone_swing_pct": ozone_swing_pct,
+        "ozone_contact_pct": ozone_contact_pct,
     }

--- a/tests/test_pitching_stats_utils.py
+++ b/tests/test_pitching_stats_utils.py
@@ -1,0 +1,53 @@
+from tests.test_simulation import make_pitcher
+from logic.simulation import PitcherState
+from logic.stats import compute_pitching_derived, compute_pitching_rates
+from pytest import approx
+
+
+def test_pitching_stat_helpers():
+    pitcher = make_pitcher("p")
+    stats = PitcherState(pitcher)
+    stats.gs = 1
+    stats.gf = 1
+    stats.outs = 27
+    stats.r = 0
+    stats.er = 0
+    stats.h = 3
+    stats.hr = 1
+    stats.bb = 1
+    stats.so = 9
+    stats.bf = 27
+    stats.hbp = 0
+    stats.first_pitch_strikes = 20
+    stats.pitches_thrown = 90
+    stats.zone_pitches = 50
+    stats.zone_swings = 30
+    stats.zone_contacts = 25
+    stats.o_zone_swings = 10
+    stats.o_zone_contacts = 5
+
+    derived = compute_pitching_derived(stats)
+    assert derived["ip"] == approx(9.0)
+    assert derived["cg"] == 1
+    assert derived["sho"] == 1
+    assert derived["qs"] == 1
+    assert derived["k_minus_bb"] == 8
+
+    rates = compute_pitching_rates(stats)
+    assert rates["h9"] == approx(3.0)
+    assert rates["hr9"] == approx(1.0)
+    assert rates["k9"] == approx(9.0)
+    assert rates["bb9"] == approx(1.0)
+    assert rates["era"] == approx(0.0)
+    assert rates["whip"] == approx(4 / 9)
+    assert rates["k_bb"] == approx(9.0)
+    assert rates["fip"] == approx(2.978, rel=1e-3)
+    assert rates["lob_pct"] == approx(4 / 2.6)
+    assert rates["fps_pct"] == approx(20 / 27)
+    assert rates["zone_pct"] == approx(50 / 90)
+    assert rates["z_swing_pct"] == approx(30 / 50)
+    assert rates["z_contact_pct"] == approx(25 / 30)
+    assert rates["ozone_pct"] == approx((90 - 50) / 90)
+    assert rates["ozone_swing_pct"] == approx(10 / (90 - 50))
+    assert rates["ozone_contact_pct"] == approx(5 / 10)
+


### PR DESCRIPTION
## Summary
- compute IP, CG, SHO, QS, K-BB, H/9, HR/9, K/9, BB/9, ERA, WHIP, K/BB, FIP, LOB%, FPS%, zone-based rates
- track new pitching counters and update season and box score calculations
- test new pitching stat utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e6826b27c832eba01f6c2d85569d7