### PR TITLE
Add fielding statistics tracking

### DIFF
--- a/logic/stats.py
+++ b/logic/stats.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Dict, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .simulation import BatterState, PitcherState
+    from .simulation import BatterState, PitcherState, FieldingState
 
 
 def compute_batting_derived(stats: 'BatterState') -> Dict[str, float]:
@@ -129,4 +129,31 @@ def compute_pitching_rates(stats: 'PitcherState') -> Dict[str, float]:
         "ozone_pct": ozone_pct,
         "ozone_swing_pct": ozone_swing_pct,
         "ozone_contact_pct": ozone_contact_pct,
+    }
+
+
+def compute_fielding_derived(stats: 'FieldingState') -> Dict[str, float]:
+    """Return derived fielding totals."""
+
+    tc = stats.po + stats.a + stats.e
+    of_a = stats.a if stats.player.primary_position in {"LF", "CF", "RF"} else 0
+    return {"tc": tc, "of_a": of_a}
+
+
+def compute_fielding_rates(stats: 'FieldingState') -> Dict[str, float]:
+    """Return rate-based fielding metrics."""
+
+    tc = stats.po + stats.a + stats.e
+    fpct = (stats.po + stats.a) / tc if tc else 0.0
+    total_play = stats.po + stats.a
+    rf9 = total_play / stats.g if stats.g else 0.0
+    rfg = total_play / stats.g if stats.g else 0.0
+    cs_pct = stats.cs / stats.sba if stats.sba else 0.0
+    pb_g = stats.pb / stats.g if stats.g else 0.0
+    return {
+        "fpct": fpct,
+        "rf9": rf9,
+        "rfg": rfg,
+        "cs_pct": cs_pct,
+        "pb_g": pb_g,
     }

--- a/tests/test_stats_utils.py
+++ b/tests/test_stats_utils.py
@@ -1,6 +1,12 @@
 from tests.test_simulation import make_player
-from logic.simulation import BatterState
-from logic.stats import compute_batting_derived, compute_batting_rates
+from tests.test_simulation import make_player
+from logic.simulation import BatterState, FieldingState
+from logic.stats import (
+    compute_batting_derived,
+    compute_batting_rates,
+    compute_fielding_derived,
+    compute_fielding_rates,
+)
 from pytest import approx
 
 
@@ -39,3 +45,26 @@ def test_batting_stat_helpers():
     assert rates["k_pct"] == approx(0.2)
     assert rates["bb_k"] == approx(1.0)
     assert rates["sb_pct"] == approx(0.5)
+
+
+def test_fielding_stat_helpers():
+    player = make_player("p")
+    player.primary_position = "C"
+    stats = FieldingState(player)
+    stats.g = 1
+    stats.gs = 1
+    stats.po = 1
+    stats.a = 1
+    stats.cs = 1
+    stats.sba = 1
+
+    derived = compute_fielding_derived(stats)
+    assert derived["tc"] == 2
+    assert derived["of_a"] == 0
+
+    rates = compute_fielding_rates(stats)
+    assert rates["fpct"] == approx(1.0)
+    assert rates["rf9"] == approx(2.0)
+    assert rates["rfg"] == approx(2.0)
+    assert rates["cs_pct"] == approx(1.0)
+    assert rates["pb_g"] == approx(0.0)


### PR DESCRIPTION
## Summary
- Introduce `FieldingState` dataclass to capture defensive metrics
- Track defensive plays like strikeouts and caught stealing with fielding statistics
- Compute derived fielding metrics and surface fielding stats in box scores

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e69d240ec832e9330380f456badad