### PR TITLE
Refine bunt charging logic with situational modifiers

### DIFF
--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -434,7 +434,26 @@ class GameSimulation:
         # outcome for manual inspection in the exhibition dialog.  The
         # simplified simulation does not yet modify gameplay based on them.
         runner = offense.bases[0].player if offense.bases[0] else None
-        if self.defense.maybe_charge_bunt():
+        pitcher_fa = (
+            defense.current_pitcher_state.player.fa
+            if defense.current_pitcher_state
+            else 0
+        )
+        first_fa = next(
+            (p.fa for p in defense.lineup if p.primary_position == "1B"), 0
+        )
+        third_fa = next(
+            (p.fa for p in defense.lineup if p.primary_position == "3B"), 0
+        )
+        charge_first, charge_third = self.defense.maybe_charge_bunt(
+            pitcher_fa=pitcher_fa,
+            first_fa=first_fa,
+            third_fa=third_fa,
+            on_first=offense.bases[0] is not None,
+            on_second=offense.bases[1] is not None,
+            on_third=offense.bases[2] is not None,
+        )
+        if charge_first or charge_third:
             self.debug_log.append("Defense charges bunt")
         if runner and self.defense.maybe_hold_runner(runner.sp):
             self.debug_log.append("Defense holds runner")

--- a/tests/test_defensive_manager.py
+++ b/tests/test_defensive_manager.py
@@ -17,14 +17,35 @@ class MockRandom(random.Random):
 
 def test_charge_bunt_chance():
     cfg = make_cfg(
+        chargeChanceBaseFirst=10,
         chargeChanceBaseThird=20,
-        chargeChanceSacChanceAdjust=10,
+        chargeChanceSacChanceAdjust=5,
+        chargeChancePitcherFAPct=10,
+        chargeChanceFAPct=10,
+        chargeChanceThirdOnFirstSecond=15,
+        chargeChanceThirdOnThird=25,
         defManChargeChancePct=50,
     )
-    rng = MockRandom([0.1, 0.2])
+    rng = MockRandom([0.1, 0.3, 0.9, 0.05])
     dm = DefensiveManager(cfg, rng)
-    assert dm.maybe_charge_bunt() is True
-    assert dm.maybe_charge_bunt() is False
+    res = dm.maybe_charge_bunt(
+        pitcher_fa=40,
+        first_fa=30,
+        third_fa=60,
+        on_first=True,
+        on_second=True,
+        on_third=False,
+    )
+    assert res == (True, False)
+    res = dm.maybe_charge_bunt(
+        pitcher_fa=40,
+        first_fa=30,
+        third_fa=60,
+        on_first=False,
+        on_second=False,
+        on_third=True,
+    )
+    assert res == (False, True)
 
 
 def test_hold_runner_chance():

--- a/tests/test_offensive_manager.py
+++ b/tests/test_offensive_manager.py
@@ -116,6 +116,11 @@ def test_hit_and_run_chance_and_advance():
         "pitchAroundChanceBase": 0,
         "pickoffChanceBase": 0,
         "chargeChanceBaseThird": 0,
+        "chargeChancePitcherFAPct": 0,
+        "chargeChanceFAPct": 0,
+        "chargeChanceThirdOnFirstSecond": 0,
+        "chargeChanceThirdOnThird": 0,
+        "chargeChanceSacChanceAdjust": 0,
         "holdChanceBase": 0,
     })
     runner = make_player("r")
@@ -125,7 +130,12 @@ def test_hit_and_run_chance_and_advance():
     runner_state = BatterState(runner)
     away.lineup_stats[runner.player_id] = runner_state
     away.bases[0] = runner_state
-    sim = GameSimulation(home, away, full, MockRandom([0.0, 0.0, 0.0, 0.9, 0.0, 0.9, 0.0, 0.9]))
+    sim = GameSimulation(
+        home,
+        away,
+        full,
+        MockRandom([0.0, 0.0, 0.0, 0.9, 0.0, 0.9, 0.0, 0.9]),
+    )
     outs = sim.play_at_bat(away, home)
     assert outs == 1
     assert away.bases[1] is runner_state
@@ -166,6 +176,11 @@ def test_sacrifice_bunt_chance_and_advance():
         "pitchAroundChanceBase": 0,
         "pickoffChanceBase": 0,
         "chargeChanceBaseThird": 0,
+        "chargeChancePitcherFAPct": 0,
+        "chargeChanceFAPct": 0,
+        "chargeChanceThirdOnFirstSecond": 0,
+        "chargeChanceThirdOnThird": 0,
+        "chargeChanceSacChanceAdjust": 0,
         "holdChanceBase": 0,
     })
     runner = make_player("r")
@@ -206,6 +221,11 @@ def test_suicide_squeeze_chance_and_score():
         "pitchAroundChanceBase": 0,
         "pickoffChanceBase": 0,
         "chargeChanceBaseThird": 0,
+        "chargeChancePitcherFAPct": 0,
+        "chargeChanceFAPct": 0,
+        "chargeChanceThirdOnFirstSecond": 0,
+        "chargeChanceThirdOnThird": 0,
+        "chargeChanceSacChanceAdjust": 0,
         "holdChanceBase": 0,
     })
     runner = make_player("r")


### PR DESCRIPTION
## Summary
- Handle bunt charging per fielder using base chances for 1B and 3B
- Factor pitcher/fielder FA ratings and runner situations into charge chance
- Adjust simulation and tests for new bunt charge logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f105516d4832ea92fde17320e49d2