### PR TITLE
Factor offensive steal chance into pickoff decisions

### DIFF
--- a/logic/defensive_manager.py
+++ b/logic/defensive_manager.py
@@ -74,10 +74,12 @@ class DefensiveManager:
             chance += cfg.get("holdChanceAdjust", 0)
         return self._roll(chance)
 
-    def maybe_pickoff(self, lead: int = 0, pitches_since: int = 0) -> bool:
+    def maybe_pickoff(
+        self, steal_chance: int = 0, lead: int = 0, pitches_since: int = 0
+    ) -> bool:
         cfg = self.config
         chance = cfg.get("pickoffChanceBase", 0)
-        chance += cfg.get("pickoffChanceStealChanceAdjust", 0)
+        chance += steal_chance + cfg.get("pickoffChanceStealChanceAdjust", 0)
         chance += cfg.get("pickoffChanceLeadMult", 0) * lead
         chance += cfg.get("pickoffChancePitchesMult", 0) * pitches_since
         return self._roll(chance)

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -457,9 +457,21 @@ class GameSimulation:
             self.debug_log.append("Defense charges bunt")
         if runner and self.defense.maybe_hold_runner(runner.sp):
             self.debug_log.append("Defense holds runner")
-            if self.defense.maybe_pickoff():
+            steal_chance = 0
+            pitcher_state = defense.current_pitcher_state
+            if pitcher_state is not None:
+                pitcher = pitcher_state.player
+                steal_chance = int(
+                    self.offense.calculate_steal_chance(
+                        runner_sp=runner.sp,
+                        pitcher_hold=pitcher.hold_runner,
+                        pitcher_is_left=pitcher.bats == "L",
+                    )
+                    * 100
+                )
+            if self.defense.maybe_pickoff(steal_chance=steal_chance):
                 self.debug_log.append("Pickoff attempt")
-            if self.defense.maybe_pitch_out():
+            if self.defense.maybe_pitch_out(steal_chance=steal_chance):
                 self.debug_log.append("Pitch out")
         pitch_around, ibb = self.defense.maybe_pitch_around()
         if ibb:

--- a/tests/test_defensive_manager.py
+++ b/tests/test_defensive_manager.py
@@ -68,8 +68,8 @@ def test_pickoff_chance():
     )
     rng = MockRandom([0.25, 0.35])
     dm = DefensiveManager(cfg, rng)
-    assert dm.maybe_pickoff(lead=2) is True
-    assert dm.maybe_pickoff(lead=2) is False
+    assert dm.maybe_pickoff(steal_chance=5, lead=2) is True
+    assert dm.maybe_pickoff(steal_chance=5, lead=2) is False
 
 
 def test_pitch_out_chance():

--- a/tests/test_offensive_manager.py
+++ b/tests/test_offensive_manager.py
@@ -122,6 +122,7 @@ def test_hit_and_run_chance_and_advance():
         "chargeChanceThirdOnThird": 0,
         "chargeChanceSacChanceAdjust": 0,
         "holdChanceBase": 0,
+        "holdChanceAdjust": 0,
     })
     runner = make_player("r")
     batter = make_player("b", ch=10, ph=10)
@@ -182,6 +183,7 @@ def test_sacrifice_bunt_chance_and_advance():
         "chargeChanceThirdOnThird": 0,
         "chargeChanceSacChanceAdjust": 0,
         "holdChanceBase": 0,
+        "holdChanceAdjust": 0,
     })
     runner = make_player("r")
     batter = make_player("b", ch=10, ph=10)
@@ -227,6 +229,7 @@ def test_suicide_squeeze_chance_and_score():
         "chargeChanceThirdOnThird": 0,
         "chargeChanceSacChanceAdjust": 0,
         "holdChanceBase": 0,
+        "holdChanceAdjust": 0,
     })
     runner = make_player("r")
     batter = make_player("b")

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -138,8 +138,9 @@ def test_steal_attempt_failure():
     away.lineup_stats[runner.player_id] = runner_state
     away.bases[0] = runner_state
     cfg.values.update({"pitchOutChanceBase": 0})
-    # hnr success ->0.0, steal failure ->0.9, pitch strike ->0.0, swing hit ->0.0, post-hit steal attempt fails ->1.0
-    rng = MockRandom([0.0, 0.9, 0.0, 0.0, 1.0])
+    # pickoff attempt ->0.0, pitch out ->0.9, hnr success ->0.0, steal failure ->0.9,
+    # pitch strike ->0.0, swing hit ->0.0, post-hit steal attempt fails ->1.0
+    rng = MockRandom([0.0, 0.9, 0.0, 0.9, 0.0, 0.0, 1.0])
     sim = GameSimulation(home, away, cfg, rng)
     outs = sim.play_at_bat(away, home)
     assert outs == 1


### PR DESCRIPTION
## Summary
- include offensive steal chance when evaluating defensive pickoff chances
- wire simulation to compute and pass steal chance to pickoff and pitch-out logic
- update tests for new pickoff signature and deterministic sequences

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f1358634c832ebe292fe56b5dbcda