### PR TITLE
Refine pickoff logic with pitch tracking

### DIFF
--- a/logic/defensive_manager.py
+++ b/logic/defensive_manager.py
@@ -81,7 +81,9 @@ class DefensiveManager:
         chance = cfg.get("pickoffChanceBase", 0)
         chance += steal_chance + cfg.get("pickoffChanceStealChanceAdjust", 0)
         chance += cfg.get("pickoffChanceLeadMult", 0) * lead
-        chance += cfg.get("pickoffChancePitchesMult", 0) * pitches_since
+        chance += cfg.get("pickoffChancePitchesMult", 0) * (
+            4 - min(pitches_since, 4)
+        )
         return self._roll(chance)
 
     def maybe_pitch_out(

--- a/tests/test_defensive_manager.py
+++ b/tests/test_defensive_manager.py
@@ -65,11 +65,12 @@ def test_pickoff_chance():
         pickoffChanceBase=10,
         pickoffChanceStealChanceAdjust=10,
         pickoffChanceLeadMult=5,
+        pickoffChancePitchesMult=10,
     )
-    rng = MockRandom([0.25, 0.35])
+    rng = MockRandom([0.25, 0.9])
     dm = DefensiveManager(cfg, rng)
-    assert dm.maybe_pickoff(steal_chance=5, lead=2) is True
-    assert dm.maybe_pickoff(steal_chance=5, lead=2) is False
+    assert dm.maybe_pickoff(steal_chance=5, lead=2, pitches_since=0) is True
+    assert dm.maybe_pickoff(steal_chance=5, lead=2, pitches_since=4) is False
 
 
 def test_pitch_out_chance():


### PR DESCRIPTION
## Summary
- adjust pickoff chance to scale with pitches since last attempt
- track runner lead and pitches since pickoff in simulation
- expand pickoff unit test for pitch-count multiplier

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f2b8606d8832e8cd81be8c5105add