### PR TITLE
Pass context to pitch-out logic

### DIFF
--- a/logic/offensive_manager.py
+++ b/logic/offensive_manager.py
@@ -120,7 +120,7 @@ class OffensiveManager:
     # ------------------------------------------------------------------
     # Hit and run
     # ------------------------------------------------------------------
-    def maybe_hit_and_run(
+    def calculate_hit_and_run_chance(
         self,
         *,
         runner_sp: int,
@@ -131,7 +131,8 @@ class OffensiveManager:
         run_diff: int = 0,
         runners_on_first_and_second: bool = False,
         pitcher_wild: bool = False,
-    ) -> bool:
+    ) -> float:
+        """Return probability that a hit and run will be attempted."""
         cfg = self.config
         chance = cfg.get("hnrChanceBase", 0)
         if run_diff <= -3:
@@ -187,7 +188,32 @@ class OffensiveManager:
             chance += cfg.get("hnrChanceVeryHighPHAdjust", 0)
 
         chance *= cfg.get("offManHNRChancePct", 100) / 100.0
-        return self._roll(chance)
+        chance = max(0.0, min(100.0, chance))
+        return chance / 100.0
+
+    def maybe_hit_and_run(
+        self,
+        *,
+        runner_sp: int,
+        batter_ch: int,
+        batter_ph: int,
+        balls: int = 0,
+        strikes: int = 0,
+        run_diff: int = 0,
+        runners_on_first_and_second: bool = False,
+        pitcher_wild: bool = False,
+    ) -> bool:
+        chance = self.calculate_hit_and_run_chance(
+            runner_sp=runner_sp,
+            batter_ch=batter_ch,
+            batter_ph=batter_ph,
+            balls=balls,
+            strikes=strikes,
+            run_diff=run_diff,
+            runners_on_first_and_second=runners_on_first_and_second,
+            pitcher_wild=pitcher_wild,
+        )
+        return self._roll(chance * 100)
 
     # ------------------------------------------------------------------
     # Sacrifice bunt

--- a/tests/test_defensive_manager.py
+++ b/tests/test_defensive_manager.py
@@ -85,6 +85,34 @@ def test_pitch_out_chance():
     assert dm.maybe_pitch_out(steal_chance=15, ball_count=0) is False
 
 
+def test_pitch_out_ball_counts():
+    cfg = make_cfg(
+        pitchOutChanceStealThresh=10,
+        pitchOutChanceBase=20,
+        pitchOutChanceBall0Adjust=10,
+        pitchOutChanceBall1Adjust=-10,
+    )
+    rng = MockRandom([0.25, 0.25])
+    dm = DefensiveManager(cfg, rng)
+    assert dm.maybe_pitch_out(steal_chance=15, ball_count=0) is True
+    assert dm.maybe_pitch_out(steal_chance=15, ball_count=1) is False
+
+
+def test_pitch_out_innings_and_home():
+    cfg = make_cfg(
+        pitchOutChanceStealThresh=10,
+        pitchOutChanceBase=20,
+        pitchOutChanceInn8Adjust=30,
+        pitchOutChanceInn9Adjust=50,
+        pitchOutChanceHomeAdjust=10,
+    )
+    rng = MockRandom([0.4, 0.8, 0.15])
+    dm = DefensiveManager(cfg, rng)
+    assert dm.maybe_pitch_out(steal_chance=15, inning=8, is_home_team=True) is True
+    assert dm.maybe_pitch_out(steal_chance=15, inning=5, is_home_team=False) is False
+    assert dm.maybe_pitch_out(steal_chance=15, inning=9) is True
+
+
 def test_pitch_around_chance():
     cfg = make_cfg(
         pitchAroundChanceNoInn=0,

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -138,9 +138,9 @@ def test_steal_attempt_failure():
     away.lineup_stats[runner.player_id] = runner_state
     away.bases[0] = runner_state
     cfg.values.update({"pitchOutChanceBase": 0})
-    # pickoff attempt ->0.0, pitch out ->0.9, hnr success ->0.0, steal failure ->0.9,
+    # pickoff attempt ->0.0, hnr success ->0.0, steal failure ->0.9,
     # pitch strike ->0.0, swing hit ->0.0, post-hit steal attempt fails ->1.0
-    rng = MockRandom([0.0, 0.9, 0.0, 0.9, 0.0, 0.0, 1.0])
+    rng = MockRandom([0.0, 0.0, 0.9, 0.0, 0.0, 1.0])
     sim = GameSimulation(home, away, cfg, rng)
     outs = sim.play_at_bat(away, home)
     assert outs == 1


### PR DESCRIPTION
## Summary
- calculate hit-and-run probability in OffensiveManager
- supply steal, hit-and-run, count, inning, and home/away info to pitch-out decisions
- verify pitch-out behaviour across counts and innings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f2dc8f0fc832e9d361a867714ccd8