### PR TITLE
Support Icons8 API key via environment or config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ advanced SDXL avatar generation (`diffusers`, `transformers`, `torch`,
 `opencv-python`, `diskcache`). If you only need the basic features you may omit
 those packages.
 
+### Icons8 API Key
+Avatar images are downloaded from the Icons8 service. Set the
+`ICONS8_API_KEY` environment variable or place an API key under the `[icons8]`
+section of a `config.ini` file so requests are authenticated.
+
 ### Running tests
 Tests are located in the `tests/` directory and can be executed with:
 

--- a/services/icons8_avatar_service.py
+++ b/services/icons8_avatar_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import configparser
 import io
 import os
 import re
@@ -11,6 +12,22 @@ import urllib.request
 from typing import Tuple
 
 from PIL import Image
+
+
+def _get_api_key() -> str | None:
+    """Return the Icons8 API key from environment or config file if present."""
+
+    key = os.getenv("ICONS8_API_KEY")
+    if key:
+        return key
+
+    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    cfg_path = os.path.join(base_dir, "config.ini")
+    if os.path.exists(cfg_path):
+        parser = configparser.ConfigParser()
+        parser.read(cfg_path)
+        return parser.get("icons8", "api_key", fallback=None)
+    return None
 
 
 def fetch_icons8_avatar(
@@ -56,6 +73,7 @@ def fetch_icons8_avatar(
     if os.path.exists(avatar_path) and os.path.exists(thumb_path):
         return avatar_path, thumb_path
 
+    api_key = _get_api_key()
     params = {
         "name": name,
         "ethnicity": ethnicity,
@@ -63,6 +81,8 @@ def fetch_icons8_avatar(
         "clothesColor": primary_hex.lstrip("#"),
         "background": secondary_hex.lstrip("#"),
     }
+    if api_key:
+        params["key"] = api_key
     url = "https://avatars.icons8.com/api/iconsets/avatar" + "?" + urllib.parse.urlencode(params)
 
     try:


### PR DESCRIPTION
## Summary
- Read Icons8 API key from `ICONS8_API_KEY` env var or `config.ini`
- Include API key in Icons8 avatar requests
- Document required environment variable and config option in README

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*
- `pip install pytest` *(fails: externally-managed-environment)*

------
https://chatgpt.com/codex/tasks/task_e_689f4094a700832e8abe00d86499e680