### PR TITLE
Handle Icons8 HTTP errors

### DIFF
--- a/services/icons8_avatar_service.py
+++ b/services/icons8_avatar_service.py
@@ -88,10 +88,21 @@ def fetch_icons8_avatar(
     try:
         with urllib.request.urlopen(url, timeout=10) as response:
             if response.status != 200:
-                raise RuntimeError(f"Icons8 API returned status {response.status}")
+                raise RuntimeError(
+                    f"Icons8 API returned status {response.status}"
+                )
             data = response.read()
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="ignore")
+        snippet = body[:200]
+        raise RuntimeError(
+            f"Icons8 API HTTP {exc.code}: {exc.reason}. "
+            f"Response: {snippet}"
+        ) from exc
     except urllib.error.URLError as exc:
-        raise RuntimeError("Failed to fetch avatar from Icons8") from exc
+        raise RuntimeError(
+            f"Failed to fetch avatar from Icons8: {exc.reason}"
+        ) from exc
 
     img = Image.open(io.BytesIO(data))
     if img.size != (size, size):


### PR DESCRIPTION
## Summary
- add detailed HTTP error handling for Icons8 avatar service
- include response snippets and exception reasons in RuntimeErrors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f422c9198832ea09b7ae196981446