### PR TITLE
Fix Icons8 avatar SSL certificate handling

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ transformers
 torch
 opencv-python
 diskcache
+certifi

--- a/services/icons8_avatar_service.py
+++ b/services/icons8_avatar_service.py
@@ -9,6 +9,11 @@ import re
 import urllib.error
 import urllib.parse
 import urllib.request
+import ssl
+try:
+    import certifi
+except ImportError:  # pragma: no cover - fallback if certifi missing
+    certifi = None
 from typing import Tuple
 
 from PIL import Image
@@ -85,8 +90,11 @@ def fetch_icons8_avatar(
         params["key"] = api_key
     url = "https://avatars.icons8.com/api/iconsets/avatar" + "?" + urllib.parse.urlencode(params)
 
+    ssl_context = ssl.create_default_context(
+        cafile=certifi.where() if certifi else None
+    )
     try:
-        with urllib.request.urlopen(url, timeout=10) as response:
+        with urllib.request.urlopen(url, timeout=10, context=ssl_context) as response:
             if response.status != 200:
                 raise RuntimeError(
                     f"Icons8 API returned status {response.status}"


### PR DESCRIPTION
## Summary
- ensure Icons8 avatar downloads use a certifi-backed SSL context
- add certifi to development dependencies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f67f43544832e97a2aae1e5492b30