### PR TITLE
Improve SSL error hint for avatar fetch

### DIFF
--- a/services/icons8_avatar_service.py
+++ b/services/icons8_avatar_service.py
@@ -108,6 +108,16 @@ def fetch_icons8_avatar(
             f"Response: {snippet}"
         ) from exc
     except urllib.error.URLError as exc:
+        if isinstance(exc.reason, ssl.SSLCertVerificationError):
+            hint = (
+                "certificate verify failed. Ensure your CA certificates are "
+                "up to date"
+            )
+            if not certifi:
+                hint += " or install the 'certifi' package"
+            raise RuntimeError(
+                f"Failed to fetch avatar from Icons8: {hint}"
+            ) from exc
         raise RuntimeError(
             f"Failed to fetch avatar from Icons8: {exc.reason}"
         ) from exc


### PR DESCRIPTION
## Summary
- clarify error when Icons8 avatar download fails due to SSL certificate issues

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f6967ad04832e976148b94601522a