### PR TITLE
Pin certifi version in development requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,4 @@ transformers
 torch
 opencv-python
 diskcache
-certifi
+certifi>=2024.2.2


### PR DESCRIPTION
## Summary
- pin `certifi` in `requirements-dev.txt` to require version 2024.2.2 or newer

## Testing
- `pip install -r requirements-dev.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `PYTHONDONTWRITEBYTECODE=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f6ed1e0ac832e919a46c0abfbe497