### PR TITLE
Improve SSL certificate verification error guidance

### DIFF
--- a/services/icons8_avatar_service.py
+++ b/services/icons8_avatar_service.py
@@ -110,11 +110,16 @@ def fetch_icons8_avatar(
     except urllib.error.URLError as exc:
         if isinstance(exc.reason, ssl.SSLCertVerificationError):
             hint = (
-                "certificate verify failed. Ensure your CA certificates are "
-                "up to date"
+                "certificate verify failed. Update CA certificates "
+                "(sudo update-ca-certificates)"
             )
-            if not certifi:
-                hint += " or install the 'certifi' package"
+            if certifi:
+                hint += (
+                    " or update certifi "
+                    "(python -m pip install --upgrade certifi)"
+                )
+            else:
+                hint += " or install certifi (python -m pip install certifi)"
             raise RuntimeError(
                 f"Failed to fetch avatar from Icons8: {hint}"
             ) from exc


### PR DESCRIPTION
## Summary
- expand SSL certificate verification error hint with commands for updating CA certificates or certifi

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f72499e2c832e90cb8c103ecae093