### PR TITLE
Disable SSL verification for Icons8 avatar service

### DIFF
--- a/services/icons8_avatar_service.py
+++ b/services/icons8_avatar_service.py
@@ -86,7 +86,10 @@ def fetch_icons8_avatar(
         params["key"] = api_key
     url = "https://avatars.icons8.com/api/iconsets/avatar" + "?" + urllib.parse.urlencode(params)
 
+    # WARNING: This disables certificate checks and must not be enabled in production.
     ssl_context = ssl.create_default_context()
+    ssl_context.check_hostname = False
+    ssl_context.verify_mode = ssl.CERT_NONE
     try:
         with urllib.request.urlopen(url, timeout=10, context=ssl_context) as response:
             if response.status != 200:


### PR DESCRIPTION
## Summary
- disable SSL hostname and certificate verification for Icons8 avatar fetcher
- warn about the dangers of skipping certificate validation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f7b3b7ee4832ea375ed9325ea70dd