### PR TITLE
Add confirmations before downloading player avatars

### DIFF
--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -215,6 +215,26 @@ class AdminDashboard(QWidget):
         return
 
     def generate_player_avatars(self):
+        first = QMessageBox.question(
+            self,
+            "Download Avatars",
+            "The system will connect to the internet to download player avatars. Continue?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if first != QMessageBox.StandardButton.Yes:
+            return
+
+        second = QMessageBox.question(
+            self,
+            "Download Avatars",
+            "Downloading avatars may take a few minutes. Do you still want to generate avatars?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if second != QMessageBox.StandardButton.Yes:
+            return
+
         players = {p.player_id: p for p in load_players_from_csv("data/players.csv")}
         teams = load_teams("data/teams.csv")
 


### PR DESCRIPTION
## Summary
- Prompt administrators to confirm internet download of player avatars
- Add second confirmation warning about potential download time

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f7c9c1c54832e82634323a2bedf34