### PR TITLE
Fix Icons8 avatar service 403 by adding User-Agent header

### DIFF
--- a/services/icons8_avatar_service.py
+++ b/services/icons8_avatar_service.py
@@ -107,8 +107,10 @@ def fetch_icons8_avatar(
     ssl_context = ssl.create_default_context()
     ssl_context.check_hostname = False
     ssl_context.verify_mode = ssl.CERT_NONE
+    headers = {"User-Agent": "Mozilla/5.0"}
+    request = urllib.request.Request(url, headers=headers)
     try:
-        with urllib.request.urlopen(url, timeout=10, context=ssl_context) as response:
+        with urllib.request.urlopen(request, timeout=10, context=ssl_context) as response:
             if response.status != 200:
                 raise RuntimeError(
                     f"Icons8 API returned status {response.status}"

--- a/tests/test_icons8_avatar_service.py
+++ b/tests/test_icons8_avatar_service.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import types
+import urllib.request
+
+import pytest
+
+# Provide a minimal PIL stub if Pillow is unavailable
+if "PIL" not in sys.modules:
+    pil_module = types.ModuleType("PIL")
+    image_module = types.ModuleType("Image")
+    pil_module.Image = image_module
+    sys.modules["PIL"] = pil_module
+    sys.modules["PIL.Image"] = image_module
+
+from services import icons8_avatar_service
+
+
+def test_icons8_request_includes_user_agent(monkeypatch, tmp_path):
+    monkeypatch.setenv("ICONS8_API_KEY", "dummy")
+
+    expected_base = os.path.join(os.path.dirname(icons8_avatar_service.__file__), "..")
+    orig_abspath = os.path.abspath
+
+    def fake_abspath(path):
+        if path == expected_base:
+            return str(tmp_path)
+        return orig_abspath(path)
+
+    monkeypatch.setattr(icons8_avatar_service.os.path, "abspath", fake_abspath)
+
+    def fake_urlopen(request, timeout=10, context=None):
+        assert isinstance(request, urllib.request.Request)
+        assert request.headers["User-agent"] == "Mozilla/5.0"
+        raise urllib.error.URLError("boom")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(RuntimeError):
+        icons8_avatar_service.fetch_icons8_avatar(
+            "Test Player", "white", "#123456", "#654321"
+        )


### PR DESCRIPTION
## Summary
- add a Mozilla/5.0 User-Agent to Icons8 avatar requests
- test that the Icons8 avatar service sends the User-Agent

## Testing
- `pytest` *(fails: ImportError: cannot import name 'ImageDraw' from 'PIL')*
- `pytest tests/test_icons8_avatar_service.py`


------
https://chatgpt.com/codex/tasks/task_e_689f8f2b4334832eb21b082c7061a8bb