### PR TITLE
Strip Icons8 API key and add whitespace test

### DIFF
--- a/services/icons8_avatar_service.py
+++ b/services/icons8_avatar_service.py
@@ -23,7 +23,9 @@ def _get_api_key() -> str | None:
 
     key = os.getenv("ICONS8_API_KEY")
     if key:
-        return key
+        key = key.strip()
+        if key:
+            return key
 
     base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
     cfg_path = os.path.join(base_dir, "config.ini")
@@ -32,7 +34,9 @@ def _get_api_key() -> str | None:
         parser.read(cfg_path)
         key = parser.get("icons8", "api_key", fallback=None)
         if key:
-            return key
+            key = key.strip()
+            if key:
+                return key
 
     log.warning(
         "Icons8 API key not found; requests will fail with HTTP 403"

--- a/tests/test_icons8_avatar_service.py
+++ b/tests/test_icons8_avatar_service.py
@@ -69,3 +69,8 @@ def test_icons8_request_includes_token_param(monkeypatch, tmp_path):
         )
 
     assert "token=dummy" in captured["url"]
+
+
+def test_get_api_key_strips_whitespace(monkeypatch):
+    monkeypatch.setenv("ICONS8_API_KEY", "dummy\n")
+    assert icons8_avatar_service._get_api_key() == "dummy"


### PR DESCRIPTION
## Summary
- trim API key from env vars and config when fetching Icons8 API key
- test `_get_api_key` to ensure trailing whitespace is removed

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest` *(fails: ImportError: cannot import name 'ImageDraw' from 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_689f9a9544f8832ebbe1f453e87c0bf6