### PR TITLE
Log full Icons8 HTTP error body

### DIFF
--- a/tests/test_icons8_avatar_service.py
+++ b/tests/test_icons8_avatar_service.py
@@ -1,3 +1,5 @@
+import io
+import logging
 import os
 import sys
 import types
@@ -69,6 +71,41 @@ def test_icons8_request_includes_token_param(monkeypatch, tmp_path):
         )
 
     assert "token=dummy" in captured["url"]
+
+
+def test_http_error_logs_full_body_and_url(monkeypatch, tmp_path, caplog):
+    monkeypatch.setenv("ICONS8_API_KEY", "dummy")
+
+    expected_base = os.path.join(os.path.dirname(icons8_avatar_service.__file__), "..")
+    orig_abspath = os.path.abspath
+
+    def fake_abspath(path):
+        if path == expected_base:
+            return str(tmp_path)
+        return orig_abspath(path)
+
+    monkeypatch.setattr(icons8_avatar_service.os.path, "abspath", fake_abspath)
+
+    def fake_urlopen(request, timeout=10, context=None):
+        body = b"full error body"
+        raise urllib.error.HTTPError(
+            request.full_url, 400, "Bad Request", {}, io.BytesIO(body)
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError) as exc_info:
+            icons8_avatar_service.fetch_icons8_avatar(
+                "Test Player", "white", "#123456", "#654321"
+            )
+
+    message = str(exc_info.value)
+    assert "full error body" in message
+    assert "token" not in message
+    assert "full error body" in caplog.text
+    assert "token" not in caplog.text
+    assert "name=Test+Player" in caplog.text
 
 
 def test_get_api_key_strips_whitespace(monkeypatch):


### PR DESCRIPTION
## Summary
- log full response body and sanitized URL when Icons8 API returns an HTTP error
- add test verifying error logging with full body and URL sans token

## Testing
- `pytest` *(fails: ImportError: cannot import name 'ImageDraw' from 'PIL')*
- `pytest tests/test_icons8_avatar_service.py`

------
https://chatgpt.com/codex/tasks/task_e_689f9b89339c832eb14a646129c44cbb