### PR TITLE
Add CLI diagnostics for Icons8 avatar service

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ missing or invalid, the API responds with HTTP 403.
 > conda update certifi
 > ```
 
+### Icons8 avatar service diagnostics
+To verify that the API key is configured and the Icons8 service is reachable,
+run the diagnostic module:
+
+```bash
+python -m services.icons8_avatar_service "Player Name" black "#aabbcc" "#ddeeff"
+```
+
+The command prints the paths to the downloaded avatar image and thumbnail or an
+error message if the request fails.
+
 ### Running tests
 Tests are located in the `tests/` directory and can be executed with:
 

--- a/services/icons8_avatar_service.py
+++ b/services/icons8_avatar_service.py
@@ -157,3 +157,33 @@ def fetch_icons8_avatar(
 
 
 __all__ = ["fetch_icons8_avatar"]
+
+
+if __name__ == "__main__":  # pragma: no cover - simple CLI wrapper
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Fetch an avatar from Icons8 for diagnostic purposes."
+    )
+    parser.add_argument("name", help="Display name for the avatar")
+    parser.add_argument(
+        "ethnicity",
+        help="Skin tone keyword accepted by Icons8, e.g. 'black' or 'asian'",
+    )
+    parser.add_argument(
+        "primary_hex", help="Jersey colour in '#RRGGBB' format"
+    )
+    parser.add_argument(
+        "secondary_hex", help="Background colour in '#RRGGBB' format"
+    )
+    args = parser.parse_args()
+
+    try:
+        avatar, thumb = fetch_icons8_avatar(
+            args.name, args.ethnicity, args.primary_hex, args.secondary_hex
+        )
+    except Exception as exc:  # pragma: no cover - CLI display
+        print(f"Error: {exc}")
+    else:
+        print(avatar)
+        print(thumb)


### PR DESCRIPTION
## Summary
- add an argparse-driven `__main__` entry point to `icons8_avatar_service` for quick CLI diagnostics
- document how to invoke the diagnostic module in `README.md`

## Testing
- `pytest` *(fails: ImportError: cannot import name 'ImageDraw' from 'PIL' - Pillow missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f9cfcd1bc832e8ec151ad527f1a8e