### PR TITLE
Pass game state into pitch-around logic

### DIFF
--- a/logic/defensive_manager.py
+++ b/logic/defensive_manager.py
@@ -125,6 +125,7 @@ class DefensiveManager:
         on_deck_ph: int = 0,
         on_deck_ch: int = 0,
         batter_gf: int = 50,
+        on_deck_gf: int = 50,
         outs: int = 0,
         on_first: bool = False,
         on_second: bool = False,

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -510,6 +510,7 @@ class GameSimulation:
             on_deck_ph=on_deck.ph,
             on_deck_ch=on_deck.ch,
             batter_gf=batter.gf,
+            on_deck_gf=on_deck.gf,
             outs=outs_before,
             on_first=on_first,
             on_second=on_second,

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -281,6 +281,28 @@ def test_pitch_around_ibb_in_simulation():
     assert any("Intentional walk issued" in ev for ev in sim.debug_log)
 
 
+def test_no_pitch_around_with_early_inning_or_outs():
+    cfg = make_cfg(
+        pitchAroundChanceNoInn=0,
+        pitchAroundChanceBase=0,
+        pitchAroundChanceInn7Adjust=40,
+        pitchAroundChanceOut2=40,
+        pitchAroundChanceOut0=-40,
+        pitchAroundChancePH1BatAdjust=40,
+        defManPitchAroundToIBBPct=100,
+    )
+    rng = MockRandom([0.0] * 40)
+    batter1 = make_player("b1", ph=90)
+    batter2 = make_player("b2", ph=10)
+    away = TeamState(lineup=[batter1, batter2], bench=[], pitchers=[make_pitcher("ap")])
+    home = TeamState(lineup=[make_player("h1")], bench=[], pitchers=[make_pitcher("hp")])
+    sim = GameSimulation(home, away, cfg, rng)
+    sim.current_outs = 0  # Early in inning with no outs
+    sim.play_at_bat(away, home)
+    assert all("Intentional walk issued" not in ev for ev in sim.debug_log)
+    assert all("Pitch around" not in ev for ev in sim.debug_log)
+
+
 def test_fielding_stats_tracking():
     cfg = load_config()
     catcher = make_player("c")


### PR DESCRIPTION
## Summary
- Provide on-deck batter GF along with inning, outs and base runners when checking for pitch-arounds
- Add regression test ensuring early-inning/less-than-two-out situations don't trigger pitch-arounds

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fafaea768832e8e65f210f53f0646