### PR TITLE
Add build script for executable packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+build/
+dist/
+*.spec

--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ for example:
 pytest tests/test_simulation.py::test_run_tracking_and_boxscore -q
 ```
 
+### Building an executable
+Install PyInstaller and create a standalone binary with:
+
+```bash
+pip install -r requirements-dev.txt
+python build_exe.py
+```
+
+The executable will be written to the `dist/` directory.
+
 ### Default Admin Credentials
 When a new league is created or user accounts are cleared, the system rewrites
 `data/users.txt` to contain a single administrator account. Use these fallback

--- a/build_exe.py
+++ b/build_exe.py
@@ -1,0 +1,18 @@
+"""Build an executable for NexGen-BBPro using PyInstaller."""
+import PyInstaller.__main__
+
+
+def main() -> None:
+    """Run PyInstaller to create a standalone executable."""
+    PyInstaller.__main__.run(
+        [
+            "main.py",
+            "--onefile",
+            "--name",
+            "NexGen-BBPro",
+        ]
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ torch
 opencv-python
 diskcache
 certifi>=2024.2.2
+pyinstaller


### PR DESCRIPTION
## Summary
- add PyInstaller build script to package project into a standalone executable
- document executable build steps in README
- include PyInstaller dependency and ignore build artifacts

## Testing
- `pytest`
- `pip install pyinstaller` *(fails: Could not find a version that satisfies the requirement pyinstaller)*

------
https://chatgpt.com/codex/tasks/task_e_689fc51debd0832e86e487db74402b76