### PR TITLE
Refactor steal chance scaling

### DIFF
--- a/logic/offensive_manager.py
+++ b/logic/offensive_manager.py
@@ -52,7 +52,7 @@ class OffensiveManager:
     ) -> float:
         """Return probability that a steal will be attempted."""
         cfg = self.config
-        chance = cfg.get("offManStealChancePct", 0)
+        chance = 0.0
 
         count_key = f"stealChance{balls}{strikes}Count"
         chance += cfg.get(count_key, 0)
@@ -114,6 +114,7 @@ class OffensiveManager:
         if run_diff <= cfg.get("stealChanceWayBehindThresh", -9999):
             chance += cfg.get("stealChanceWayBehindAdjust", 0)
 
+        chance *= cfg.get("offManStealChancePct", 0) / 100.0
         chance = max(0.0, min(100.0, chance))
         return chance / 100.0
 

--- a/tests/test_offensive_manager.py
+++ b/tests/test_offensive_manager.py
@@ -90,7 +90,7 @@ def test_calculate_steal_chance():
         pitcher_hold=55,
         pitcher_is_left=False,
     )
-    assert chance == 0.85
+    assert chance == 0.175
 
 
 def test_hit_and_run_chance_and_advance():

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -140,9 +140,9 @@ def test_steal_attempt_failure():
     away.lineup_stats[runner.player_id] = runner_state
     away.bases[0] = runner_state
     cfg.values.update({"pitchOutChanceBase": 0})
-    # pickoff attempt ->0.0, hnr success ->0.0, steal failure ->0.9,
-    # pitch strike ->0.0, swing hit ->0.0, post-hit steal attempt fails ->1.0
-    rng = MockRandom([0.0, 0.0, 0.9, 0.0, 0.0, 1.0])
+    # hnr success ->0.0, steal failure ->0.9, pitch strike ->0.0,
+    # swing hit ->0.0, post-hit steal attempt fails ->1.0
+    rng = MockRandom([0.0, 0.9, 0.0, 0.0, 1.0])
     sim = GameSimulation(home, away, cfg, rng)
     outs = sim.play_at_bat(away, home)
     assert outs == 1


### PR DESCRIPTION
## Summary
- Rework steal probability to start from zero, apply adjustments, then scale by `offManStealChancePct`
- Adjust steal chance unit tests for new percentage scaling
- Update simulation test sequence to reflect modified steal logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a13f340580832eb4e52330be3f7a30