### PR TITLE
Handle second-to-third steal attempts

### DIFF
--- a/tests/test_offensive_manager.py
+++ b/tests/test_offensive_manager.py
@@ -128,6 +128,50 @@ def test_calculate_steal_chance_situational_modifiers():
     assert good > bad
 
 
+def test_calculate_steal_chance_on_second_modifiers():
+    cfg = make_cfg(
+        offManStealChancePct=100,
+        stealChance10Count=10,
+        stealChanceOnSecond0OutAdjust=20,
+        stealChanceOnSecond1OutAdjust=10,
+        stealChanceOnSecond2OutAdjust=-10,
+        stealChanceOnSecondHighCHThresh=70,
+        stealChanceOnSecondHighCHAdjust=15,
+    )
+    om = OffensiveManager(cfg, MockRandom([]))
+    good = om.calculate_steal_chance(
+        balls=1,
+        strikes=0,
+        runner_sp=50,
+        pitcher_hold=50,
+        pitcher_is_left=False,
+        outs=0,
+        runner_on=2,
+        batter_ch=80,
+    )
+    neutral = om.calculate_steal_chance(
+        balls=1,
+        strikes=0,
+        runner_sp=50,
+        pitcher_hold=50,
+        pitcher_is_left=False,
+        outs=1,
+        runner_on=2,
+        batter_ch=80,
+    )
+    bad = om.calculate_steal_chance(
+        balls=1,
+        strikes=0,
+        runner_sp=50,
+        pitcher_hold=50,
+        pitcher_is_left=False,
+        outs=2,
+        runner_on=2,
+        batter_ch=60,
+    )
+    assert good > neutral > bad
+
+
 def test_hit_and_run_chance_and_advance():
     cfg = make_cfg(
         hnrChanceBase=30,

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -108,7 +108,7 @@ def test_runner_advancement_respects_speed():
     away1.bases[0] = runner_state1
 
     cfg_slow = make_cfg(speedBase=10)
-    rng1 = MockRandom([0.0, 0.0, 0.9])
+    rng1 = MockRandom([0.0, 0.0, 0.9, 0.9])
     sim1 = GameSimulation(home1, away1, cfg_slow, rng1)
     outs1 = sim1.play_at_bat(away1, home1)
     assert outs1 == 0
@@ -124,7 +124,7 @@ def test_runner_advancement_respects_speed():
     away2.bases[0] = runner_state2
 
     cfg_fast = make_cfg(speedBase=30)
-    rng2 = MockRandom([0.0, 0.0, 0.9])
+    rng2 = MockRandom([0.0, 0.0, 0.9, 0.9])
     sim2 = GameSimulation(home2, away2, cfg_fast, rng2)
     outs2 = sim2.play_at_bat(away2, home2)
     assert outs2 == 0

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -203,6 +203,28 @@ def test_steal_count_and_situational_modifiers():
     assert res2 is None
 
 
+def test_second_base_steal_attempt_success():
+    cfg = load_config()
+    runner = make_player("run", sp=80)
+    batter = make_player("bat")
+    home = TeamState(lineup=[make_player("h1")], bench=[], pitchers=[make_pitcher("hp")])
+    away = TeamState(lineup=[batter], bench=[], pitchers=[make_pitcher("ap")])
+    runner_state = BatterState(runner)
+    away.lineup_stats[runner.player_id] = runner_state
+    away.bases[1] = runner_state
+    sim = GameSimulation(home, away, cfg, MockRandom([0.0]))
+    res = sim._attempt_steal(
+        away,
+        home,
+        home.current_pitcher_state.player,
+        force=True,
+        runner_on=2,
+    )
+    assert res is True
+    assert away.bases[2] is runner_state
+    assert runner_state.sb == 1
+
+
 def test_pitcher_change_when_tired():
     cfg = load_config()
     home = TeamState(


### PR DESCRIPTION
## Summary
- Allow `_attempt_steal` to process runners on second stealing third
- Trigger steal logic for runners on second and pass appropriate parameters
- Add tests covering second-base steal chances and second-to-third steals

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a143c974e4832ea3f637553a03ecb7