### PR TITLE
Scale suicide squeeze chance with OffMan modifier

### DIFF
--- a/logic/offensive_manager.py
+++ b/logic/offensive_manager.py
@@ -290,7 +290,7 @@ class OffensiveManager:
         ):
             return False
 
-        chance = cfg.get("offManSqueezeChancePct", 0)
+        chance = 0.0
         if (balls, strikes) in [(0, 0), (1, 0), (0, 1)]:
             chance += cfg.get("squeezeChanceLowCountAdjust", 0)
         elif (balls, strikes) in [(1, 1), (2, 0)]:
@@ -298,6 +298,8 @@ class OffensiveManager:
 
         if runner_on_third_sp >= cfg.get("squeezeChanceThirdFastSPThresh", 0):
             chance += cfg.get("squeezeChanceThirdFastAdjust", 0)
+
+        chance *= cfg.get("offManSqueezeChancePct", 100) / 100.0
 
         return self._roll(chance)
 

--- a/tests/test_offensive_manager.py
+++ b/tests/test_offensive_manager.py
@@ -362,11 +362,37 @@ def test_sacrifice_bunt_on_deck_high_close_late():
 
 
 def test_suicide_squeeze_chance_and_score():
-    cfg = make_cfg(offManSqueezeChancePct=50, squeezeChanceLowCountAdjust=0, squeezeChanceMedCountAdjust=0, squeezeChanceThirdFastSPThresh=0, squeezeChanceThirdFastAdjust=0, squeezeChanceMaxCH=100, squeezeChanceMaxPH=100)
+    cfg = make_cfg(
+        offManSqueezeChancePct=50,
+        squeezeChanceLowCountAdjust=100,
+        squeezeChanceMedCountAdjust=0,
+        squeezeChanceThirdFastSPThresh=0,
+        squeezeChanceThirdFastAdjust=0,
+        squeezeChanceMaxCH=100,
+        squeezeChanceMaxPH=100,
+    )
     rng = MockRandom([0.4, 0.6])
     om = OffensiveManager(cfg, rng)
-    assert om.maybe_suicide_squeeze(batter_ch=50, batter_ph=50, balls=0, strikes=0, runner_on_third_sp=50) is True
-    assert om.maybe_suicide_squeeze(batter_ch=50, batter_ph=50, balls=0, strikes=0, runner_on_third_sp=50) is False
+    assert (
+        om.maybe_suicide_squeeze(
+            batter_ch=50,
+            batter_ph=50,
+            balls=0,
+            strikes=0,
+            runner_on_third_sp=50,
+        )
+        is True
+    )
+    assert (
+        om.maybe_suicide_squeeze(
+            batter_ch=50,
+            batter_ph=50,
+            balls=0,
+            strikes=0,
+            runner_on_third_sp=50,
+        )
+        is False
+    )
 
     full = load_config()
     full.values.update({
@@ -375,7 +401,7 @@ def test_suicide_squeeze_chance_and_score():
         "sacChanceBase": 0,
         "offManSacChancePct": 0,
         "offManSqueezeChancePct": 100,
-        "squeezeChanceLowCountAdjust": 0,
+        "squeezeChanceLowCountAdjust": 100,
         "squeezeChanceMedCountAdjust": 0,
         "squeezeChanceThirdFastSPThresh": 0,
         "squeezeChanceThirdFastAdjust": 0,


### PR DESCRIPTION
## Summary
- scale suicide squeeze chance adjustments by `offManSqueezeChancePct`
- update squeeze tests to reflect scaled probability

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a14a890ebc832ebdb496366758392b