### PR TITLE
Implement need-hit pinch hitter logic

### DIFF
--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -565,9 +565,25 @@ class GameSimulation:
                 self._on_pitcher_exit(old_pitcher, offense, defense)
                 self._on_pitcher_enter(offense, defense)
             else:
-                batter = self.subs.maybe_pinch_hit(
-                    offense, batter_idx, self.debug_log
-                )
+                starter = offense.lineup[batter_idx]
+                if run_diff < 0:
+                    on_deck_idx = (batter_idx + 1) % len(offense.lineup)
+                    batter = self.subs.maybe_pinch_hit_need_hit(
+                        offense,
+                        batter_idx,
+                        on_deck_idx,
+                        inning=inning,
+                        outs=outs_before,
+                        run_diff=run_diff,
+                        home_team=offense is self.home,
+                        log=self.debug_log,
+                    )
+                else:
+                    batter = starter
+                if batter is starter:
+                    batter = self.subs.maybe_pinch_hit(
+                        offense, batter_idx, self.debug_log
+                    )
             offense.batting_index += 1
         on_deck_idx = offense.batting_index % len(offense.lineup)
         on_deck = offense.lineup[on_deck_idx]

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -115,6 +115,22 @@ def test_pinch_hitter_not_used():
     assert stats.bb == 1
 
 
+def test_pinch_hit_need_hit_used():
+    cfg = make_cfg(phForHitBase=100)
+    bench = make_player("bench", ph=80, ch=80)
+    starter = make_player("start", ph=10, ch=10)
+    home = TeamState(lineup=[make_player("h1")], bench=[], pitchers=[make_pitcher("hp")])
+    away = TeamState(lineup=[starter], bench=[bench], pitchers=[make_pitcher("ap")])
+    home.runs = 1
+    away.runs = 0
+    rng = MockRandom([0.0, 0.0, 0.0, 1.0])
+    sim = GameSimulation(home, away, cfg, rng)
+    sim.play_at_bat(away, home)
+    assert away.lineup[0].player_id == "bench"
+    stats = away.lineup_stats["bench"]
+    assert stats.ab == 1
+
+
 def test_steal_attempt_success():
     cfg = load_config()
     runner = make_player("run", ph=80, sp=90)

--- a/tests/test_substitution_manager.py
+++ b/tests/test_substitution_manager.py
@@ -88,6 +88,28 @@ def test_pinch_hit():
     assert team.lineup[0].player_id == "bench"
 
 
+def test_pinch_hit_need_hit():
+    cfg = load_config()
+    cfg.values.update({"phForHitBase": 100})
+    bench = make_player("bench", ph=80, ch=80)
+    starter = make_player("start", ph=10, ch=10)
+    deck = make_player("deck")
+    team = TeamState(lineup=[starter, deck], bench=[bench], pitchers=[make_pitcher("p")])
+    mgr = SubstitutionManager(cfg, MockRandom([0.0]))
+    player = mgr.maybe_pinch_hit_need_hit(
+        team,
+        0,
+        1,
+        inning=9,
+        outs=1,
+        run_diff=-1,
+        home_team=False,
+        log=[],
+    )
+    assert player.player_id == "bench"
+    assert team.lineup[0].player_id == "bench"
+
+
 def test_pinch_run():
     cfg = load_config()
     cfg.values.update({"pinchRunChance": 100})


### PR DESCRIPTION
## Summary
- Add `maybe_pinch_hit_need_hit` to SubstitutionManager to evaluate pinch hitters when a base hit is essential, using phForHit metrics and combined ratings
- Trigger this logic from `GameSimulation.play_at_bat` when the offense trails, before fall back to standard pinch hit logic
- Extend tests to cover need-hit pinch hitting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a14fa45cb0832e91812661c686a9da