### PR TITLE
Add run-based pinch hitting logic with platoon checks

### DIFF
--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -568,8 +568,9 @@ class GameSimulation:
                 starter = offense.lineup[batter_idx]
                 if run_diff < 0:
                     on_deck_idx = (batter_idx + 1) % len(offense.lineup)
-                    batter = self.subs.maybe_pinch_hit_need_hit(
+                    batter = self.subs.maybe_pinch_hit_need_run(
                         offense,
+                        defense,
                         batter_idx,
                         on_deck_idx,
                         inning=inning,
@@ -578,6 +579,17 @@ class GameSimulation:
                         home_team=offense is self.home,
                         log=self.debug_log,
                     )
+                    if batter is starter:
+                        batter = self.subs.maybe_pinch_hit_need_hit(
+                            offense,
+                            batter_idx,
+                            on_deck_idx,
+                            inning=inning,
+                            outs=outs_before,
+                            run_diff=run_diff,
+                            home_team=offense is self.home,
+                            log=self.debug_log,
+                        )
                 else:
                     batter = starter
                 if batter is starter:

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -123,6 +123,22 @@ def test_pinch_hit_need_hit_used():
     away = TeamState(lineup=[starter], bench=[bench], pitchers=[make_pitcher("ap")])
     home.runs = 1
     away.runs = 0
+    rng = MockRandom([0.0, 0.0, 0.0, 0.0, 1.0])
+    sim = GameSimulation(home, away, cfg, rng)
+    sim.play_at_bat(away, home)
+    assert away.lineup[0].player_id == "bench"
+    stats = away.lineup_stats["bench"]
+    assert stats.ab == 1
+
+
+def test_pinch_hit_need_run_used():
+    cfg = make_cfg(phForRunBase=100)
+    bench = make_player("bench", ph=80, ch=80)
+    starter = make_player("start", ph=10, ch=10)
+    home = TeamState(lineup=[make_player("h1")], bench=[], pitchers=[make_pitcher("hp")])
+    away = TeamState(lineup=[starter], bench=[bench], pitchers=[make_pitcher("ap")])
+    home.runs = 1
+    away.runs = 0
     rng = MockRandom([0.0, 0.0, 0.0, 1.0])
     sim = GameSimulation(home, away, cfg, rng)
     sim.play_at_bat(away, home)

--- a/tests/test_substitution_manager.py
+++ b/tests/test_substitution_manager.py
@@ -110,6 +110,65 @@ def test_pinch_hit_need_hit():
     assert team.lineup[0].player_id == "bench"
 
 
+def test_pinch_hit_need_run():
+    cfg = load_config()
+    cfg.values.update({"phForRunBase": 100})
+    bench = make_player("bench", ph=80, ch=80)
+    starter = make_player("start", ph=10, ch=10)
+    deck = make_player("deck")
+    team = TeamState(
+        lineup=[starter, deck], bench=[bench], pitchers=[make_pitcher("p1")]
+    )
+    defense = TeamState(
+        lineup=[make_player("d")], bench=[], pitchers=[make_pitcher("p2")]
+    )
+    mgr = SubstitutionManager(cfg, MockRandom([0.0]))
+    player = mgr.maybe_pinch_hit_need_run(
+        team,
+        defense,
+        0,
+        1,
+        inning=9,
+        outs=1,
+        run_diff=-1,
+        home_team=False,
+        log=[],
+    )
+    assert player.player_id == "bench"
+    assert team.lineup[0].player_id == "bench"
+
+
+def test_pinch_hit_need_run_platoon():
+    cfg = load_config()
+    cfg.values.update({"phForRunPHPlatAdvAdjust": 100})
+    bench = make_player("bench", ph=80, ch=80)
+    bench.bats = "L"
+    starter = make_player("start", ph=10, ch=10)
+    starter.bats = "R"
+    deck = make_player("deck")
+    team = TeamState(
+        lineup=[starter, deck], bench=[bench], pitchers=[make_pitcher("p1")]
+    )
+    defense = TeamState(
+        lineup=[make_player("d")], bench=[], pitchers=[make_pitcher("p2")]
+    )
+    defense.pitchers[0].bats = "R"
+    mgr = SubstitutionManager(cfg, MockRandom([0.0]))
+    player = mgr.maybe_pinch_hit_need_run(
+        team,
+        defense,
+        0,
+        1,
+        inning=9,
+        outs=1,
+        run_diff=-1,
+        home_team=False,
+        log=[],
+    )
+    assert player.player_id == "bench"
+    assert team.lineup[0].player_id == "bench"
+
+
 def test_pinch_run():
     cfg = load_config()
     cfg.values.update({"pinchRunChance": 100})


### PR DESCRIPTION
## Summary
- Introduce `maybe_pinch_hit_need_run` using `phForRun*` config to weigh slugging, game context and platoon advantage
- Integrate run-focused pinch hitting into simulation before other pinch-hit logic
- Add unit tests covering run pinch-hitting scenarios and platoon advantage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a152de6fd8832e9a2b8b58d522e8d7