### PR TITLE
Randomize swing angle calculation

### DIFF
--- a/logic/physics.py
+++ b/logic/physics.py
@@ -89,17 +89,16 @@ class Physics:
     ) -> float:
         """Return the swing angle in degrees for a player.
 
-        ``gf`` is the batter's ground/fly rating.  ``swing_type`` and
+        ``gf`` is the batter's ground/fly rating. ``swing_type`` and
         ``pitch_loc`` can influence the result by applying configuration based
-        adjustments.  A deterministic value is returned which keeps unit tests
-        simple and reproducible.
+        adjustments. The angle is randomized within the configured range using
+        the RNG supplied to :class:`Physics`. Supplying a seeded RNG keeps unit
+        tests reproducible.
         """
 
         base = getattr(self.config, "swingAngleTenthDegreesBase")
         rng_range = getattr(self.config, "swingAngleTenthDegreesRange")
-        # Keep deterministic: use the mid point of the range rather than a
-        # random pick.
-        angle = base + rng_range / 2.0
+        angle = self.rng.uniform(base, base + rng_range) if rng_range else base
 
         gf_pct = getattr(self.config, "swingAngleTenthDegreesGFPct")
         angle += (gf - 50) * gf_pct / 100.0

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -77,6 +77,20 @@ def make_pitcher(pid: str) -> Pitcher:
     )
 
 
+def test_swing_angle_varies_with_range():
+    cfg = make_cfg(
+        swingAngleTenthDegreesBase=100,
+        swingAngleTenthDegreesRange=20,
+    )
+    rng = MockRandom([0.0, 0.9])
+    physics = Physics(cfg, rng)
+    angle1 = physics.swing_angle(50)
+    angle2 = physics.swing_angle(50)
+    assert angle1 == pytest.approx(10.0)
+    assert angle2 == pytest.approx(11.8)
+    assert angle1 != angle2
+
+
 def test_swing_result_respects_bat_speed():
     # Low bat speed -> out
     cfg_slow = make_cfg(swingSpeedBase=10, averagePitchSpeed=50)


### PR DESCRIPTION
## Summary
- Draw swing angles from a random range to allow variability and seeded determinism
- Test that swing angle changes when a non-zero range is configured

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2296990c8832e85a471d56de97d65