### PR TITLE
Add bullpen warmup tracker and substitution logic

### DIFF
--- a/logic/bullpen.py
+++ b/logic/bullpen.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .playbalance_config import PlayBalanceConfig
+
+
+@dataclass
+class WarmupTracker:
+    """Track warmup state for a bullpen pitcher.
+
+    The tracker counts warmup pitches and keeps track of elapsed time since the
+    last thrown pitch.  Timing behaviour is driven by values in
+    ``PlayBalanceConfig`` which mirror the constants from the original
+    ``PB.INI`` file.
+    """
+
+    config: PlayBalanceConfig
+    pitches: int = 0
+    elapsed: int = 0
+    _since_last_pitch: int = 0
+
+    # ------------------------------------------------------------------
+    # Pitching actions
+    # ------------------------------------------------------------------
+    def warm_pitch(self, *, quick: bool = False) -> None:
+        """Record a warmup pitch.
+
+        ``quick`` selects the faster timing variant used when the game is in a
+        hurry.  Both variants reset the cooldown timer.
+        """
+
+        key = "warmupSecsPerQuickPitch" if quick else "warmupSecsPerWarmPitch"
+        secs = self.config.get(key, 0)
+        self.pitches += 1
+        self.elapsed += secs
+        self._since_last_pitch = 0
+
+    def maintain_pitch(self) -> None:
+        """Record a maintenance pitch to keep the arm warm."""
+
+        secs = self.config.get("warmupSecsPerMaintPitch", 0)
+        self.elapsed += secs
+        self._since_last_pitch = 0
+
+    # ------------------------------------------------------------------
+    # Time progression
+    # ------------------------------------------------------------------
+    def advance(self, seconds: int) -> None:
+        """Advance the internal clock by ``seconds``.
+
+        Once the configured idle time has passed the pitcher slowly loses warmup
+        pitches until he is considered cold again.
+        """
+
+        if seconds <= 0:
+            return
+        self.elapsed += seconds
+        self._since_last_pitch += seconds
+        before_cool = self.config.get("warmupSecsBeforeCool", 0)
+        if self._since_last_pitch <= before_cool:
+            return
+        excess = self._since_last_pitch - before_cool
+        cool_secs = self.config.get("warmupSecsPerCoolPitch", 1)
+        lost = excess // cool_secs
+        if lost:
+            self.pitches = max(0, self.pitches - int(lost))
+            excess -= lost * cool_secs
+            self._since_last_pitch = before_cool + excess
+        # Prevent runaway timers when completely cold
+        if self.pitches == 0 and self._since_last_pitch > before_cool:
+            self._since_last_pitch = before_cool
+
+    # ------------------------------------------------------------------
+    # Query helpers
+    # ------------------------------------------------------------------
+    def is_ready(self) -> bool:
+        """Return ``True`` if the pitcher has thrown enough warmup pitches."""
+
+        needed = self.config.get("warmupPitchCount", 0)
+        return self.pitches >= needed

--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -297,6 +297,12 @@ _DEFAULTS: Dict[str, Any] = {
     "defSubLowNewDefAdjust": 0,
     "defSubVeryLowNewDefAdjust": 0,
     "doubleSwitchChance": 0,
+    "warmupPitchCount": 0,
+    "warmupSecsPerWarmPitch": 30,
+    "warmupSecsPerQuickPitch": 20,
+    "warmupSecsPerMaintPitch": 120,
+    "warmupSecsPerCoolPitch": 60,
+    "warmupSecsBeforeCool": 1800,
     "pitcherTiredThresh": 0,
     # Pitcher substitution thresholds and scoring
     "pitchScoringOut": 0,

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -14,6 +14,7 @@ from logic.playbalance_config import PlayBalanceConfig
 from logic.physics import Physics
 from logic.pitcher_ai import PitcherAI
 from logic.batter_ai import BatterAI
+from logic.bullpen import WarmupTracker
 from .stats import (
     compute_batting_derived,
     compute_batting_rates,
@@ -167,6 +168,7 @@ class TeamState:
     inning_events: List[List[str]] = field(default_factory=list)
     team_stats: Dict[str, float] = field(default_factory=dict)
     warming_reliever: bool = False
+    bullpen_warmups: Dict[str, WarmupTracker] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if self.pitchers:

--- a/tests/test_substitution_manager.py
+++ b/tests/test_substitution_manager.py
@@ -540,3 +540,31 @@ def test_position_player_mopup():
     assert team.current_pitcher_state.player.player_id == bench_player.player_id
     assert bench_player not in team.bench
 
+
+def test_reliever_requires_warmup():
+    cfg = make_cfg(
+        pitcherTiredThresh=0,
+        pitcherExhaustedThresh=0,
+        warmupPitchCount=2,
+    )
+    team = TeamState(
+        lineup=[make_player("d")],
+        bench=[],
+        pitchers=[make_pitcher("p1"), make_pitcher("p2", role="RP")],
+    )
+    mgr = SubstitutionManager(cfg, MockRandom([]))
+    state = team.current_pitcher_state
+    state.pitches_thrown = state.player.endurance
+    team.warming_reliever = True
+    assert not mgr.maybe_replace_pitcher(
+        team, inning=1, run_diff=0, home_team=True
+    )
+    mgr.maybe_warm_reliever(team, inning=1, run_diff=0, home_team=True)
+    assert not mgr.maybe_replace_pitcher(
+        team, inning=1, run_diff=0, home_team=True
+    )
+    mgr.maybe_warm_reliever(team, inning=1, run_diff=0, home_team=True)
+    assert mgr.maybe_replace_pitcher(
+        team, inning=1, run_diff=0, home_team=True
+    )
+

--- a/tests/test_warmup_tracker.py
+++ b/tests/test_warmup_tracker.py
@@ -1,0 +1,50 @@
+from logic.bullpen import WarmupTracker
+from tests.util.pbini_factory import make_cfg
+
+def test_warmup_becomes_ready():
+    cfg = make_cfg(
+        warmupPitchCount=2,
+        warmupSecsPerWarmPitch=10,
+    )
+    tracker = WarmupTracker(cfg)
+    tracker.warm_pitch()
+    assert not tracker.is_ready()
+    tracker.warm_pitch()
+    assert tracker.is_ready()
+    assert tracker.pitches == 2
+    assert tracker.elapsed == 20
+
+
+def test_maintenance_resets_timer():
+    cfg = make_cfg(
+        warmupPitchCount=1,
+        warmupSecsPerWarmPitch=10,
+        warmupSecsPerMaintPitch=5,
+        warmupSecsBeforeCool=15,
+        warmupSecsPerCoolPitch=5,
+    )
+    tracker = WarmupTracker(cfg)
+    tracker.warm_pitch()
+    tracker.advance(10)
+    assert tracker.is_ready()
+    tracker.maintain_pitch()
+    tracker.advance(10)
+    assert tracker.is_ready()
+
+
+def test_cooldown_reduces_pitches():
+    cfg = make_cfg(
+        warmupPitchCount=2,
+        warmupSecsPerWarmPitch=10,
+        warmupSecsBeforeCool=0,
+        warmupSecsPerCoolPitch=5,
+    )
+    tracker = WarmupTracker(cfg)
+    tracker.warm_pitch()
+    tracker.warm_pitch()
+    assert tracker.is_ready()
+    tracker.advance(5)
+    assert tracker.pitches == 1
+    tracker.advance(5)
+    assert tracker.pitches == 0
+    assert not tracker.is_ready()


### PR DESCRIPTION
## Summary
- add WarmupTracker for bullpen pitchers using PBINI timing values
- require relievers to finish warmup pitches before entering and track cooldown
- provide configuration defaults and unit tests for warmup behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a264b45710832e99f58da43f8fe89b