### PR TITLE
Gracefully handle OpenAI config parsing

### DIFF
--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -1,0 +1,12 @@
+from utils import openai_client
+
+
+def test_read_api_key_handles_raw_section(tmp_path, monkeypatch):
+    config = tmp_path / "config.ini"
+    config.write_text("[OpenAIkey]\nline1\nline2\n")
+    fake_module_path = tmp_path / "utils" / "openai_client.py"
+    fake_module_path.parent.mkdir()
+    fake_module_path.touch()
+    monkeypatch.setattr(openai_client, "__file__", str(fake_module_path))
+    assert openai_client._read_api_key() == "line1line2"
+


### PR DESCRIPTION
## Summary
- prevent `configparser.ParsingError` when `config.ini` contains raw OpenAI key lines
- fall back to manual parsing and add regression test for multi-line key sections

## Testing
- `pytest`
- `pytest tests/test_openai_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a26a6cf15c832eb0f6c455606cbca1