### PR TITLE
Ensure avatar generation progress dialog displays

### DIFF
--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -239,6 +239,8 @@ class AdminDashboard(QWidget):
         progress.setWindowModality(Qt.WindowModality.WindowModal)
         progress.setValue(0)
         progress.show()
+        # Allow the event loop to process the show event so the dialog appears
+        QApplication.processEvents()
 
         missing = []
 


### PR DESCRIPTION
## Summary
- Keep avatar generation UI responsive by processing events after showing the progress dialog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a275c29cb0832ea18f3548866bc0ca