### PR TITLE
Implement weighted pitch objective selection

### DIFF
--- a/tests/test_offensive_manager.py
+++ b/tests/test_offensive_manager.py
@@ -15,7 +15,9 @@ class MockRandom(random.Random):
         self.values = list(values)
 
     def random(self):  # type: ignore[override]
-        return self.values.pop(0)
+        if self.values:
+            return self.values.pop(0)
+        return 0.0
 
     def randint(self, a, b):  # type: ignore[override]
         # ``PitcherAI`` uses ``randint`` for pitch variation which is irrelevant

--- a/tests/test_pitcher_ai.py
+++ b/tests/test_pitcher_ai.py
@@ -103,25 +103,21 @@ def test_pitch_objective_weights():
         pitchRatVariationCount=1,
         pitchRatVariationFaces=6,
         pitchRatVariationBase=0,
-        pitchObj00CountEstablishWeight=0,
-        pitchObj00CountOutsideWeight=10,
+        pitchObj00CountEstablishWeight=1,
+        pitchObj00CountOutsideWeight=2,
+        pitchObj00CountBestWeight=3,
     )
-    ai = PitcherAI(cfg, SeqRandom([1]))
+    # Three calls using deterministic floats to select each objective based on
+    # their relative weight: 1/6 establish, 2/6 outside, 3/6 best.
+    ai = PitcherAI(cfg, SeqRandom([1], floats=[0.0, 0.4, 0.9]))
     ai.new_game()
-    _, obj = ai.select_pitch(pitcher)
-    assert obj == "outside"
+    _, obj1 = ai.select_pitch(pitcher)
+    _, obj2 = ai.select_pitch(pitcher)
+    _, obj3 = ai.select_pitch(pitcher)
 
-    cfg2 = make_cfg(
-        pitchRatVariationCount=1,
-        pitchRatVariationFaces=6,
-        pitchRatVariationBase=0,
-        pitchObj00CountEstablishWeight=10,
-        pitchObj00CountOutsideWeight=0,
-    )
-    ai2 = PitcherAI(cfg2, SeqRandom([1]))
-    ai2.new_game()
-    _, obj2 = ai2.select_pitch(pitcher)
-    assert obj2 == "establish"
+    assert obj1 == "establish"
+    assert obj2 == "outside"
+    assert obj3 == "best"
 
 
 def test_pitch_variation_cached_per_game():

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -19,7 +19,9 @@ class MockRandom(random.Random):
         self.values = list(values)
 
     def random(self):  # type: ignore[override]
-        return self.values.pop(0)
+        if self.values:
+            return self.values.pop(0)
+        return 0.0
 
     def randint(self, a, b):  # type: ignore[override]
         # ``PitcherAI`` uses ``randint`` for pitch variation.  Returning the

--- a/tests/util/pbini_factory.py
+++ b/tests/util/pbini_factory.py
@@ -18,6 +18,21 @@ def make_cfg(**entries: int) -> PlayBalanceConfig:
 
 def load_config() -> PlayBalanceConfig:
     """Load the full test configuration from ``logic/PBINI.txt``."""
-
     pbini = load_pbini(Path("logic/PBINI.txt"))
-    return PlayBalanceConfig.from_dict(pbini)
+    cfg = PlayBalanceConfig.from_dict(pbini)
+    # The real configuration contains pitch objective weights which would
+    # introduce additional randomness via :class:`PitcherAI`.  Tests expect
+    # deterministic behaviour so clear all such weights.
+    for balls in range(4):
+        for strikes in range(3):
+            prefix = f"pitchObj{balls}{strikes}Count"
+            for suffix in [
+                "EstablishWeight",
+                "OutsideWeight",
+                "BestWeight",
+                "BestCenterWeight",
+                "FastCenterWeight",
+                "PlusWeight",
+            ]:
+                cfg.values[f"{prefix}{suffix}"] = 0
+    return cfg


### PR DESCRIPTION
## Summary
- Use weighted randomness when choosing pitch objectives based on six `pitchObj` weights
- Seed and adjust test RNGs for deterministic outcomes
- Add unit test covering weighted objective selection

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a27d17b6e0832eb2478f2aa30f677a