### PR TITLE
Refine batter swing decisions with pitch classification

### DIFF
--- a/tests/test_batter_ai.py
+++ b/tests/test_batter_ai.py
@@ -58,3 +58,14 @@ def test_primary_look_adjust_increases_swings():
     )
     assert swing is True
     assert contact == 1.0
+
+
+def test_pitch_classification():
+    cfg = load_config()
+    ai = BatterAI(cfg)
+
+    assert ai.pitch_class(0) == "sure strike"
+    assert ai.pitch_class(3) == "sure strike"
+    assert ai.pitch_class(4) == "close strike"
+    assert ai.pitch_class(5) == "close ball"
+    assert ai.pitch_class(6) == "sure ball"


### PR DESCRIPTION
## Summary
- Compute pitch classes (sure strike, close strike, close ball, sure ball) based on configurable zone distances
- Adjust swing probability using pitch class and expose `pitch_class` helper
- Add unit test verifying pitch classification boundaries

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a27fc8559c832e9c1c803aaf01aba8