### PR TITLE
feat: adjust batter AI for best pitch

### DIFF
--- a/tests/test_batter_ai.py
+++ b/tests/test_batter_ai.py
@@ -60,6 +60,25 @@ def test_primary_look_adjust_increases_swings():
     assert contact == 1.0
 
 
+def test_best_look_adjust_increases_swings():
+    cfg = load_config()
+    cfg.values.update({"idRatingBase": 0, "lookBestType00CountAdjust": 50})
+    ai = BatterAI(cfg)
+    batter = make_player("b1")
+    pitcher = make_pitcher("p1")
+    swing, contact = ai.decide_swing(
+        batter,
+        pitcher,
+        pitch_type="fb",
+        balls=0,
+        strikes=0,
+        dist=0,
+        random_value=0.4,
+    )
+    assert swing is True
+    assert contact == 1.0
+
+
 def test_pitch_classification():
     cfg = load_config()
     ai = BatterAI(cfg)


### PR DESCRIPTION
## Summary
- cache each pitcher's best pitch for batter decision logic
- account for lookBestType count adjustments when pitch matches best pitch
- test best-pitch recognition alongside primary pitch scenarios

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a281ac593c832e93e4b3113067960a