### PR TITLE
Refine batter identification logic

### DIFF
--- a/tests/test_batter_ai.py
+++ b/tests/test_batter_ai.py
@@ -24,10 +24,20 @@ def test_swing_decision_respects_idrating():
 
 def test_misidentification_reduces_contact():
     cfg = load_config()
-    cfg.values.update({"idRatingBase": 0})
+    cfg.values.update(
+        {
+            "idRatingBase": 0,
+            "idRatingCHPct": 0,
+            "idRatingExpPct": 0,
+            "idRatingPitchRatPct": 0,
+        }
+    )
     ai = BatterAI(cfg)
     batter = make_player("b1")
+    batter.ch = 0
+    batter.exp = 0
     pitcher = make_pitcher("p1")
+    pitcher.fb = 100
     swing, contact = ai.decide_swing(
         batter,
         pitcher,
@@ -43,10 +53,21 @@ def test_misidentification_reduces_contact():
 
 def test_primary_look_adjust_increases_swings():
     cfg = load_config()
-    cfg.values.update({"idRatingBase": 0, "lookPrimaryType00CountAdjust": 50})
+    cfg.values.update(
+        {
+            "idRatingBase": 0,
+            "idRatingCHPct": 0,
+            "idRatingExpPct": 0,
+            "idRatingPitchRatPct": 0,
+            "lookPrimaryType00CountAdjust": 50,
+        }
+    )
     ai = BatterAI(cfg)
     batter = make_player("b1")
+    batter.ch = 0
+    batter.exp = 0
     pitcher = make_pitcher("p1")
+    pitcher.fb = 100
     swing, contact = ai.decide_swing(
         batter,
         pitcher,
@@ -57,15 +78,26 @@ def test_primary_look_adjust_increases_swings():
         random_value=0.4,
     )
     assert swing is True
-    assert contact == 1.0
+    assert contact == 0.5
 
 
 def test_best_look_adjust_increases_swings():
     cfg = load_config()
-    cfg.values.update({"idRatingBase": 0, "lookBestType00CountAdjust": 50})
+    cfg.values.update(
+        {
+            "idRatingBase": 0,
+            "idRatingCHPct": 0,
+            "idRatingExpPct": 0,
+            "idRatingPitchRatPct": 0,
+            "lookBestType00CountAdjust": 50,
+        }
+    )
     ai = BatterAI(cfg)
     batter = make_player("b1")
+    batter.ch = 0
+    batter.exp = 0
     pitcher = make_pitcher("p1")
+    pitcher.fb = 100
     swing, contact = ai.decide_swing(
         batter,
         pitcher,
@@ -76,7 +108,89 @@ def test_best_look_adjust_increases_swings():
         random_value=0.4,
     )
     assert swing is True
-    assert contact == 1.0
+    assert contact == 0.5
+
+
+def test_ch_and_exp_ratings_increase_identification():
+    cfg = load_config()
+    cfg.values.update({"idRatingBase": 0, "idRatingPitchRatPct": 0})
+    ai = BatterAI(cfg)
+    pitcher = make_pitcher("p1")
+    pitcher.fb = 100
+
+    batter_low = make_player("low")
+    batter_low.ch = 0
+    batter_low.exp = 0
+    swing_low, contact_low = ai.decide_swing(
+        batter_low,
+        pitcher,
+        pitch_type="fb",
+        balls=0,
+        strikes=0,
+        dist=0,
+        random_value=0.4,
+    )
+
+    batter_high = make_player("high")
+    batter_high.ch = 100
+    batter_high.exp = 100
+    swing_high, contact_high = ai.decide_swing(
+        batter_high,
+        pitcher,
+        pitch_type="fb",
+        balls=0,
+        strikes=0,
+        dist=0,
+        random_value=0.4,
+    )
+
+    assert swing_low is True
+    assert contact_low == 0.5
+    assert swing_high is True
+    assert contact_high == 1.0
+
+
+def test_pitch_rating_makes_identification_harder():
+    cfg = load_config()
+    cfg.values.update(
+        {
+            "idRatingBase": 0,
+            "idRatingCHPct": 0,
+            "idRatingExpPct": 0,
+            "idRatingPitchRatPct": 100,
+        }
+    )
+    ai = BatterAI(cfg)
+    batter = make_player("b1")
+    batter.ch = 0
+    batter.exp = 0
+
+    pitcher_easy = make_pitcher("easy")
+    pitcher_easy.fb = 0
+    swing_e, contact_e = ai.decide_swing(
+        batter,
+        pitcher_easy,
+        pitch_type="fb",
+        balls=0,
+        strikes=0,
+        dist=0,
+        random_value=0.4,
+    )
+
+    pitcher_hard = make_pitcher("hard")
+    pitcher_hard.fb = 100
+    swing_h, contact_h = ai.decide_swing(
+        batter,
+        pitcher_hard,
+        pitch_type="fb",
+        balls=0,
+        strikes=0,
+        dist=0,
+        random_value=0.4,
+    )
+
+    assert swing_e is True and contact_e == 1.0
+    assert swing_h is True and contact_h == 0.5
 
 
 def test_pitch_classification():


### PR DESCRIPTION
## Summary
- compute pitch identification chance using CH/EXP and pitch rating factors
- weight type, location, and timing recognition separately in BatterAI
- add tests for CH/EXP influence and pitch difficulty on swing/contact

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a283bdb1c0832ebe089dabbc602a67