### PR TITLE
Add timing curve dice for contact quality

### DIFF
--- a/tests/test_batter_ai.py
+++ b/tests/test_batter_ai.py
@@ -1,3 +1,5 @@
+import pytest
+
 from logic.batter_ai import BatterAI
 from tests.util.pbini_factory import load_config
 from tests.test_simulation import make_player, make_pitcher
@@ -19,7 +21,7 @@ def test_swing_decision_respects_idrating():
         random_value=0.0,
     )
     assert swing is True
-    assert contact == 1.0
+    assert contact == pytest.approx(0.93)
 
 
 def test_misidentification_reduces_contact():
@@ -147,7 +149,7 @@ def test_ch_and_exp_ratings_increase_identification():
     assert swing_low is True
     assert contact_low == 0.5
     assert swing_high is True
-    assert contact_high == 1.0
+    assert contact_high == pytest.approx(0.82)
 
 
 def test_pitch_rating_makes_identification_harder():
@@ -189,7 +191,7 @@ def test_pitch_rating_makes_identification_harder():
         random_value=0.4,
     )
 
-    assert swing_e is True and contact_e == 1.0
+    assert swing_e is True and contact_e == pytest.approx(0.77)
     assert swing_h is True and contact_h == 0.5
 
 
@@ -202,3 +204,85 @@ def test_pitch_classification():
     assert ai.pitch_class(4) == "close strike"
     assert ai.pitch_class(5) == "close ball"
     assert ai.pitch_class(6) == "sure ball"
+
+
+@pytest.mark.parametrize(
+    "base,expected",
+    [
+        (50, 0.99),
+        (65, 0.89),
+        (85, 0.79),
+        (92, 0.69),
+        (98, 0.59),
+    ],
+)
+def test_timing_curve_selection(base, expected):
+    cfg = load_config()
+    cfg.values.update(
+        {
+            "idRatingBase": base,
+            "idRatingCHPct": 0,
+            "idRatingExpPct": 0,
+            "idRatingPitchRatPct": 0,
+            "timingVeryBadThresh": 60,
+            "timingVeryBadCount": 1,
+            "timingVeryBadFaces": 1,
+            "timingVeryBadBase": 0,
+            "timingBadThresh": 80,
+            "timingBadCount": 1,
+            "timingBadFaces": 1,
+            "timingBadBase": 10,
+            "timingMedThresh": 90,
+            "timingMedCount": 1,
+            "timingMedFaces": 1,
+            "timingMedBase": 20,
+            "timingGoodThresh": 95,
+            "timingGoodCount": 1,
+            "timingGoodFaces": 1,
+            "timingGoodBase": 30,
+            "timingVeryGoodCount": 1,
+            "timingVeryGoodFaces": 1,
+            "timingVeryGoodBase": 40,
+        }
+    )
+    ai = BatterAI(cfg)
+    batter = make_player("b1")
+    pitcher = make_pitcher("p1")
+    swing, contact = ai.decide_swing(
+        batter,
+        pitcher,
+        pitch_type="fb",
+        balls=0,
+        strikes=0,
+        dist=0,
+        random_value=0.4,
+    )
+    assert swing is True
+    assert contact == pytest.approx(expected)
+
+
+def test_contact_quality_variability():
+    cfg = load_config()
+    cfg.values.update({"idRatingBase": 100})
+    ai = BatterAI(cfg)
+    batter = make_player("b1")
+    pitcher = make_pitcher("p1")
+    _, contact1 = ai.decide_swing(
+        batter,
+        pitcher,
+        pitch_type="fb",
+        balls=0,
+        strikes=0,
+        dist=0,
+        random_value=0.1,
+    )
+    _, contact2 = ai.decide_swing(
+        batter,
+        pitcher,
+        pitch_type="fb",
+        balls=0,
+        strikes=0,
+        dist=0,
+        random_value=0.2,
+    )
+    assert contact1 != contact2


### PR DESCRIPTION
## Summary
- vary batter contact quality by selecting timing curves based on base identification chance and rolling configured dice
- add comprehensive tests covering curve selection and randomness of timing outcomes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2864883b8832e9a056c7dcbf72f0a