### PR TITLE
Handle batter step-out on hit-by-pitch attempts

### DIFF
--- a/tests/test_hit_by_pitch.py
+++ b/tests/test_hit_by_pitch.py
@@ -1,0 +1,47 @@
+from logic.simulation import GameSimulation, TeamState
+from tests.test_simulation import MockRandom, make_player, make_pitcher
+from tests.util.pbini_factory import make_cfg
+
+
+def test_step_out_converts_hit_pitch_to_ball():
+    cfg = make_cfg(hbpBatterStepOutChance=100)
+    batter = make_player("bat")
+    home = TeamState(
+        lineup=[make_player("h1")],
+        bench=[],
+        pitchers=[make_pitcher("hp", control=0)],
+    )
+    away = TeamState(
+        lineup=[batter], bench=[], pitchers=[make_pitcher("ap")]
+    )
+    rng = MockRandom([0.9, 0.99, 0.0, 0.0])
+    sim = GameSimulation(home, away, cfg, rng)
+    sim.play_at_bat(away, home)
+    stats = away.lineup_stats[batter.player_id]
+    pitcher_state = home.pitcher_stats["hp"]
+    assert stats.hbp == 0
+    assert pitcher_state.hbp == 0
+    assert pitcher_state.balls_thrown == 1
+
+
+def test_hit_by_pitch_recorded_on_failed_step_out():
+    cfg = make_cfg(hbpBatterStepOutChance=0)
+    batter = make_player("bat")
+    home = TeamState(
+        lineup=[make_player("h1")],
+        bench=[],
+        pitchers=[make_pitcher("hp", control=0)],
+    )
+    away = TeamState(
+        lineup=[batter], bench=[], pitchers=[make_pitcher("ap")]
+    )
+    rng = MockRandom([0.9, 0.99, 0.0, 0.0])
+    sim = GameSimulation(home, away, cfg, rng)
+    outs = sim.play_at_bat(away, home)
+    assert outs == 0
+    stats = away.lineup_stats[batter.player_id]
+    pitcher_state = home.pitcher_stats["hp"]
+    assert stats.hbp == 1
+    assert pitcher_state.hbp == 1
+    assert pitcher_state.balls_thrown == 0
+    assert away.bases[0] is stats

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -461,7 +461,7 @@ def test_pitch_control_affects_location():
         lineup=[make_player("h1")], bench=[], pitchers=[make_pitcher("hp", control=30)]
     )
     away_low = TeamState(lineup=[batter2], bench=[], pitchers=[make_pitcher("ap")])
-    rng_low = MockRandom([0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9])
+    rng_low = MockRandom([0.8, 0.9, 0.8, 0.9, 0.8, 0.9, 0.8, 0.9])
     sim_low = GameSimulation(home_low, away_low, cfg, rng_low)
     outs_low = sim_low.play_at_bat(away_low, home_low)
     stats_low = away_low.lineup_stats[batter2.player_id]


### PR DESCRIPTION
## Summary
- Roll against `hbpBatterStepOutChance` when a pitch would hit the batter, converting to a ball on success and recording HBP on failure
- Add regression tests for step-out success and HBP recording
- Adjust existing simulation test for new HBP logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a290a4b570832eb36a4bc0bba1909e