### PR TITLE
Add fielder reaction delay based on FA

### DIFF
--- a/logic/physics.py
+++ b/logic/physics.py
@@ -30,6 +30,30 @@ class Physics:
         return base + pct * sp / 100.0
 
     # ------------------------------------------------------------------
+    # Fielder reaction delay
+    # ------------------------------------------------------------------
+    def reaction_delay(self, position: str, fa: int) -> float:
+        """Return the reaction delay for a fielder."""
+
+        suffix_map = {
+            "P": "Pitcher",
+            "C": "Catcher",
+            "1B": "FirstBase",
+            "2B": "SecondBase",
+            "3B": "ThirdBase",
+            "SS": "ShortStop",
+            "LF": "LeftField",
+            "CF": "CenterField",
+            "RF": "RightField",
+        }
+        suffix = suffix_map.get(position.upper())
+        if suffix is None:
+            return 0.0
+        base = getattr(self.config, f"delayBase{suffix}")
+        pct = getattr(self.config, f"delayFAPct{suffix}")
+        return base + pct * fa / 100.0
+
+    # ------------------------------------------------------------------
     # Pitch velocity
     # ------------------------------------------------------------------
     def pitch_velocity(

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -1248,9 +1248,11 @@ class GameSimulation:
             )
             attempt = self.rng.random() < chance
         if attempt:
-            tag_out = self.fielding_ai.should_tag_runner(10, 10)
-            success_prob = 0.3 if tag_out else 0.7
             catcher_fs = self._get_fielder(defense, "C")
+            fa = catcher_fs.player.fa if catcher_fs else 0
+            delay = self.physics.reaction_delay("C", fa)
+            tag_out = self.fielding_ai.should_tag_runner(delay, 10)
+            success_prob = 0.3 if tag_out else 0.7
             if self.rng.random() < success_prob:
                 ps_runner = offense.base_pitchers[base_idx]
                 offense.bases[base_idx] = None

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -470,3 +470,11 @@ def test_missed_control_expands_box_and_reduces_velocity():
         + miss_amt * cfg.speedReductionEffMOPct / 100
     )
     assert sim.last_pitch_speed == pytest.approx(10 - reduction)
+
+
+def test_reaction_delay_decreases_with_fa():
+    cfg = make_cfg(delayBaseCatcher=12, delayFAPctCatcher=-4)
+    physics = Physics(cfg)
+    low = physics.reaction_delay("C", 20)
+    high = physics.reaction_delay("C", 80)
+    assert high < low

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -183,6 +183,57 @@ def test_steal_attempt_failure():
     assert away.bases[0] is not None
 
 
+def test_catcher_reaction_delay_affects_steal():
+    cfg = make_cfg(
+        generalSlop=0,
+        tagTimeSlop=0,
+        delayBaseCatcher=12,
+        delayFAPctCatcher=-4,
+    )
+    runner = make_player("run")
+
+    def make_catcher(pid: str, fa: int) -> Player:
+        return Player(
+            player_id=pid,
+            first_name="F" + pid,
+            last_name="L" + pid,
+            birthdate="2000-01-01",
+            height=72,
+            weight=180,
+            bats="R",
+            primary_position="C",
+            other_positions=[],
+            gf=50,
+            ch=0,
+            ph=0,
+            sp=0,
+            pl=0,
+            vl=0,
+            sc=0,
+            fa=fa,
+            arm=0,
+        )
+
+    slow_def = TeamState(lineup=[make_catcher("cs", 0)], bench=[], pitchers=[make_pitcher("hp")])
+    fast_def = TeamState(lineup=[make_catcher("cf", 100)], bench=[], pitchers=[make_pitcher("hp")])
+
+    offense1 = TeamState(lineup=[runner], bench=[], pitchers=[make_pitcher("ap")])
+    rstate1 = BatterState(runner)
+    offense1.lineup_stats[runner.player_id] = rstate1
+    offense1.bases[0] = rstate1
+    sim1 = GameSimulation(slow_def, offense1, cfg, MockRandom([0.5]))
+    res1 = sim1._attempt_steal(offense1, slow_def, slow_def.pitchers[0], force=True)
+    assert res1 is True
+
+    offense2 = TeamState(lineup=[runner], bench=[], pitchers=[make_pitcher("ap")])
+    rstate2 = BatterState(runner)
+    offense2.lineup_stats[runner.player_id] = rstate2
+    offense2.bases[0] = rstate2
+    sim2 = GameSimulation(fast_def, offense2, cfg, MockRandom([0.5]))
+    res2 = sim2._attempt_steal(offense2, fast_def, fast_def.pitchers[0], force=True)
+    assert res2 is False
+
+
 def test_steal_count_and_situational_modifiers():
     cfg = make_cfg(
         offManStealChancePct=100,


### PR DESCRIPTION
## Summary
- compute fielding reaction delay based on position and fielder ability
- use reaction delay in steal attempts so catchers with better FA react faster
- test that higher FA shortens delay and affects steal outcomes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4b09a29f0832eafbb68addb2d9d5d