### PR TITLE
Add catch probability and fielding tests

### DIFF
--- a/logic/fielding_ai.py
+++ b/logic/fielding_ai.py
@@ -28,6 +28,69 @@ class FieldingAI:
             return "dive"
         return "no_attempt"
 
+    def catch_probability(
+        self, position: str, fa: int, hang_time: float, action: str
+    ) -> float:
+        """Return the probability of successfully catching the ball.
+
+        ``position`` is the fielder's defensive position and ``fa`` their
+        fielding ability rating. ``hang_time`` represents either the time a
+        fly ball spends in the air or the time a throw takes to reach the
+        fielder. ``action`` is one of ``"catch"``, ``"dive"`` or ``"leap"``.
+
+        The calculation is influenced by several ``PlayBalance`` configuration
+        values. A 100% probability is returned when ``hang_time`` exceeds the
+        ``automaticCatchDist`` threshold.
+        """
+
+        if hang_time >= self.config.automaticCatchDist:
+            return 1.0
+
+        chance = self.config.catchBaseChance + fa / self.config.catchFADiv
+
+        if hang_time < 1.0:
+            chance += self.config.catchChanceLessThan1Sec
+            tenths = int((1.0 - hang_time) * 10)
+            chance += tenths * self.config.catchChancePerTenth
+
+        if action == "dive":
+            chance += self.config.catchChanceDiving
+        elif action == "leap":
+            chance += self.config.catchChanceLeaping
+
+        pos_adjust = {
+            "P": self.config.catchChancePitcherAdjust,
+            "C": self.config.catchChanceCatcherAdjust,
+            "1B": self.config.catchChanceFirstBaseAdjust,
+            "2B": self.config.catchChanceSecondBaseAdjust,
+            "3B": self.config.catchChanceThirdBaseAdjust,
+            "SS": self.config.catchChanceShortStopAdjust,
+            "LF": self.config.catchChanceLeftFieldAdjust,
+            "CF": self.config.catchChanceCenterFieldAdjust,
+            "RF": self.config.catchChanceRightFieldAdjust,
+        }
+        chance += pos_adjust.get(position, 0)
+
+        return max(0.0, min(1.0, chance / 100))
+
+    def resolve_fly_ball(
+        self, position: str, fa: int, hang_time: float, action: str
+    ) -> bool:
+        """Return ``True`` if the fly ball is caught."""
+
+        prob = self.catch_probability(position, fa, hang_time, action)
+        rng = self.rng or Random()
+        return rng.random() < prob
+
+    def resolve_throw(
+        self, position: str, fa: int, hang_time: float, action: str = "catch"
+    ) -> bool:
+        """Return ``True`` if the thrown ball is caught."""
+
+        prob = self.catch_probability(position, fa, hang_time, action)
+        rng = self.rng or Random()
+        return rng.random() < prob
+
     def should_relay_throw(self, fielder_time: float, runner_time: float) -> bool:
         """Return ``True`` if a relay throw should be attempted."""
 

--- a/tests/test_catch_probability.py
+++ b/tests/test_catch_probability.py
@@ -1,0 +1,40 @@
+from logic.fielding_ai import FieldingAI
+from logic.playbalance_config import PlayBalanceConfig
+
+
+def _make_ai():
+    cfg = PlayBalanceConfig()
+    cfg.catchBaseChance = 90
+    cfg.catchFADiv = 7
+    cfg.catchChanceDiving = -40
+    cfg.catchChanceLeaping = -15
+    cfg.catchChanceLessThan1Sec = -10
+    cfg.catchChancePerTenth = -1
+    cfg.catchChancePitcherAdjust = -10
+    cfg.catchChanceCatcherAdjust = 10
+    cfg.catchChanceLeftFieldAdjust = 5
+    cfg.catchChanceCenterFieldAdjust = 5
+    cfg.catchChanceRightFieldAdjust = 5
+    cfg.automaticCatchDist = 15
+    return FieldingAI(cfg)
+
+
+def test_diving_and_leaping_affect_probability():
+    ai = _make_ai()
+    fa = 70
+    hang_time = 1.0
+    dive = ai.catch_probability("CF", fa, hang_time, "dive")
+    leap = ai.catch_probability("CF", fa, hang_time, "leap")
+    normal = ai.catch_probability("CF", fa, hang_time, "catch")
+    assert normal > leap > dive
+
+
+def test_position_adjustments_affect_probability():
+    ai = _make_ai()
+    fa = 70
+    hang_time = 1.0
+    pitcher = ai.catch_probability("P", fa, hang_time, "catch")
+    catcher = ai.catch_probability("C", fa, hang_time, "catch")
+    left_field = ai.catch_probability("LF", fa, hang_time, "catch")
+    assert catcher > pitcher
+    assert left_field > pitcher


### PR DESCRIPTION
## Summary
- add catch_probability to FieldingAI incorporating action, hang time, position and config adjustments
- use catch probability when resolving fly balls and throws
- test diving/leaping and positional catch probability differences

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4b2189ffc832e8ac54153efbcf2e3