### PR TITLE
Add wild pitch catch resolution

### DIFF
--- a/logic/fielding_ai.py
+++ b/logic/fielding_ai.py
@@ -73,6 +73,32 @@ class FieldingAI:
 
         return max(0.0, min(1.0, chance / 100))
 
+    def wild_pitch_catch_probability(
+        self, fa: int, *, glove_side: bool, high: bool
+    ) -> float:
+        """Return the probability of a catcher blocking a wild pitch."""
+
+        chance = (
+            self.config.wildCatchChanceBase
+            + self.config.wildCatchChanceFAPct * fa / 100
+        )
+        if not glove_side:
+            chance += self.config.wildCatchChanceOppMod
+        if high:
+            chance += self.config.wildCatchChanceHighMod
+        return max(0.0, min(1.0, chance / 100))
+
+    def resolve_wild_pitch(
+        self, fa: int, *, glove_side: bool, high: bool
+    ) -> bool:
+        """Return ``True`` if the wild pitch is blocked."""
+
+        prob = self.wild_pitch_catch_probability(
+            fa, glove_side=glove_side, high=high
+        )
+        rng = self.rng or Random()
+        return rng.random() < prob
+
     def good_throw_probability(self, position: str, fa: int) -> float:
         """Return the probability of making an accurate throw.
 

--- a/tests/test_wild_pitch_catch.py
+++ b/tests/test_wild_pitch_catch.py
@@ -1,0 +1,20 @@
+from logic.fielding_ai import FieldingAI
+from tests.util.pbini_factory import make_cfg
+
+
+def test_glove_side_vs_cross_body_probability():
+    cfg = make_cfg(
+        wildCatchChanceBase=80,
+        wildCatchChanceFAPct=50,
+        wildCatchChanceOppMod=-20,
+    )
+    ai = FieldingAI(cfg)
+    fa = 60
+    glove = ai.wild_pitch_catch_probability(fa, glove_side=True, high=False)
+    cross = ai.wild_pitch_catch_probability(fa, glove_side=False, high=False)
+    expected_glove = min(1.0, (80 + 50 * fa / 100) / 100)
+    expected_cross = min(1.0, (80 + 50 * fa / 100 - 20) / 100)
+    assert glove == expected_glove
+    assert cross == expected_cross
+    assert cross < glove
+


### PR DESCRIPTION
## Summary
- compute catcher block chance on wild pitches using PlayBalance values and FA
- roll wild pitch outcomes as blocked or passed ball
- cover glove-side vs. cross-body adjustments with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4ba166dfc832e93d6c355297373f5