### PR TITLE
Respect chase distance limits when assigning fielders

### DIFF
--- a/tests/test_fielding_ai.py
+++ b/tests/test_fielding_ai.py
@@ -77,3 +77,70 @@ def test_bad_throw_sets_error_state():
     ai = FieldingAI(cfg, rng=Random(0))
     caught, error = ai.resolve_throw("SS", fa=0, hang_time=1.0)
     assert error
+
+
+def test_infielder_chase_limit():
+    cfg = PlayBalanceConfig()
+    cfg.infieldMaxChaseDist = 50
+    ai = FieldingAI(cfg)
+    # Distance beyond limit results in no attempt despite ample hang time
+    action = ai.catch_action(
+        hang_time=60,
+        run_time=10,
+        position="SS",
+        distance=60,
+    )
+    assert action == "no_attempt"
+
+    # At the limit the fielder will pursue the ball
+    action = ai.catch_action(
+        hang_time=60,
+        run_time=10,
+        position="SS",
+        distance=50,
+    )
+    assert action == "catch"
+
+
+def test_pitcher_chase_limit():
+    cfg = PlayBalanceConfig()
+    cfg.pitcherMaxChaseDist = 90
+    ai = FieldingAI(cfg)
+    action = ai.catch_action(
+        hang_time=60,
+        run_time=10,
+        position="P",
+        distance=100,
+    )
+    assert action == "no_attempt"
+
+    action = ai.catch_action(
+        hang_time=60,
+        run_time=10,
+        position="P",
+        distance=90,
+    )
+    assert action == "catch"
+
+
+def test_outfielder_chase_limit():
+    cfg = PlayBalanceConfig()
+    cfg.outfieldMinChaseDist = 150
+    ai = FieldingAI(cfg)
+    action = ai.catch_action(
+        hang_time=60,
+        run_time=10,
+        position="CF",
+        distance=10,
+        dist_from_home=140,
+    )
+    assert action == "no_attempt"
+
+    action = ai.catch_action(
+        hang_time=60,
+        run_time=10,
+        position="CF",
+        distance=10,
+        dist_from_home=150,
+    )
+    assert action == "catch"


### PR DESCRIPTION
## Summary
- prevent infielders and pitchers from pursuing balls beyond their PB.INI chase distance limits
- require outfielders to only chase balls deep enough from home plate
- add unit tests for infielder, pitcher, and outfielder chase distance edge cases

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4bb521348832eafea239b2497ee2f