### PR TITLE
Implement long-lead baserunning and pickoff scare logic

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -260,6 +260,8 @@ _DEFAULTS: Dict[str, Any] = {
     "pickoffChanceStealChanceAdjust": 0,
     "pickoffChanceLeadMult": 0,
     "pickoffChancePitchesMult": 0,
+    "longLeadSpeed": 0,
+    "pickoffScareSpeed": 0,
     "pitchOutChanceStealThresh": 0,
     "pitchOutChanceHitRunThresh": 0,
     "pitchOutChanceBase": 0,

--- a/tests/test_offensive_manager.py
+++ b/tests/test_offensive_manager.py
@@ -205,7 +205,7 @@ def test_hit_and_run_chance_and_advance():
         "holdChanceBase": 0,
         "holdChanceAdjust": 0,
     })
-    runner = make_player("r")
+    runner = make_player("r", sp=80)
     batter = make_player("b", ch=10, ph=10)
     home = TeamState(lineup=[make_player("h1")], bench=[], pitchers=[make_pitcher("hp")])
     away = TeamState(lineup=[batter], bench=[], pitchers=[make_pitcher("ap")])
@@ -345,7 +345,7 @@ def test_sacrifice_bunt_on_deck_high_close_late():
             "holdChanceAdjust": 0,
         }
     )
-    runner = make_player("r")
+    runner = make_player("r", sp=80)
     batter = make_player("b", ch=10, ph=10)
     on_deck = make_player("d", ch=60, ph=60)
     home = TeamState(lineup=[make_player("h1")], bench=[], pitchers=[make_pitcher("hp")])


### PR DESCRIPTION
## Summary
- Add `longLead` state for fast runners and enforce long leads for steal attempts
- Handle pickoff attempts that nearly succeed and scare slow runners back to short leads
- Track lead state and adjust unit tests for new baserunning rules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4bc75b904832eb108af28533334e1