### PR TITLE
Handle full game flow in exhibition simulations

### DIFF
--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -451,15 +451,27 @@ class GameSimulation:
     # Core loop helpers
     # ------------------------------------------------------------------
     def simulate_game(self, innings: int = 9) -> None:
-        """Simulate ``innings`` innings.
+        """Simulate a complete game.
 
-        Only very small parts of a real baseball game are modelled – enough to
-        exercise decision making paths for the tests.
+        The game will extend into extra innings if tied after the requested
+        number of innings and the bottom half of the final inning is skipped
+        when the home team is already ahead. Only very small parts of a real
+        baseball game are modelled – enough to exercise decision making
+        paths for the tests.
         """
 
-        for _ in range(innings):
-            self._play_half(self.away, self.home)  # Top half
-            self._play_half(self.home, self.away)  # Bottom half
+        inning = 1
+        if innings > 0:
+            while True:
+                # Top half
+                self._play_half(self.away, self.home)
+                if inning >= innings and self.away.runs < self.home.runs:
+                    break
+                # Bottom half
+                self._play_half(self.home, self.away)
+                if inning >= innings and self.home.runs != self.away.runs:
+                    break
+                inning += 1
 
         # Finalize pitching stats for pitchers who finished the game
         self._on_pitcher_exit(self.home.current_pitcher_state, self.away, self.home, game_finished=True)


### PR DESCRIPTION
## Summary
- extend simulation loop to skip the bottom of the 9th when the home team already leads and to continue into extra innings if tied
- add regression tests for early endings and extra inning play
- adjust boxscore test helper to simulate a deterministic single-inning game

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4bf5c5c3c832eb39c5d63477b19bd