### PR TITLE
feat: persist play balance overrides

### DIFF
--- a/tests/test_playbalance_config.py
+++ b/tests/test_playbalance_config.py
@@ -1,3 +1,4 @@
+import logic.playbalance_config as playbalance_config
 from logic.playbalance_config import PlayBalanceConfig
 
 
@@ -16,3 +17,43 @@ def test_playbalance_config_defaults():
     assert cfg.sureStrikeDist == 3
     assert cfg.lookPrimaryType00CountAdjust == 0
     assert cfg.lookBestType30CountAdjust == 15
+
+
+def test_save_and_load_overrides(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        playbalance_config, "_OVERRIDE_PATH", tmp_path / "overrides.json"
+    )
+    playbalance_config._DEFAULTS.clear()
+    playbalance_config._DEFAULTS.update(playbalance_config._BASE_DEFAULTS)
+
+    cfg = PlayBalanceConfig()
+    cfg.speedBase = 42
+    cfg.save_overrides()
+
+    playbalance_config._DEFAULTS.clear()
+    playbalance_config._DEFAULTS.update(playbalance_config._BASE_DEFAULTS)
+    playbalance_config.PlayBalanceConfig.load_overrides()
+
+    cfg2 = PlayBalanceConfig()
+    assert cfg2.speedBase == 42
+    cfg.reset()
+
+
+def test_reset_overrides(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        playbalance_config, "_OVERRIDE_PATH", tmp_path / "overrides.json"
+    )
+    playbalance_config._DEFAULTS.clear()
+    playbalance_config._DEFAULTS.update(playbalance_config._BASE_DEFAULTS)
+
+    cfg = PlayBalanceConfig()
+    cfg.speedBase = 42
+    cfg.save_overrides()
+    assert playbalance_config._OVERRIDE_PATH.exists()
+
+    cfg.reset()
+    assert (
+        playbalance_config._DEFAULTS["speedBase"]
+        == playbalance_config._BASE_DEFAULTS["speedBase"]
+    )
+    assert not playbalance_config._OVERRIDE_PATH.exists()


### PR DESCRIPTION
## Summary
- allow persisting PlayBalance overrides to `data/playbalance_overrides.json`
- load saved overrides on module import and provide helpers to save or reset
- add tests for saving, loading, and resetting overrides

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4d9693864832ea0139881ce9c4e5c