### PR TITLE
Add configurable play balance editor

### DIFF
--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -17,6 +17,7 @@ from PyQt6.QtWidgets import (
 from PyQt6.QtCore import Qt
 from ui.team_entry_dialog import TeamEntryDialog
 from ui.exhibition_game_dialog import ExhibitionGameDialog
+from ui.playbalance_editor import PlayBalanceEditor
 from utils.trade_utils import load_trades, save_trade
 from utils.news_logger import log_news_event
 from utils.roster_loader import load_roster
@@ -85,6 +86,10 @@ class AdminDashboard(QWidget):
         self.exhibition_button = QPushButton("Simulate Exhibition Game")
         self.exhibition_button.clicked.connect(self.open_exhibition_dialog)
         button_layout.addWidget(self.exhibition_button, alignment=Qt.AlignmentFlag.AlignHCenter)
+
+        self.playbalance_button = QPushButton("Edit Play Balance")
+        self.playbalance_button.clicked.connect(self.open_playbalance_editor)
+        button_layout.addWidget(self.playbalance_button, alignment=Qt.AlignmentFlag.AlignHCenter)
 
         layout.addLayout(button_layout)
         layout.addStretch()
@@ -271,6 +276,10 @@ class AdminDashboard(QWidget):
 
     def open_exhibition_dialog(self):
         dialog = ExhibitionGameDialog(self)
+        dialog.exec()
+
+    def open_playbalance_editor(self):
+        dialog = PlayBalanceEditor(self)
         dialog.exec()
 
     def open_add_user(self):

--- a/ui/playbalance_editor.py
+++ b/ui/playbalance_editor.py
@@ -1,0 +1,97 @@
+from PyQt6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QLineEdit,
+    QHBoxLayout,
+    QPushButton,
+)
+from PyQt6.QtGui import QIntValidator
+from typing import Dict, List
+
+from logic.playbalance_config import PlayBalanceConfig, _DEFAULTS
+
+
+class PlayBalanceEditor(QDialog):
+    """Dialog allowing administrators to tweak key PlayBalance values."""
+
+    # Keys grouped by category for display in the tree widget.
+    _CATEGORIES: Dict[str, List[str]] = {
+        "Physics": [
+            "speedBase",
+            "swingSpeedBase",
+            "averagePitchSpeed",
+            "ballAirResistancePct",
+        ],
+        "AI": [
+            "pitchRatVariationBase",
+            "sureStrikeDist",
+            "closeBallDist",
+            "couldBeCaughtSlop",
+        ],
+        "Managerial": [
+            "offManStealChancePct",
+            "defManChargeChancePct",
+            "defManPitchAroundToIBBPct",
+            "doubleSwitchBase",
+        ],
+    }
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Play Balance Editor")
+        self.config = PlayBalanceConfig()
+        self._editors: Dict[str, QLineEdit] = {}
+
+        layout = QVBoxLayout()
+        self.tree = QTreeWidget()
+        self.tree.setColumnCount(2)
+        self.tree.setHeaderLabels(["Key", "Value"])
+        layout.addWidget(self.tree)
+
+        validator = QIntValidator(self)
+
+        for category, keys in self._CATEGORIES.items():
+            cat_item = QTreeWidgetItem([category])
+            self.tree.addTopLevelItem(cat_item)
+            for key in keys:
+                value = _DEFAULTS.get(key, 0)
+                item = QTreeWidgetItem(cat_item, [key])
+                editor = QLineEdit(str(value))
+                editor.setValidator(validator)
+                self.tree.setItemWidget(item, 1, editor)
+                self._editors[key] = editor
+            cat_item.setExpanded(True)
+
+        btn_row = QHBoxLayout()
+        save_btn = QPushButton("Save")
+        reset_btn = QPushButton("Reset to Defaults")
+        cancel_btn = QPushButton("Cancel")
+        save_btn.clicked.connect(self.save)
+        reset_btn.clicked.connect(self.reset_defaults)
+        cancel_btn.clicked.connect(self.reject)
+        btn_row.addWidget(save_btn)
+        btn_row.addWidget(reset_btn)
+        btn_row.addWidget(cancel_btn)
+        layout.addLayout(btn_row)
+
+        self.setLayout(layout)
+
+    def save(self) -> None:
+        """Persist edited values to overrides."""
+        for key, editor in self._editors.items():
+            text = editor.text().strip()
+            if not text:
+                continue
+            value = int(editor.text())
+            self.config.values[key] = value
+        self.config.save_overrides()
+        self.accept()
+
+    def reset_defaults(self) -> None:
+        """Restore defaults and update the UI."""
+        self.config.reset()
+        for key, editor in self._editors.items():
+            editor.setText(str(_DEFAULTS.get(key, 0)))
+


### PR DESCRIPTION
## Summary
- Provide PlayBalanceEditor dialog to tune physics, AI, and managerial defaults with save/reset support
- Add AdminDashboard button to access the new play balance editor

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4dc77ec50832e9a7a65fee7707cd7