### PR TITLE
Add PlayBalance override regression tests

### DIFF
--- a/tests/test_playbalance_config.py
+++ b/tests/test_playbalance_config.py
@@ -1,5 +1,7 @@
 import logic.playbalance_config as playbalance_config
 from logic.playbalance_config import PlayBalanceConfig
+from logic.simulation import GameSimulation, TeamState, BatterState
+from tests.test_physics import make_player, make_pitcher, MockRandom
 
 
 def test_playbalance_config_defaults():
@@ -57,3 +59,50 @@ def test_reset_overrides(tmp_path, monkeypatch):
         == playbalance_config._BASE_DEFAULTS["speedBase"]
     )
     assert not playbalance_config._OVERRIDE_PATH.exists()
+
+
+def test_speedbase_override_affects_simulation(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        playbalance_config, "_OVERRIDE_PATH", tmp_path / "overrides.json"
+    )
+    playbalance_config._DEFAULTS.clear()
+    playbalance_config._DEFAULTS.update(playbalance_config._BASE_DEFAULTS)
+
+    def advance_base(cfg: PlayBalanceConfig) -> int:
+        batter = make_player("bat", ph=80)
+        runner = make_player("run", sp=50)
+        runner_state = BatterState(runner)
+        home = TeamState(
+            lineup=[make_player("h1")], bench=[], pitchers=[make_pitcher("hp1")]
+        )
+        away = TeamState(
+            lineup=[batter], bench=[], pitchers=[make_pitcher("ap1")]
+        )
+        away.lineup_stats[runner.player_id] = runner_state
+        away.bases[0] = runner_state
+        sim = GameSimulation(home, away, cfg, MockRandom([0.0, 0.0, 0.9, 0.9]))
+        sim.play_at_bat(away, home)
+        if away.bases[2] is runner_state:
+            return 3
+        if away.bases[1] is runner_state:
+            return 2
+        return 1
+
+    baseline = advance_base(PlayBalanceConfig())
+    assert baseline == 2
+
+    cfg = PlayBalanceConfig()
+    cfg.speedBase = 30
+    cfg.save_overrides()
+
+    playbalance_config._DEFAULTS.clear()
+    playbalance_config._DEFAULTS.update(playbalance_config._BASE_DEFAULTS)
+    playbalance_config.PlayBalanceConfig.load_overrides()
+
+    overridden = advance_base(PlayBalanceConfig())
+    assert overridden == 3
+
+    cfg.reset()
+    reset = advance_base(PlayBalanceConfig())
+    assert reset == baseline
+

--- a/tests/util/pbini_factory.py
+++ b/tests/util/pbini_factory.py
@@ -16,9 +16,16 @@ def make_cfg(**entries: int) -> PlayBalanceConfig:
     return PlayBalanceConfig.from_dict({"PlayBalance": entries})
 
 
-def load_config() -> PlayBalanceConfig:
-    """Load the full test configuration from ``logic/PBINI.txt``."""
-    pbini = load_pbini(Path("logic/PBINI.txt"))
+def load_config(path: Path | None = None) -> PlayBalanceConfig:
+    """Load the full test configuration from ``path``.
+
+    If ``path`` is ``None`` the default ``logic/PBINI.txt`` is used.  This
+    helper allows tests to provide their own PlayBalance files when specific
+    values need to be exercised.
+    """
+
+    path = Path("logic/PBINI.txt") if path is None else Path(path)
+    pbini = load_pbini(path)
     cfg = PlayBalanceConfig.from_dict(pbini)
     # The real configuration contains pitch objective weights which would
     # introduce additional randomness via :class:`PitcherAI`.  Tests expect


### PR DESCRIPTION
## Summary
- allow test config loader to accept custom PlayBalance files
- verify PlayBalance overrides impact simulations and reset to defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4dd806614832e9aff52b68beb66db