### PR TITLE
Use OpenAI for logo generation with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,19 @@ UBL (Ultimate Baseball League) Simulation is a Python project that models a smal
 - **League management:** classes for players, teams, trades and rosters in `models/` with supporting services and UI dialogs.
 - **Game simulation:** `logic/simulation.py` provides a minimal engine for at-bats, pitching changes and base running.
 - **Data files:** example data lives in the `data/` directory including rosters, lineups and configuration values.
+- **AI-generated logos:** `utils.logo_generator` can create team logos using OpenAI's image API.
+
+## OpenAI setup
+
+Utilities that generate images (avatars and team logos) require an OpenAI API
+key. Create a `[OpenAIkey]` section in `config.ini`:
+
+```
+[OpenAIkey]
+key=<your API key>
+```
+
+The key enables calls to OpenAI's `images.generate` endpoint.
 
 ### Play balance configuration
 

--- a/tests/test_logo_generator_openai.py
+++ b/tests/test_logo_generator_openai.py
@@ -1,0 +1,66 @@
+import base64
+from types import SimpleNamespace
+
+import os
+
+import pytest
+
+from utils import logo_generator
+from models.team import Team
+
+
+def _fake_b64_png() -> str:
+    # 1x1 px transparent PNG
+    return (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6XwHAAAAABJRU5ErkJggg=="
+    )
+
+
+def test_generates_logo_and_calls_callback(tmp_path, monkeypatch):
+    team = Team(
+        team_id="TST",
+        name="Testers",
+        city="Testville",
+        abbreviation="TST",
+        division="Test",
+        stadium="Test Field",
+        primary_color="#112233",
+        secondary_color="#445566",
+        owner_id="0",
+    )
+
+    # Patch load_teams to return our single team
+    monkeypatch.setattr(logo_generator, "load_teams", lambda _: [team])
+
+    calls = {}
+
+    class DummyImages:
+        def generate(self, **kwargs):
+            calls.update(kwargs)
+            return SimpleNamespace(data=[SimpleNamespace(b64_json=_fake_b64_png())])
+
+    monkeypatch.setattr(logo_generator, "client", SimpleNamespace(images=DummyImages()))
+
+    progress = []
+
+    def cb(done, total):
+        progress.append((done, total))
+
+    out_dir = tmp_path
+    logo_generator.generate_team_logos(out_dir=str(out_dir), size=256, progress_callback=cb)
+
+    assert "Testville" in calls["prompt"]
+    assert "Testers" in calls["prompt"]
+    assert "#112233" in calls["prompt"]
+    assert "#445566" in calls["prompt"]
+
+    outfile = out_dir / "tst.png"
+    assert outfile.exists()
+    assert progress == [(1, 1)]
+
+
+def test_raises_without_client(tmp_path, monkeypatch):
+    monkeypatch.setattr(logo_generator, "client", None)
+    monkeypatch.setattr(logo_generator, "load_teams", lambda _: [])
+    with pytest.raises(RuntimeError):
+        logo_generator.generate_team_logos(out_dir=str(tmp_path))

--- a/utils/logo_generator.py
+++ b/utils/logo_generator.py
@@ -1,38 +1,31 @@
 """Utilities for generating team logos.
 
-Creates simple team logos using the :mod:`images.auto_logo` module. Logos are
-written to ``logo/teams`` relative to the repository root and named after the
-team's ID (lower‑cased).
+Logos are created using OpenAI's image generation API and written to
+``logo/teams`` relative to the project root. Each logo is named after the
+team's ID (lower-cased). If the OpenAI client is unavailable a fallback to the
+legacy :mod:`images.auto_logo` generator can be enabled.
 """
+
 from __future__ import annotations
 
+import base64
 import os
 from typing import Callable, List, Optional
 
-from images.auto_logo import TeamSpec, batch_generate, _seed_from_name
+from utils.openai_client import client
 from utils.team_loader import load_teams
 
 
-def generate_team_logos(
-    out_dir: str | None = None,
-    size: int = 512,
-    progress_callback: Optional[Callable[[int, int], None]] = None,
-) -> str:
-    """Generate logos for all teams and return the output directory.
+def _auto_logo_fallback(
+    teams: List[object],
+    out_dir: str,
+    size: int,
+    progress_callback: Optional[Callable[[int, int], None]],
+) -> None:
+    """Generate logos using the legacy ``images.auto_logo`` module."""
 
-    Parameters
-    ----------
-    out_dir:
-        Optional output directory. Defaults to ``logo/teams`` relative to the
-        project root.
-    size:
-        Pixel size for the generated square logos.
-    progress_callback:
-        Optional callback receiving ``(completed, total)`` after each logo is
-        saved.
-    """
+    from images.auto_logo import TeamSpec, batch_generate, _seed_from_name  # pragma: no cover
 
-    teams = load_teams("data/teams.csv")
     specs: List[TeamSpec] = []
     for t in teams:
         specs.append(
@@ -47,10 +40,6 @@ def generate_team_logos(
             )
         )
 
-    if out_dir is None:
-        base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-        out_dir = os.path.join(base_dir, "logo", "teams")
-    os.makedirs(out_dir, exist_ok=True)
     total = len(specs)
     completed = 0
 
@@ -61,4 +50,65 @@ def generate_team_logos(
             progress_callback(completed, total)
 
     batch_generate(specs, out_dir=out_dir, size=size, callback=cb)
+
+
+def generate_team_logos(
+    out_dir: str | None = None,
+    size: int = 512,
+    progress_callback: Optional[Callable[[int, int], None]] = None,
+    allow_auto_logo: bool = False,
+) -> str:
+    """Generate logos for all teams and return the output directory.
+
+    Parameters
+    ----------
+    out_dir:
+        Optional output directory. Defaults to ``logo/teams`` relative to the
+        project root.
+    size:
+        Pixel size for the generated square logos.
+    progress_callback:
+        Optional callback receiving ``(completed, total)`` after each logo is
+        saved.
+    allow_auto_logo:
+        When ``True`` and the OpenAI client is not configured, fall back to the
+        older :mod:`images.auto_logo` generator.
+    """
+
+    teams = load_teams("data/teams.csv")
+
+    if out_dir is None:
+        base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        out_dir = os.path.join(base_dir, "logo", "teams")
+    os.makedirs(out_dir, exist_ok=True)
+
+    if client is None:
+        if allow_auto_logo:
+            _auto_logo_fallback(teams, out_dir, size, progress_callback)
+            return out_dir
+        raise RuntimeError("OpenAI client is not configured")
+
+    total = len(teams)
+    for idx, t in enumerate(teams, start=1):
+        prompt = (
+            f"Professional baseball logo for the {t.city} {t.name}. "
+            f"Use primary color {t.primary_color} and secondary color {t.secondary_color}."
+        )
+        result = client.images.generate(
+            model="gpt-image-1",
+            prompt=prompt,
+            size=f"{size}x{size}",
+        )
+        b64 = result.data[0].b64_json
+        image_bytes = base64.b64decode(b64)
+        path = os.path.join(out_dir, f"{t.team_id.lower()}.png")
+        with open(path, "wb") as f:
+            f.write(image_bytes)
+        if progress_callback:
+            progress_callback(idx, total)
+
     return out_dir
+
+
+__all__ = ["generate_team_logos"]
+


### PR DESCRIPTION
## Summary
- Replace internal logo generator with OpenAI `images.generate` and optional auto-logo fallback
- Add unit tests mocking OpenAI client to verify prompts and file output
- Document OpenAI API key setup for logo creation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4deb9c378832eb20f4e5ef49c59d0