### PR TITLE
Load OpenAI API key from environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__/
 build/
 dist/
 *.spec
+
+config.ini

--- a/README.md
+++ b/README.md
@@ -12,7 +12,16 @@ UBL (Ultimate Baseball League) Simulation is a Python project that models a smal
 ## OpenAI setup
 
 Utilities that generate images (avatars and team logos) require an OpenAI API
-key. Create a `[OpenAIkey]` section in `config.ini`:
+key. Set the `OPENAI_API_KEY` environment variable before running the
+application:
+
+```bash
+export OPENAI_API_KEY=<your API key>
+```
+
+For local development you may instead create a `config.ini` file containing a
+`[OpenAIkey]` section. This file is ignored by git and serves only as a
+fallback when the environment variable is missing:
 
 ```
 [OpenAIkey]

--- a/config.ini
+++ b/config.ini
@@ -1,2 +1,0 @@
-[OpenAIkey]
-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

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -10,3 +10,16 @@ def test_read_api_key_handles_raw_section(tmp_path, monkeypatch):
     monkeypatch.setattr(openai_client, "__file__", str(fake_module_path))
     assert openai_client._read_api_key() == "line1line2"
 
+
+def test_env_var_takes_precedence(tmp_path, monkeypatch):
+    config = tmp_path / "config.ini"
+    config.write_text("[OpenAIkey]\nfilekey\n")
+    fake_module_path = tmp_path / "utils" / "openai_client.py"
+    fake_module_path.parent.mkdir()
+    fake_module_path.touch()
+    monkeypatch.setattr(openai_client, "__file__", str(fake_module_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "envkey")
+    assert openai_client._read_api_key() == "envkey"
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert openai_client._read_api_key() == "filekey"
+

--- a/utils/openai_client.py
+++ b/utils/openai_client.py
@@ -1,13 +1,15 @@
-"""Reusable OpenAI client configured via ``config.ini``.
+"""Reusable OpenAI client configured via environment or ``config.ini``.
 
-Reads the API key from the ``[OpenAIkey]`` section of ``config.ini`` and
-creates a singleton ``OpenAI`` client that can be imported anywhere in the
-project. If the :mod:`openai` package is not installed or a key is missing, the
-``client`` variable will be ``None``.
+Reads the API key from the ``OPENAI_API_KEY`` environment variable, falling
+back to the ``[OpenAIkey]`` section of ``config.ini``. A singleton ``OpenAI``
+client is created that can be imported anywhere in the project. If the
+:mod:`openai` package is not installed or a key is missing, the ``client``
+variable will be ``None``.
 """
 from __future__ import annotations
 
 import configparser
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -18,7 +20,12 @@ except Exception:  # pragma: no cover
 
 
 def _read_api_key() -> Optional[str]:
-    """Return the OpenAI API key from ``config.ini`` if available."""
+    """Return the OpenAI API key from environment or ``config.ini``."""
+
+    env_key = os.getenv("OPENAI_API_KEY")
+    if env_key:
+        return env_key
+
     base_dir = Path(__file__).resolve().parent.parent
     config_path = base_dir / "config.ini"
     parser = configparser.ConfigParser()


### PR DESCRIPTION
## Summary
- remove committed OpenAI API key and ignore local config.ini files
- read `OPENAI_API_KEY` environment variable with config.ini fallback
- document new API key configuration and add tests for env var precedence

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4e03f2490832e837f80f11f42c90d