### PR TITLE
Ensure team loader resolves CSV path from project root

### DIFF
--- a/tests/test_team_loader.py
+++ b/tests/test_team_loader.py
@@ -27,3 +27,9 @@ def test_invalid_hex_color_raises(tmp_path):
     team.secondary_color = "ZZZZZZ"  # invalid characters
     with pytest.raises(ValueError):
         save_team_settings(team, str(team_file))
+
+
+def test_load_teams_from_any_cwd(monkeypatch):
+    monkeypatch.chdir("ui")
+    teams = load_teams()
+    assert teams, "Expected to load teams regardless of working directory"

--- a/utils/team_loader.py
+++ b/utils/team_loader.py
@@ -1,8 +1,19 @@
 import csv
+import os
 import re
 from models.team import Team
 
-def load_teams(file_path="data/teams.csv"):
+def _resolve_path(file_path: str) -> str:
+    """Return an absolute path for ``file_path`` relative to the project root."""
+
+    if os.path.isabs(file_path):
+        return file_path
+    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    return os.path.join(base_dir, file_path)
+
+
+def load_teams(file_path: str = "data/teams.csv"):
+    file_path = _resolve_path(file_path)
     teams = []
     with open(file_path, mode="r", newline="") as csvfile:
         reader = csv.DictReader(csvfile)
@@ -22,7 +33,7 @@ def load_teams(file_path="data/teams.csv"):
     return teams
 
 
-def save_team_settings(team: Team, file_path="data/teams.csv") -> None:
+def save_team_settings(team: Team, file_path: str = "data/teams.csv") -> None:
     """Persist updates to a single team's stadium or colors.
 
     Reads the entire teams file, updates the matching team's fields and
@@ -45,6 +56,7 @@ def save_team_settings(team: Team, file_path="data/teams.csv") -> None:
             return value.upper()
         raise ValueError(f"Invalid hex color for {field}: {value}")
 
+    file_path = _resolve_path(file_path)
     teams = []
     with open(file_path, mode="r", newline="") as csvfile:
         reader = csv.DictReader(csvfile)


### PR DESCRIPTION
## Summary
- make team loader resolve relative paths against project root so UI works from any directory
- add regression test verifying load_teams works regardless of working directory

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4e66db774832e8f233678727b3289