### PR TITLE
Enable auto logo fallback by default

### DIFF
--- a/tests/test_logo_generator_openai.py
+++ b/tests/test_logo_generator_openai.py
@@ -59,8 +59,23 @@ def test_generates_logo_and_calls_callback(tmp_path, monkeypatch):
     assert progress == [(1, 1)]
 
 
-def test_raises_without_client(tmp_path, monkeypatch):
+def test_auto_logo_fallback_without_client(tmp_path, monkeypatch):
+    monkeypatch.setattr(logo_generator, "client", None)
+    monkeypatch.setattr(logo_generator, "load_teams", lambda _: [])
+
+    called = {}
+
+    def fake_fallback(teams, out_dir, size, progress_callback):
+        called["args"] = (teams, out_dir, size, progress_callback)
+
+    monkeypatch.setattr(logo_generator, "_auto_logo_fallback", fake_fallback)
+
+    logo_generator.generate_team_logos(out_dir=str(tmp_path))
+    assert "args" in called
+
+
+def test_raises_without_client_when_disabled(tmp_path, monkeypatch):
     monkeypatch.setattr(logo_generator, "client", None)
     monkeypatch.setattr(logo_generator, "load_teams", lambda _: [])
     with pytest.raises(RuntimeError):
-        logo_generator.generate_team_logos(out_dir=str(tmp_path))
+        logo_generator.generate_team_logos(out_dir=str(tmp_path), allow_auto_logo=False)

--- a/utils/logo_generator.py
+++ b/utils/logo_generator.py
@@ -56,7 +56,7 @@ def generate_team_logos(
     out_dir: str | None = None,
     size: int = 512,
     progress_callback: Optional[Callable[[int, int], None]] = None,
-    allow_auto_logo: bool = False,
+    allow_auto_logo: bool = True,
 ) -> str:
     """Generate logos for all teams and return the output directory.
 
@@ -71,8 +71,9 @@ def generate_team_logos(
         Optional callback receiving ``(completed, total)`` after each logo is
         saved.
     allow_auto_logo:
-        When ``True`` and the OpenAI client is not configured, fall back to the
-        older :mod:`images.auto_logo` generator.
+        When ``True`` (the default) and the OpenAI client is not configured,
+        fall back to the older :mod:`images.auto_logo` generator. Set to
+        ``False`` to raise a ``RuntimeError`` instead.
     """
 
     teams = load_teams("data/teams.csv")


### PR DESCRIPTION
## Summary
- default team logo generation to use legacy auto_logo when OpenAI isn't configured
- add tests for auto logo fallback and for disabling fallback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4e762bbb8832eba24dcb4cb3162c0