### PR TITLE
Use sample-style HTML for standings

### DIFF
--- a/tests/test_standings_window.py
+++ b/tests/test_standings_window.py
@@ -200,3 +200,5 @@ def test_standings_window_displays_league_and_teams():
     assert "UBL" in html
     assert "East" in html
     assert "Dallas Rockets" in html
+    assert "<pre>" in html
+    assert "<ul>" not in html

--- a/ui/standings_window.py
+++ b/ui/standings_window.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import os
 from collections import defaultdict
+from datetime import datetime
+
 from PyQt6.QtWidgets import QDialog, QVBoxLayout, QTextEdit
 
 from utils.team_loader import load_teams
@@ -43,12 +45,37 @@ class StandingsWindow(QDialog):
         for team in teams:
             divisions[team.division].append(f"{team.city} {team.name}")
 
-        parts = [f"<h1>{league_name} Standings</h1>"]
-        for division in sorted(divisions):
-            parts.append(f"<h2>{division} Division</h2>")
-            parts.append("<ul>")
-            for name in sorted(divisions[division]):
-                parts.append(f"<li>{name}</li>")
-            parts.append("</ul>")
+        # Build HTML using the same format as the sample standings page.
+        today = datetime.now().strftime("%A, %B %d, %Y")
+        parts = [
+            "<html><head>",
+            f"<title>{league_name} Standings</title>",
+            "</head><body>",
+            "<b><font size=\"+2\"><center>",
+            f"{league_name} Standings",
+            "</center></font>",
+            "<font size=\"+1\"><center>",
+            today,
+            "</center></font></b>",
+            "<hr><b><font size=\"+1\"><center>",
+            league_name,
+            "</center></font></b>",
+            "<pre>",
+        ]
 
+        header = (
+            "{:<22}W   L   Pct.    GB    1-run  X-inn   L-10  Strk     Home   "
+            "Road    v.RHP  v.LHP   in Div  nonDiv"
+        )
+
+        for division in sorted(divisions):
+            parts.append(f"<b>{header.format(division)}</b>")
+            for name in sorted(divisions[division]):
+                parts.append(
+                    f"{name:<22}0   0   .000   ---     0-0    0-0    0-0   W  0     "
+                    "0-0    0-0      0-0    0-0      0-0    0-0"
+                )
+            parts.append("")
+
+        parts.extend(["</pre></body></html>"])
         self.viewer.setHtml("\n".join(parts))


### PR DESCRIPTION
## Summary
- Render standings window with sample-style preformatted HTML so league, division and team names mirror the sample layout
- Check standings window output includes preformatted markup and no list elements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5086b26e0832ebef6731c5c7305f2