### PR TITLE
Add simulation engine overview documentation

### DIFF
--- a/docs/simulation_engine.md
+++ b/docs/simulation_engine.md
@@ -1,0 +1,71 @@
+# Simulation Engine Overview
+
+This document describes how NexGen BBPro simulates a baseball game and the key
+modules involved in decision making and physics.
+
+## Player State Data Structures
+
+Several dataclasses track in-game state and statistics:
+
+- **`BatterState`**, **`PitcherState`**, and **`FieldingState`** capture
+  performance for individual players during the game【F:logic/simulation.py†L33-L146】
+- **`TeamState`** maintains the current lineup, bench, pitchers, base runners and
+  cumulative team stats for each side【F:logic/simulation.py†L149-L192】
+
+These structures are created before the game starts and are updated throughout
+play as events occur.
+
+## GameSimulation
+
+The `GameSimulation` class orchestrates the game loop.  It owns references to
+state for both teams and composes the managers and AI helpers that drive
+strategy and outcomes【F:logic/simulation.py†L193-L200】【F:logic/simulation.py†L10-L18】.
+It also tracks situational details such as defensive alignment, pitcher fatigue
+and environmental conditions.
+
+During play the simulation:
+
+1. Sets the defensive alignment before each plate appearance.
+2. Uses `PitcherAI` to choose pitch type and `BatterAI` to decide whether to
+   swing.
+3. Delegates physical calculations—like pitch speed or batted ball flight—to the
+   `Physics` helper.
+4. Updates statistics in the player and team state objects.
+5. Consults the `SubstitutionManager` for pinch hitters, pitching changes and
+   other personnel moves.
+
+## AI and Managers
+
+A collection of focused modules encapsulate specific decision making:
+
+- `PitcherAI` selects pitches and objectives using configurable weights and
+  tracks which pitches have been established【F:logic/pitcher_ai.py†L1-L33】【F:logic/pitcher_ai.py†L48-L60】.
+- `BatterAI` applies count-based adjustments to swing decisions and computes the
+  contact quality of a swing【F:logic/batter_ai.py†L1-L39】【F:logic/batter_ai.py†L58-L70】.
+- `SubstitutionManager` evaluates pinch hitting, defensive replacements and
+  bullpen usage using ratings derived from player attributes and configuration
+  chances【F:logic/substitution_manager.py†L1-L108】.
+- Offensive and defensive strategy is delegated to `OffensiveManager` and
+  `DefensiveManager` (not shown here), while `FieldingAI` positions fielders
+  according to batter tendencies.
+
+## Physics Helpers
+
+The `Physics` class provides deterministic calculations for movement speed,
+reaction delays, throwing mechanics and pitch characteristics.  All formulas are
+parameterised by the `PlayBalanceConfig` so tests can verify configuration
+impact【F:logic/physics.py†L8-L75】【F:logic/physics.py†L92-L130】.
+
+## Statistics
+
+At the end of each play, raw totals are converted into derived and rate stats
+using helpers in `logic.stats`.  For example, batting rates include batting
+average, on-base percentage and slugging percentage computed from counting
+stats【F:logic/stats.py†L9-L60】.
+
+## Configuration
+
+`PlayBalanceConfig` exposes the many tunable values that influence all of the
+above modules.  By adjusting this configuration, tests and future gameplay modes
+can explore different balancing options for the simulation engine.
+


### PR DESCRIPTION
## Summary
- Document how the simulation engine orchestrates games and the modules that drive logic, physics and statistics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a508e80ae4832e809e678ca0802f77