### PR TITLE
Bundle data directories and unify resource paths

### DIFF
--- a/build_exe.py
+++ b/build_exe.py
@@ -1,17 +1,18 @@
 """Build an executable for NexGen-BBPro using PyInstaller."""
+
+from __future__ import annotations
+
+import os
 import PyInstaller.__main__
 
 
 def main() -> None:
     """Run PyInstaller to create a standalone executable."""
-    PyInstaller.__main__.run(
-        [
-            "main.py",
-            "--onefile",
-            "--name",
-            "NexGen-BBPro",
-        ]
-    )
+    data_dirs = ["data", "logo", "assets", "images"]
+    params = ["main.py", "--onefile", "--name", "NexGen-BBPro"]
+    for d in data_dirs:
+        params += ["--add-data", f"{d}{os.pathsep}{d}"]
+    PyInstaller.__main__.run(params)
 
 
 if __name__ == "__main__":

--- a/logic/league_creator.py
+++ b/logic/league_creator.py
@@ -2,7 +2,9 @@ import colorsys
 import os
 import csv
 import shutil
+from pathlib import Path
 from typing import Dict, List, Tuple
+
 from models.player import Player
 from models.pitcher import Pitcher
 from utils.player_writer import save_players_to_csv
@@ -97,18 +99,19 @@ def _dict_to_model(data: dict):
         )
 
 
-def create_league(base_dir: str, divisions: Dict[str, List[Tuple[str, str]]], league_name: str):
-    os.makedirs(base_dir, exist_ok=True)
-    rosters_dir = os.path.join(base_dir, "rosters")
-    if os.path.exists(rosters_dir):
+def create_league(base_dir: str | Path, divisions: Dict[str, List[Tuple[str, str]]], league_name: str):
+    base_dir = Path(base_dir)
+    base_dir.mkdir(parents=True, exist_ok=True)
+    rosters_dir = base_dir / "rosters"
+    if rosters_dir.exists():
         shutil.rmtree(rosters_dir)
-    os.makedirs(rosters_dir, exist_ok=True)
+    rosters_dir.mkdir(parents=True, exist_ok=True)
 
     clear_users()
 
-    teams_path = os.path.join(base_dir, "teams.csv")
-    players_path = os.path.join(base_dir, "players.csv")
-    league_path = os.path.join(base_dir, "league.txt")
+    teams_path = base_dir / "teams.csv"
+    players_path = base_dir / "players.csv"
+    league_path = base_dir / "league.txt"
 
     team_rows = []
     all_players = []
@@ -163,8 +166,8 @@ def create_league(base_dir: str, divisions: Dict[str, List[Tuple[str, str]]], le
             for level_players in roster_levels.values():
                 all_players.extend(level_players)
 
-            roster_file = os.path.join(rosters_dir, f"{abbr}.csv")
-            with open(roster_file, "w", newline="") as f:
+            roster_file = rosters_dir / f"{abbr}.csv"
+            with roster_file.open("w", newline="") as f:
                 writer = csv.writer(f)
                 for level, players in roster_levels.items():
                     for p in players:

--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -5,9 +5,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict
 
+from utils.path_utils import get_base_dir
+
 from .pbini_loader import load_pbini
 
-DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+DATA_DIR = get_base_dir() / "data"
 _OVERRIDE_PATH = DATA_DIR / "playbalance_overrides.json"
 
 # Default values for PlayBalance configuration entries used throughout the

--- a/logic/player_generator.py
+++ b/logic/player_generator.py
@@ -3,17 +3,19 @@ import random
 from datetime import datetime, timedelta
 from typing import Dict, List, Tuple, Set, Optional
 import csv
-import os
+from pathlib import Path
+
+from utils.path_utils import get_base_dir
 
 # Constants
-base_dir = os.path.dirname(os.path.abspath(__file__))
-NAME_PATH = os.path.join(base_dir, "..", "data", "names.csv")
+BASE_DIR = get_base_dir()
+NAME_PATH = BASE_DIR / "data" / "names.csv"
 
 
 def _load_name_pool() -> Dict[str, List[Tuple[str, str]]]:
     pool: Dict[str, List[Tuple[str, str]]] = {}
-    if os.path.exists(NAME_PATH):
-        with open(NAME_PATH, newline="") as f:
+    if NAME_PATH.exists():
+        with NAME_PATH.open(newline="") as f:
             reader = csv.DictReader(f)
             for row in reader:
                 pool.setdefault(row["ethnicity"], []).append(

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -16,6 +16,7 @@ from logic.pitcher_ai import PitcherAI
 from logic.batter_ai import BatterAI
 from logic.bullpen import WarmupTracker
 from logic.fielding_ai import FieldingAI
+from utils.path_utils import get_base_dir
 from .stats import (
     compute_batting_derived,
     compute_batting_rates,
@@ -1503,7 +1504,7 @@ def save_boxscore_html(game_type: str, html: str, game_id: str | None = None) ->
         Full path of the written file.
     """
 
-    base = Path(__file__).resolve().parent.parent / "data" / "boxscores" / game_type
+    base = get_base_dir() / "data" / "boxscores" / game_type
     base.mkdir(parents=True, exist_ok=True)
     if game_id is None:
         game_id = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/ui/exhibition_game_dialog.py
+++ b/ui/exhibition_game_dialog.py
@@ -9,7 +9,6 @@ from PyQt6.QtWidgets import (
 )
 from PyQt6.QtCore import Qt
 from typing import Dict
-import os
 
 from utils.team_loader import load_teams
 from utils.player_loader import load_players_from_csv
@@ -25,6 +24,7 @@ from logic.simulation import (
 )
 from models.pitcher import Pitcher
 from logic.playbalance_config import PlayBalanceConfig
+from utils.path_utils import get_base_dir
 
 
 class ExhibitionGameDialog(QDialog):
@@ -39,8 +39,8 @@ class ExhibitionGameDialog(QDialog):
         self.home_combo = QComboBox()
         self.away_combo = QComboBox()
 
-        data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "data"))
-        teams = load_teams(os.path.join(data_dir, "teams.csv"))
+        data_dir = get_base_dir() / "data"
+        teams = load_teams(data_dir / "teams.csv")
         self._teams: Dict[str, str] = {}
         for t in teams:
             label = f"{t.name} ({t.team_id})"
@@ -79,9 +79,9 @@ class ExhibitionGameDialog(QDialog):
     def _build_state(self, team_id: str) -> TeamState:
         players = {
             p.player_id: p
-            for p in load_players_from_csv(os.path.join(self._data_dir, "players.csv"))
+            for p in load_players_from_csv(self._data_dir / "players.csv")
         }
-        roster = load_roster(team_id, os.path.join(self._data_dir, "rosters"))
+        roster = load_roster(team_id, self._data_dir / "rosters")
 
         lineup = []
         bench = []
@@ -112,9 +112,7 @@ class ExhibitionGameDialog(QDialog):
         try:
             home_state = self._build_state(home_id)
             away_state = self._build_state(away_id)
-            cfg = PlayBalanceConfig.from_file(
-                os.path.join(os.path.dirname(__file__), "..", "logic", "PBINI.txt")
-            )
+            cfg = PlayBalanceConfig.from_file(get_base_dir() / "logic" / "PBINI.txt")
             sim = GameSimulation(home_state, away_state, cfg)
             sim.simulate_game()
             box = generate_boxscore(home_state, away_state)

--- a/ui/login_window.py
+++ b/ui/login_window.py
@@ -4,15 +4,14 @@ from PyQt6.QtWidgets import (
 )
 from PyQt6.QtCore import Qt
 import sys
-import os
+
+from utils.path_utils import get_base_dir
 
 from ui.admin_dashboard import AdminDashboard
 from ui.owner_dashboard import OwnerDashboard
 
 # Determine the path to the users file in a cross-platform way
-USER_FILE = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "..", "data", "users.txt")
-)
+USER_FILE = get_base_dir() / "data" / "users.txt"
 
 class LoginWindow(QWidget):
     def __init__(self, splash=None):
@@ -54,11 +53,11 @@ class LoginWindow(QWidget):
         username = self.username_input.text()
         password = self.password_input.text()
 
-        if not os.path.exists(USER_FILE):
+        if not USER_FILE.exists():
             QMessageBox.critical(self, "Error", "User file not found.")
             return
 
-        with open(USER_FILE, "r") as f:
+        with USER_FILE.open("r") as f:
             for line in f:
                 parts = line.strip().split(",")
                 if len(parts) != 4:

--- a/ui/owner_dashboard.py
+++ b/ui/owner_dashboard.py
@@ -43,6 +43,7 @@ from utils.free_agent_finder import find_free_agents
 from utils.team_loader import load_teams, save_team_settings
 from utils.pitcher_role import get_role
 from utils.trade_utils import get_pending_trades
+from utils.path_utils import get_base_dir
 
 
 def _hex_to_rgb(value: str) -> tuple[int, int, int]:
@@ -117,11 +118,10 @@ class OwnerDashboard(QWidget):
         self.schedule_action.triggered.connect(self.open_schedule_window)
         main.setMenuBar(menubar)
 
-        base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-        logo_path = os.path.join(base_dir, "logo", "teams", f"{team_id.lower()}.png")
-        if os.path.exists(logo_path):
+        logo_path = get_base_dir() / "logo" / "teams" / f"{team_id.lower()}.png"
+        if logo_path.exists():
             logo_label = QLabel()
-            pix = QPixmap(logo_path).scaled(
+            pix = QPixmap(str(logo_path)).scaled(
                 128,
                 128,
                 Qt.AspectRatioMode.KeepAspectRatio,

--- a/ui/pitching_editor.py
+++ b/ui/pitching_editor.py
@@ -1,8 +1,9 @@
 from PyQt6.QtWidgets import QDialog, QLabel, QVBoxLayout, QGridLayout, QComboBox, QPushButton, QMessageBox
-import os
 import csv
+
 from utils.pitcher_role import get_role
 from utils.pitching_autofill import autofill_pitching_staff
+from utils.path_utils import get_base_dir
 
 class PitchingEditor(QDialog):
     def __init__(self, team_id):
@@ -47,10 +48,10 @@ class PitchingEditor(QDialog):
         self.load_pitching_staff()
 
     def load_players_dict(self):
-        path = os.path.join("data", "players.csv")
+        path = get_base_dir() / "data" / "players.csv"
         players = {}
-        if os.path.exists(path):
-            with open(path, newline='', encoding="utf-8") as f:
+        if path.exists():
+            with path.open(newline='', encoding="utf-8") as f:
                 for row in csv.DictReader(f):
                     pid = row["player_id"].strip()
                     # Show the pitcher's role (SP/RP) instead of raw "P" when possible
@@ -67,9 +68,9 @@ class PitchingEditor(QDialog):
 
     def get_act_level_ids(self):
         act_ids = set()
-        path = os.path.join("data", "rosters", f"{self.team_id}.csv")
-        if os.path.exists(path):
-            with open(path, newline='', encoding="utf-8") as f:
+        path = get_base_dir() / "data" / "rosters" / f"{self.team_id}.csv"
+        if path.exists():
+            with path.open(newline='', encoding="utf-8") as f:
                 for row in csv.reader(f):
                     if len(row) >= 2 and row[1].strip().upper() == "ACT":
                         act_ids.add(row[0].strip())
@@ -84,8 +85,8 @@ class PitchingEditor(QDialog):
                 return
             if player_id:
                 used_ids.add(player_id)
-        path = os.path.join("data", "rosters", f"{self.team_id}_pitching.csv")
-        with open(path, "w", newline='', encoding="utf-8") as f:
+        path = get_base_dir() / "data" / "rosters" / f"{self.team_id}_pitching.csv"
+        with path.open("w", newline='', encoding="utf-8") as f:
             writer = csv.writer(f)
             for role, dropdown in self.pitcher_dropdowns.items():
                 player_id = dropdown.currentData()
@@ -94,9 +95,9 @@ class PitchingEditor(QDialog):
         QMessageBox.information(self, "Saved", "Pitching staff saved successfully.")
 
     def load_pitching_staff(self):
-        path = os.path.join("data", "rosters", f"{self.team_id}_pitching.csv")
-        if os.path.exists(path):
-            with open(path, newline='', encoding="utf-8") as f:
+        path = get_base_dir() / "data" / "rosters" / f"{self.team_id}_pitching.csv"
+        if path.exists():
+            with path.open(newline='', encoding="utf-8") as f:
                 for row in csv.reader(f):
                     if len(row) >= 2:
                         player_id, role = row[0], row[1]

--- a/ui/splash_screen.py
+++ b/ui/splash_screen.py
@@ -1,9 +1,9 @@
-import os
 from PyQt6.QtWidgets import QWidget, QLabel, QPushButton, QVBoxLayout
 from PyQt6.QtGui import QPixmap, QFont
 from PyQt6.QtCore import Qt
 
 from ui.login_window import LoginWindow
+from utils.path_utils import get_base_dir
 
 class SplashScreen(QWidget):
     """Initial splash screen displaying the UBL logo and start button."""
@@ -16,12 +16,8 @@ class SplashScreen(QWidget):
         layout.addStretch()
 
         logo_label = QLabel()
-        logo_path = os.path.join(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-            "logo",
-            "UBL.png",
-        )
-        logo_label.setPixmap(QPixmap(logo_path))
+        logo_path = get_base_dir() / "logo" / "UBL.png"
+        logo_label.setPixmap(QPixmap(str(logo_path)))
         logo_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(logo_label)
 

--- a/ui/standings_window.py
+++ b/ui/standings_window.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import os
 from collections import defaultdict
 from PyQt6.QtWidgets import QDialog, QVBoxLayout, QTextEdit
 
 from utils.team_loader import load_teams
+from utils.path_utils import get_base_dir
 
 
 class StandingsWindow(QDialog):
@@ -29,11 +29,11 @@ class StandingsWindow(QDialog):
 
     def _load_standings(self) -> None:
         """Load league, division and team names into the text viewer."""
-        base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-        league_path = os.path.join(base_dir, "data", "league.txt")
+        base_dir = get_base_dir()
+        league_path = base_dir / "data" / "league.txt"
 
         try:
-            with open(league_path, encoding="utf-8") as f:
+            with league_path.open(encoding="utf-8") as f:
                 league_name = f.read().strip() or "League"
         except OSError:
             league_name = "League"

--- a/utils/avatar_generator.py
+++ b/utils/avatar_generator.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 import base64
-import os
 from io import BytesIO
+from pathlib import Path
 from typing import Dict
 
 from PIL import Image
@@ -64,7 +64,7 @@ def generate_avatar(name: str, team_id: str, out_file: str, size: int = 512) -> 
     b64 = result.data[0].b64_json
     image_bytes = base64.b64decode(b64)
     with Image.open(BytesIO(image_bytes)) as img:
-        os.makedirs(os.path.dirname(out_file), exist_ok=True)
+        Path(out_file).parent.mkdir(parents=True, exist_ok=True)
         img.save(out_file, format="PNG")
     return out_file
 

--- a/utils/free_agent_finder.py
+++ b/utils/free_agent_finder.py
@@ -1,14 +1,20 @@
-import os
 import csv
+from pathlib import Path
 
-def find_free_agents(players, roster_dir="data/rosters"):
+from utils.path_utils import get_base_dir
+
+
+def find_free_agents(players, roster_dir: str | Path = "data/rosters"):
     """Return a list of Player/Pitcher objects not assigned to any roster."""
     assigned_ids = set()
 
-    # Check all roster files and collect player_ids
-    for filename in os.listdir(roster_dir):
-        if filename.endswith(".csv"):
-            with open(os.path.join(roster_dir, filename), mode="r", newline="") as f:
+    roster_dir = Path(roster_dir)
+    if not roster_dir.is_absolute():
+        roster_dir = get_base_dir() / roster_dir
+
+    for filename in roster_dir.iterdir():
+        if filename.suffix == ".csv":
+            with filename.open(mode="r", newline="") as f:
                 reader = csv.reader(f)
                 next(reader, None)  # skip header if present
                 for row in reader:

--- a/utils/lineup_loader.py
+++ b/utils/lineup_loader.py
@@ -1,16 +1,17 @@
 import csv
-import os
+from pathlib import Path
 from typing import List, Tuple, Iterable
 
 from logic.simulation import TeamState
 from models.player import Player
 from models.pitcher import Pitcher
+from utils.path_utils import get_base_dir
 from .player_loader import load_players_from_csv
 from .roster_loader import load_roster
 from .pitcher_role import get_role
 
 
-def load_lineup(team_id: str, vs: str = "lhp", lineup_dir: str = "data/lineups") -> List[Tuple[str, str]]:
+def load_lineup(team_id: str, vs: str = "lhp", lineup_dir: str | Path = "data/lineups") -> List[Tuple[str, str]]:
     """Load a lineup from ``lineup_dir`` for the given team.
 
     Files are expected to follow the naming pattern
@@ -19,12 +20,15 @@ def load_lineup(team_id: str, vs: str = "lhp", lineup_dir: str = "data/lineups")
     ``P1000``.
     """
     suffix = f"vs_{vs.lower()}"
-    file_path = os.path.join(lineup_dir, f"{team_id}_{suffix}.csv")
-    if not os.path.exists(file_path):
+    lineup_dir = Path(lineup_dir)
+    if not lineup_dir.is_absolute():
+        lineup_dir = get_base_dir() / lineup_dir
+    file_path = lineup_dir / f"{team_id}_{suffix}.csv"
+    if not file_path.exists():
         raise FileNotFoundError(f"Lineup file not found: {file_path}")
 
     lineup: List[Tuple[str, str]] = []
-    with open(file_path, newline='', encoding='utf-8') as csvfile:
+    with file_path.open(newline='', encoding='utf-8') as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
             player_id = row.get("player_id", "").strip()

--- a/utils/news_logger.py
+++ b/utils/news_logger.py
@@ -1,10 +1,15 @@
-import os
 from datetime import datetime
+from pathlib import Path
 
-NEWS_FILE = "data/news_feed.txt"
+from utils.path_utils import get_base_dir
 
-def log_news_event(event: str, file_path: str = NEWS_FILE):
-    """Appends a timestamped news event to the news feed file."""
+NEWS_FILE = get_base_dir() / "data" / "news_feed.txt"
+
+
+def log_news_event(event: str, file_path: Path = NEWS_FILE):
+    """Append a timestamped news event to the news feed file."""
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    with open(file_path, mode="a", encoding="utf-8") as f:
+    path = Path(file_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open(mode="a", encoding="utf-8") as f:
         f.write(f"[{timestamp}] {event}\n")

--- a/utils/news_reader.py
+++ b/utils/news_reader.py
@@ -1,7 +1,16 @@
-def read_latest_news(n=10, file_path="data/news_feed.txt"):
-    """Returns the latest N news items as a list of strings (most recent first)."""
+from pathlib import Path
+
+from utils.path_utils import get_base_dir
+
+
+def read_latest_news(n: int = 10, file_path: str | Path = "data/news_feed.txt"):
+    """Return the latest ``n`` news items (most recent first)."""
+
+    path = Path(file_path)
+    if not path.is_absolute():
+        path = get_base_dir() / path
     try:
-        with open(file_path, "r", encoding="utf-8") as f:
+        with path.open("r", encoding="utf-8") as f:
             lines = f.readlines()
         return list(reversed(lines[-n:]))
     except FileNotFoundError:

--- a/utils/openai_client.py
+++ b/utils/openai_client.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 import configparser
 import os
+import sys
 from pathlib import Path
 from typing import Optional
+
 
 try:  # pragma: no cover - gracefully handle missing dependency
     from openai import OpenAI
@@ -26,7 +28,7 @@ def _read_api_key() -> Optional[str]:
     if env_key:
         return env_key
 
-    base_dir = Path(__file__).resolve().parent.parent
+    base_dir = Path(getattr(sys, "_MEIPASS", Path(__file__).resolve().parent.parent))
     config_path = base_dir / "config.ini"
     parser = configparser.ConfigParser()
     try:

--- a/utils/path_utils.py
+++ b/utils/path_utils.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+def get_base_dir() -> Path:
+    """Return project root or PyInstaller's temporary directory."""
+    return Path(getattr(sys, "_MEIPASS", Path(__file__).resolve().parent.parent))

--- a/utils/player_loader.py
+++ b/utils/player_loader.py
@@ -1,6 +1,8 @@
 import csv
 from pathlib import Path
+
 from models.player import Player
+from utils.path_utils import get_base_dir
 from models.pitcher import Pitcher
 
 
@@ -29,7 +31,7 @@ def load_players_from_csv(file_path):
         working directory.
     """
 
-    base_path = Path(__file__).resolve().parent.parent
+    base_path = get_base_dir()
     csv_path = Path(file_path)
     if not csv_path.is_absolute():
         csv_path = base_path / csv_path

--- a/utils/roster_loader.py
+++ b/utils/roster_loader.py
@@ -1,14 +1,18 @@
 import csv
-import os
-from models.roster import Roster
+from pathlib import Path
 
-def load_roster(team_id, roster_dir="data/rosters"):
+from models.roster import Roster
+from utils.path_utils import get_base_dir
+def load_roster(team_id, roster_dir: str | Path = "data/rosters"):
     act, aaa, low = [], [], []
-    file_path = os.path.join(roster_dir, f"{team_id}.csv")
-    if not os.path.exists(file_path):
+    roster_dir = Path(roster_dir)
+    if not roster_dir.is_absolute():
+        roster_dir = get_base_dir() / roster_dir
+    file_path = roster_dir / f"{team_id}.csv"
+    if not file_path.exists():
         raise FileNotFoundError(f"Roster file not found: {file_path}")
 
-    with open(file_path, mode="r", newline="") as csvfile:
+    with file_path.open(mode="r", newline="") as csvfile:
         reader = csv.reader(csvfile)
         for row in reader:
             if len(row) < 2:
@@ -24,9 +28,10 @@ def load_roster(team_id, roster_dir="data/rosters"):
 
     return Roster(team_id=team_id, act=act, aaa=aaa, low=low)
 
+
 def save_roster(team_id, roster: Roster):
-    filepath = os.path.join("data", "rosters", f"{team_id}.csv")
-    with open(filepath, mode="w", newline="") as f:
+    filepath = get_base_dir() / "data" / "rosters" / f"{team_id}.csv"
+    with filepath.open(mode="w", newline="") as f:
         writer = csv.writer(f)
         for level, group in [("ACT", roster.act), ("AAA", roster.aaa), ("LOW", roster.low)]:
             for player_id in group:

--- a/utils/team_loader.py
+++ b/utils/team_loader.py
@@ -1,21 +1,24 @@
 import csv
 import os
 import re
+from pathlib import Path
 from models.team import Team
-
-def _resolve_path(file_path: str) -> str:
-    """Return an absolute path for ``file_path`` relative to the project root."""
-
-    if os.path.isabs(file_path):
-        return file_path
-    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-    return os.path.join(base_dir, file_path)
+from utils.path_utils import get_base_dir
 
 
-def load_teams(file_path: str = "data/teams.csv"):
+def _resolve_path(file_path: str | Path) -> Path:
+    """Return an absolute :class:`Path` for ``file_path`` relative to the project root."""
+
+    path = Path(file_path)
+    if path.is_absolute():
+        return path
+    return get_base_dir() / path
+
+
+def load_teams(file_path: str | Path = "data/teams.csv"):
     file_path = _resolve_path(file_path)
     teams = []
-    with open(file_path, mode="r", newline="") as csvfile:
+    with file_path.open(mode="r", newline="") as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
             team = Team(
@@ -27,13 +30,13 @@ def load_teams(file_path: str = "data/teams.csv"):
                 stadium=row["stadium"],
                 primary_color=row["primary_color"],
                 secondary_color=row["secondary_color"],
-                owner_id=row["owner_id"]
+                owner_id=row["owner_id"],
             )
             teams.append(team)
     return teams
 
 
-def save_team_settings(team: Team, file_path: str = "data/teams.csv") -> None:
+def save_team_settings(team: Team, file_path: str | Path = "data/teams.csv") -> None:
     """Persist updates to a single team's stadium or colors.
 
     Reads the entire teams file, updates the matching team's fields and
@@ -58,7 +61,7 @@ def save_team_settings(team: Team, file_path: str = "data/teams.csv") -> None:
 
     file_path = _resolve_path(file_path)
     teams = []
-    with open(file_path, mode="r", newline="") as csvfile:
+    with file_path.open(mode="r", newline="") as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
             if row["team_id"] == team.team_id:
@@ -78,7 +81,7 @@ def save_team_settings(team: Team, file_path: str = "data/teams.csv") -> None:
         "secondary_color",
         "owner_id",
     ]
-    with open(file_path, mode="w", newline="") as csvfile:
+    with file_path.open(mode="w", newline="") as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
         writer.writeheader()
         writer.writerows(teams)


### PR DESCRIPTION
## Summary
- include data, logo, assets and image directories when building the executable
- add `get_base_dir()` helper resolving paths inside or outside a PyInstaller bundle
- update modules to access resources via the new helper for cross-platform compatibility

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a50836b630832eb7dc3d744938b6a6