### PR TITLE
Hide console window for PyInstaller build

### DIFF
--- a/build_exe.py
+++ b/build_exe.py
@@ -9,7 +9,8 @@ import PyInstaller.__main__
 def main() -> None:
     """Run PyInstaller to create a standalone executable."""
     data_dirs = ["data", "logo", "assets", "images"]
-    params = ["main.py", "--onefile", "--name", "NexGen-BBPro"]
+    # --noconsole prevents a console window from appearing when the app runs
+    params = ["main.py", "--onefile", "--name", "NexGen-BBPro", "--noconsole"]
     for d in data_dirs:
         params += ["--add-data", f"{d}{os.pathsep}{d}"]
     PyInstaller.__main__.run(params)


### PR DESCRIPTION
## Summary
- prevent console window from appearing when running built app by adding `--noconsole`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a50c6560f8832e95ac5faa0e847dc4