### PR TITLE
Add UBL icon for executable build

### DIFF
--- a/build_exe.py
+++ b/build_exe.py
@@ -9,8 +9,17 @@ import PyInstaller.__main__
 def main() -> None:
     """Run PyInstaller to create a standalone executable."""
     data_dirs = ["data", "logo", "assets", "images"]
+    icon_path = os.path.join("logo", "UBL.ico")
     # --noconsole prevents a console window from appearing when the app runs
-    params = ["main.py", "--onefile", "--name", "NexGen-BBPro", "--noconsole"]
+    params = [
+        "main.py",
+        "--onefile",
+        "--name",
+        "NexGen-BBPro",
+        "--noconsole",
+        "--icon",
+        icon_path,
+    ]
     for d in data_dirs:
         params += ["--add-data", f"{d}{os.pathsep}{d}"]
     PyInstaller.__main__.run(params)


### PR DESCRIPTION
## Summary
- update `build_exe.py` to use an icon during PyInstaller packaging
- remove `UBL.ico` from version control; supply separately

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a50fc4eae4832e98103de2b1800fec