### PR TITLE
Enforce plain team avatars with consistent backgrounds

### DIFF
--- a/tests/test_avatar_generator_openai.py
+++ b/tests/test_avatar_generator_openai.py
@@ -40,6 +40,10 @@ def test_generates_avatar_at_requested_size(tmp_path, monkeypatch):
     assert "Test Player" in calls["prompt"]
     assert "illustrated" in calls["prompt"].lower()
     assert "cartoon style" in calls["prompt"].lower()
+    prompt = calls["prompt"].lower()
+    assert "plain ball cap and jersey" in prompt
+    assert "no logos, letters, or names" in prompt
+    assert "solid #112233 background" in prompt
     assert out_file.exists()
     with Image.open(out_file) as img:
         assert img.size == (size, size)

--- a/utils/avatar_generator.py
+++ b/utils/avatar_generator.py
@@ -61,8 +61,10 @@ def generate_avatar(
     ethnicity = _infer_ethnicity(name)
     prompt = (
         f"{style.capitalize()} portrait of {name}, a {ethnicity} baseball player, "
-        f"wearing team colors {colors['primary']} and {colors['secondary']} in a "
-        "cartoon style."
+        "wearing a plain ball cap and jersey in team colors "
+        f"{colors['primary']} and {colors['secondary']} with no logos, letters, "
+        "or names, on a solid "
+        f"{colors['primary']} background in a cartoon style."
     )
     api_size = 1024 if size == 512 else size
     result = client.images.generate(


### PR DESCRIPTION
## Summary
- Ensure generated avatars use plain caps and jerseys without logos, letters, or names
- Add team-specific solid background color to avatar prompt
- Extend avatar generator tests for new prompt requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a53472a5e4832ea438749904e9f676