### PR TITLE
Ensure avatars have off-white background and no text

### DIFF
--- a/tests/test_avatar_generator_openai.py
+++ b/tests/test_avatar_generator_openai.py
@@ -42,8 +42,10 @@ def test_generates_avatar_at_requested_size(tmp_path, monkeypatch):
     assert "cartoon style" in calls["prompt"].lower()
     prompt = calls["prompt"].lower()
     assert "plain ball cap and jersey" in prompt
-    assert "no logos, letters, or names" in prompt
-    assert "solid #112233 background" in prompt
+    assert "cap has no logo, image, or letters" in prompt
+    assert "jersey has no names, letters, or numbers" in prompt
+    assert "no text overlays or names" in prompt
+    assert "off-white background" in prompt
     assert out_file.exists()
     with Image.open(out_file) as img:
         assert img.size == (size, size)

--- a/utils/avatar_generator.py
+++ b/utils/avatar_generator.py
@@ -39,6 +39,10 @@ def generate_avatar(
 ) -> str:
     """Generate an avatar for ``name`` and save it to ``out_file``.
 
+    The avatar uses an off-white background and depicts a player in a plain cap
+    and jersey in team colors without any logos, images, letters, names, or
+    numbers. The image must contain no text overlays.
+
     Parameters
     ----------
     name:
@@ -62,9 +66,10 @@ def generate_avatar(
     prompt = (
         f"{style.capitalize()} portrait of {name}, a {ethnicity} baseball player, "
         "wearing a plain ball cap and jersey in team colors "
-        f"{colors['primary']} and {colors['secondary']} with no logos, letters, "
-        "or names, on a solid "
-        f"{colors['primary']} background in a cartoon style."
+        f"{colors['primary']} and {colors['secondary']}. The cap has no logo, "
+        "image, or letters and the jersey has no names, letters, or numbers. "
+        "The image contains no text overlays or names on an off-white background "
+        "in a cartoon style."
     )
     api_size = 1024 if size == 512 else size
     result = client.images.generate(


### PR DESCRIPTION
## Summary
- Enforce off-white background for generated avatars
- Remove any logos, letters, images, names, or numbers from caps and jerseys
- Update tests for the revised avatar prompt

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a537d0c460832e815cbbd6fe1caa6d