### PR TITLE
Exclude avatars from PyInstaller build

### DIFF
--- a/build_exe.py
+++ b/build_exe.py
@@ -8,7 +8,9 @@ import PyInstaller.__main__
 
 def main() -> None:
     """Run PyInstaller to create a standalone executable."""
-    data_dirs = ["data", "logo", "assets", "images"]
+    # Avatar images drastically increase bundle size and are generated on demand,
+    # so skip them when packaging the executable.
+    data_dirs = ["data", "logo", "assets"]
     icon_path = os.path.join("logo", "UBL.ico")
     # --noconsole prevents a console window from appearing when the app runs
     params = [


### PR DESCRIPTION
## Summary
- Skip bundling avatar images when building the standalone executable to keep its size down

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bcrypt')*


------
https://chatgpt.com/codex/tasks/task_e_68a63dc00320832eb70ad419024b278b