### PR TITLE
feat: support dual role players

### DIFF
--- a/tests/test_player_generator.py
+++ b/tests/test_player_generator.py
@@ -47,3 +47,35 @@ def test_pitcher_role_rp_when_endurance_low(monkeypatch):
     player = generate_player(is_pitcher=True)
     assert player["endurance"] == 55
     assert player["role"] == "RP"
+
+
+def test_pitcher_can_hit(monkeypatch):
+    def fake_randint(a, b):
+        if (a, b) == (1, 100):
+            fake_randint.calls += 1
+            return 1 if fake_randint.calls == 2 else 50
+        if (a, b) == (10, 99):
+            return 80
+        return (a + b) // 2
+
+    fake_randint.calls = 0
+    monkeypatch.setattr(pg.random, "randint", fake_randint)
+
+    player = generate_player(is_pitcher=True)
+    assert player["ch"] == int(80 * 0.75)
+    assert player["pot_ch"] >= player["ch"]
+
+
+def test_hitter_can_pitch(monkeypatch):
+    def fake_randint(a, b):
+        if (a, b) == (1, 1000):
+            return 1
+        if (a, b) == (10, 99):
+            return 80
+        return (a + b) // 2
+
+    monkeypatch.setattr(pg.random, "randint", fake_randint)
+
+    player = generate_player(is_pitcher=False, primary_position="1B")
+    assert player["control"] == int(80 * 0.75)
+    assert "P" in player["other_positions"]


### PR DESCRIPTION
## Summary
- implement ARR dual-role chances for pitchers and hitters with 75% rating allocation to secondary discipline
- add tests covering pitcher-hitting and hitter-pitching cases

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bcrypt')*

------
https://chatgpt.com/codex/tasks/task_e_68a661c747c8832e92d5b1cec51856ba