### PR TITLE
Implement weighted player rating distribution

### DIFF
--- a/tests/test_player_generator.py
+++ b/tests/test_player_generator.py
@@ -79,3 +79,17 @@ def test_hitter_can_pitch(monkeypatch):
     player = generate_player(is_pitcher=False, primary_position="1B")
     assert player["control"] == int(80 * 0.75)
     assert "P" in player["other_positions"]
+
+
+def test_hitter_distribution_totals():
+    weights = pg.HITTER_RATING_WEIGHTS["1B"]
+    total = 500
+    ratings = pg.distribute_rating_points(total, weights)
+    assert sum(ratings.values()) == total
+
+
+def test_pitcher_distribution_totals():
+    weights = pg.PITCHER_RATING_WEIGHTS
+    total = 480
+    ratings = pg.distribute_rating_points(total, weights)
+    assert sum(ratings.values()) == total


### PR DESCRIPTION
## Summary
- add `distribute_rating_points` to split rating pools using ARR weights
- generate pitcher and hitter attributes using weighted distribution
- test that rating point distribution totals are preserved

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bcrypt')*


------
https://chatgpt.com/codex/tasks/task_e_68a6633635cc832e881371d486f054a5