### PR TITLE
Add weighted skin tone field to player generator

### DIFF
--- a/logic/player_generator.py
+++ b/logic/player_generator.py
@@ -134,12 +134,22 @@ def distribute_rating_points(total: int, weights: Dict[str, int]) -> Dict[str, i
 
 PITCHER_RATE = 0.4  # Fraction of draft pool that should be pitchers
 
+SKIN_TONE_WEIGHTS = {"dark": 25, "medium": 25, "light": 25}
+
 
 def assign_primary_position() -> str:
     """Select a primary position using weights from the ARR tables."""
     return random.choices(
         list(PRIMARY_POSITION_WEIGHTS.keys()),
         weights=PRIMARY_POSITION_WEIGHTS.values(),
+    )[0]
+
+
+def assign_skin_tone() -> str:
+    """Select a skin tone using weights from the ARR tables."""
+    return random.choices(
+        list(SKIN_TONE_WEIGHTS.keys()),
+        weights=SKIN_TONE_WEIGHTS.values(),
     )[0]
 
 
@@ -389,6 +399,7 @@ def generate_player(
     player_id = f"P{random.randint(1000, 9999)}"
     height = random.randint(68, 78)
     weight = random.randint(160, 250)
+    skin_tone = assign_skin_tone()
 
     if is_pitcher:
         bats, throws = assign_bats_throws("P")
@@ -439,6 +450,7 @@ def generate_player(
             "delivery": delivery,
             "height": height,
             "weight": weight,
+            "skin_tone": skin_tone,
             "primary_position": "P",
             "other_positions": assign_secondary_positions("P"),
             "pot_control": bounded_potential(control, age),
@@ -498,6 +510,7 @@ def generate_player(
             "arm": arm,
             "height": height,
             "weight": weight,
+            "skin_tone": skin_tone,
             "primary_position": primary_pos,
             "other_positions": other_pos,
             "pot_ch": bounded_potential(ch, age),

--- a/tests/test_player_generator.py
+++ b/tests/test_player_generator.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from datetime import date
 import random
 
@@ -93,3 +94,14 @@ def test_pitcher_distribution_totals():
     total = 480
     ratings = pg.distribute_rating_points(total, weights)
     assert sum(ratings.values()) == total
+
+
+def test_skin_tone_distribution_matches_weights():
+    random.seed(0)
+    num_players = 600
+    players = [generate_player(is_pitcher=False) for _ in range(num_players)]
+    counts = Counter(p["skin_tone"] for p in players)
+    total_weight = sum(pg.SKIN_TONE_WEIGHTS.values())
+    for tone, weight in pg.SKIN_TONE_WEIGHTS.items():
+        expected = weight / total_weight
+        assert abs(counts[tone] / num_players - expected) < 0.05


### PR DESCRIPTION
## Summary
- Generate a `skin_tone` for each player using ARR-derived weights
- Expose `SKIN_TONE_WEIGHTS` and `assign_skin_tone` helper
- Test that generated skin tones follow the configured distribution

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bcrypt')*
- `pip install bcrypt` *(fails: Could not find a version that satisfies the requirement bcrypt)*
- `pytest tests/test_player_generator.py::test_skin_tone_distribution_matches_weights -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6653fd8b0832e8a5c23f279de88ce