### PR TITLE
Adjust lefty pitcher ratings

### DIFF
--- a/logic/player_generator.py
+++ b/logic/player_generator.py
@@ -459,6 +459,10 @@ def generate_player(
         endurance = pitch_attrs["endurance"]
         control = pitch_attrs["control"]
         movement = pitch_attrs["movement"]
+        if throws == "L":
+            # Left-handed pitchers gain movement at the expense of control.
+            movement = min(90, movement + 10)
+            control = max(50, control - 10)
         hold_runner = pitch_attrs["hold_runner"]
         arm = pitch_attrs["arm"]
         fa = field_attrs["fa"]

--- a/tests/test_player_generator.py
+++ b/tests/test_player_generator.py
@@ -109,6 +109,50 @@ def test_pitcher_can_hit(monkeypatch):
     assert player["pot_ch"] >= player["ch"]
 
 
+def test_lefty_pitcher_adjustment(monkeypatch):
+    def fake_distribute(total, weights):
+        fake_distribute.calls += 1
+        if fake_distribute.calls == 1:
+            return {
+                "endurance": 50,
+                "control": 60,
+                "movement": 60,
+                "hold_runner": 50,
+                "arm": 50,
+            }
+        return {k: 50 for k in weights}
+
+    fake_distribute.calls = 0
+    monkeypatch.setattr(pg, "distribute_rating_points", fake_distribute)
+    monkeypatch.setattr(pg, "assign_bats_throws", lambda _: ("R", "L"))
+
+    player = generate_player(is_pitcher=True)
+    assert player["movement"] == 70
+    assert player["control"] == 50
+
+
+def test_lefty_pitcher_adjustment_respects_caps(monkeypatch):
+    def fake_distribute(total, weights):
+        fake_distribute.calls += 1
+        if fake_distribute.calls == 1:
+            return {
+                "endurance": 50,
+                "control": 55,
+                "movement": 85,
+                "hold_runner": 50,
+                "arm": 50,
+            }
+        return {k: 50 for k in weights}
+
+    fake_distribute.calls = 0
+    monkeypatch.setattr(pg, "distribute_rating_points", fake_distribute)
+    monkeypatch.setattr(pg, "assign_bats_throws", lambda _: ("R", "L"))
+
+    player = generate_player(is_pitcher=True)
+    assert player["movement"] == 90
+    assert player["control"] == 50
+
+
 def test_hitter_can_pitch(monkeypatch):
     def fake_randint(a, b):
         if (a, b) == (1, 1000):


### PR DESCRIPTION
## Summary
- Boost movement and reduce control for left-handed pitchers within fixed bounds
- Add unit tests covering left-handed pitcher adjustments and cap enforcement

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bcrypt')*
- `pip install bcrypt` *(fails: Could not find a version that satisfies the requirement bcrypt)*
- `pytest tests/test_player_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_68a667e717b4832ea5d40180aebddb00