### PR TITLE
Refine pitch generation with dice-based logic

### DIFF
--- a/logic/player_generator.py
+++ b/logic/player_generator.py
@@ -315,17 +315,25 @@ def _weighted_choice(weight_dict: Dict[str, int]) -> str:
 
 
 def generate_pitches(throws: str, delivery: str, age: int):
-    weights = PITCH_WEIGHTS[(throws, delivery)].copy()
-    num_pitches = random.randint(2, 5)
-    selected = ["fb"]
-    weights.pop("fb", None)
-    for _ in range(num_pitches - 1):
-        pitch = _weighted_choice(weights)
-        selected.append(pitch)
-        weights.pop(pitch, None)
+    weights = PITCH_WEIGHTS[(throws, delivery)]
+    total = random.randint(10 * len(PITCH_LIST), 99 * len(PITCH_LIST)) + 60
+    num_pitches = max(2, min(5, total // 55))
 
-    ratings = {p: bounded_rating() if p in selected else 0 for p in PITCH_LIST}
-    potentials = {f"pot_{p}": bounded_potential(ratings[p], age) if p in selected else 0 for p in PITCH_LIST}
+    selected = ["fb"]
+    available = weights.copy()
+    available.pop("fb", None)
+    for _ in range(num_pitches - 1):
+        pitch = _weighted_choice(available)
+        selected.append(pitch)
+        available.pop(pitch, None)
+
+    dist_weights = {p: weights[p] for p in selected}
+    allocations = distribute_rating_points(total, dist_weights)
+    ratings = {p: allocations.get(p, 0) for p in PITCH_LIST}
+    potentials = {
+        f"pot_{p}": bounded_potential(ratings[p], age) if p in selected else 0
+        for p in PITCH_LIST
+    }
     return ratings, potentials
 
 

--- a/tests/test_player_generator.py
+++ b/tests/test_player_generator.py
@@ -191,3 +191,20 @@ def test_skin_tone_distribution_matches_weights():
     for tone, weight in pg.SKIN_TONE_WEIGHTS.items():
         expected = weight / total_weight
         assert abs(counts[tone] / num_players - expected) < 0.05
+
+
+def test_generate_pitches_counts_and_bonus(monkeypatch):
+    base_total = 110
+
+    def fake_randint(a, b):
+        if (a, b) == (10 * len(pg.PITCH_LIST), 99 * len(pg.PITCH_LIST)):
+            return base_total
+        return (a + b) // 2
+
+    monkeypatch.setattr(pg.random, "randint", fake_randint)
+    monkeypatch.setattr(pg, "_weighted_choice", lambda w: next(iter(w)))
+
+    ratings, _ = pg.generate_pitches("R", "overhand", age=25)
+
+    assert sum(1 for r in ratings.values() if r > 0) == 3
+    assert sum(ratings.values()) == base_total + 60


### PR DESCRIPTION
## Summary
- Revamp pitch selection to use dice-based point totals and apply a 60-point bonus
- Add tests confirming pitch count calculation and bonus integration

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bcrypt')*
- `pip install bcrypt` *(fails: Could not find a version that satisfies the requirement bcrypt)*

------
https://chatgpt.com/codex/tasks/task_e_68a669b127d4832e8085763fb9c58f1d