### PR TITLE
Implement probabilistic pitcher endurance adjustments

### DIFF
--- a/logic/player_generator.py
+++ b/logic/player_generator.py
@@ -100,6 +100,23 @@ def generate_name() -> tuple[str, str]:
                 return name
     return "John", "Doe"
 
+
+def _adjust_endurance(endurance: int) -> int:
+    """Apply ARR-based endurance adjustments (lines 176-180).
+
+    Pitchers with endurance between 30 and 69 have a 50% chance to have their
+    rating adjusted by adding or subtracting 1–20 points.  The result is always
+    clamped to the 1–99 range.
+    """
+
+    if 30 <= endurance <= 69 and random.randint(1, 100) <= 50:
+        delta = random.randint(1, 20)
+        if random.choice([-1, 1]) < 0:
+            endurance -= delta
+        else:
+            endurance += delta
+    return max(1, min(99, endurance))
+
 PRIMARY_POSITION_WEIGHTS = {
     "C": 19,
     "1B": 15,
@@ -364,7 +381,7 @@ def _maybe_add_pitching(player: Dict, age: int, throws: str, allocation: float =
     if random.randint(1, 1000) != 1:
         return
 
-    endurance = int(bounded_rating() * allocation)
+    endurance = _adjust_endurance(int(bounded_rating() * allocation))
     control = int(bounded_rating() * allocation)
     movement = int(bounded_rating() * allocation)
     hold_runner = int(bounded_rating() * allocation)
@@ -464,7 +481,7 @@ def generate_player(
         )
         field_attrs = distribute_rating_points(field_pool, HITTER_RATING_WEIGHTS["P"])
 
-        endurance = pitch_attrs["endurance"]
+        endurance = _adjust_endurance(pitch_attrs["endurance"])
         control = pitch_attrs["control"]
         movement = pitch_attrs["movement"]
         if throws == "L":

--- a/tests/test_player_generator.py
+++ b/tests/test_player_generator.py
@@ -208,3 +208,31 @@ def test_generate_pitches_counts_and_bonus(monkeypatch):
 
     assert sum(1 for r in ratings.values() if r > 0) == 3
     assert sum(ratings.values()) == base_total + 60
+
+
+def test_endurance_adjustment_adds(monkeypatch):
+    def fake_randint(a, b):
+        if (a, b) == (1, 100):
+            return 10  # trigger modification
+        if (a, b) == (1, 20):
+            return 5   # delta
+        return a
+
+    monkeypatch.setattr(pg.random, "randint", fake_randint)
+    monkeypatch.setattr(pg.random, "choice", lambda seq: 1)
+
+    assert pg._adjust_endurance(40) == 45
+
+
+def test_endurance_adjustment_subtracts(monkeypatch):
+    def fake_randint(a, b):
+        if (a, b) == (1, 100):
+            return 10  # trigger modification
+        if (a, b) == (1, 20):
+            return 5   # delta
+        return a
+
+    monkeypatch.setattr(pg.random, "randint", fake_randint)
+    monkeypatch.setattr(pg.random, "choice", lambda seq: -1)
+
+    assert pg._adjust_endurance(40) == 35


### PR DESCRIPTION
## Summary
- Introduce `_adjust_endurance` helper applying ARR-based probabilistic adjustments to pitcher endurance
- Integrate endurance adjustments into pitcher and dual-role player generation
- Add unit tests for endurance increase and decrease scenarios

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bcrypt')*
- `pip install bcrypt` *(fails: Could not find a version that satisfies the requirement bcrypt)*

------
https://chatgpt.com/codex/tasks/task_e_68a66b3b8230832eb1490dcdb0d4027e