### PR TITLE
Add ARR-based player aging routine and tests

### DIFF
--- a/logic/aging.py
+++ b/logic/aging.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Iterable
+
+# Aging adjustments derived from ARR lines 227-262 in pgend_original_converted.txt.
+# Values represent annual rating changes for players at a given age.
+# Keys map to player attributes: ch, ph, sp, arm, hold_runner, control, endurance, fa.
+_AGING_TABLE = {
+    18: (18, 5, 1, 1, 2, 5, 1, 2),
+    19: (15, 5, 1, 1, 3, 5, 1, 3),
+    20: (12, 5, 1, 1, 4, 5, 1, 4),
+    21: (10, 5, 1, 1, 5, 5, 1, 5),
+    22: (8, 5, 1, 1, 6, 5, 1, 6),
+    23: (6, 7, 1, 1, 7, 7, 1, 7),
+    24: (4, 9, 1, 1, 6, 9, 1, 6),
+    25: (3, 11, 1, 1, 5, 11, 1, 5),
+    26: (2, 9, 1, 1, 4, 9, 1, 4),
+    27: (1, 7, 1, 1, 3, 7, 1, 3),
+    28: (1, 5, 0, 0, 2, 5, 0, 2),
+    29: (0, 3, -1, 0, 2, 3, 0, 2),
+    30: (0, 2, -2, 0, 1, 2, 0, 1),
+    31: (0, 1, -2, 0, 0, 1, 0, 0),
+    32: (-1, 1, -3, 0, 0, 1, 0, 0),
+    33: (-2, 0, -3, 0, 0, 0, -1, -1),
+    34: (-3, -1, -4, 0, 0, 0, -1, -1),
+    35: (-4, -2, -4, -1, -1, -1, -1, -2),
+    36: (-5, -2, -5, -1, -1, -1, -1, -2),
+    37: (-5, -3, -5, -2, -2, -2, -1, -3),
+    38: (-6, -3, -6, -2, -2, -2, -1, -3),
+    39: (-6, -4, -6, -3, -3, -3, -2, -4),
+    40: (-6, -4, -6, -3, -3, -3, -2, -4),
+    41: (-6, -5, -6, -4, -4, -4, -2, -5),
+    42: (-7, -5, -6, -4, -4, -4, -3, -5),
+    43: (-7, -6, -6, -5, -5, -4, -3, -6),
+    44: (-7, -6, -6, -5, -5, -4, -4, -7),
+    45: (-8, -7, -6, -5, -6, -4, -5, -8),
+    46: (-8, -8, -6, -5, -6, -4, -5, -9),
+    47: (-8, -8, -8, -5, -7, -5, -6, -10),
+    48: (-8, -9, -8, -5, -7, -5, -6, -11),
+    49: (-8, -9, -8, -5, -7, -5, -6, -12),
+}
+
+_ATTRS = [
+    "ch",
+    "ph",
+    "sp",
+    "arm",
+    "hold_runner",
+    "control",
+    "endurance",
+    "fa",
+]
+
+AGE_ADJUSTMENTS = {
+    age: dict(zip(_ATTRS, values)) for age, values in _AGING_TABLE.items()
+}
+
+
+def calculate_age(birthdate: str) -> int:
+    """Return age in years given a birthdate ISO string."""
+
+    born = datetime.strptime(birthdate, "%Y-%m-%d").date()
+    today = date.today()
+    return today.year - born.year - ((today.month, today.day) < (born.month, born.day))
+
+
+def age_player(player) -> None:
+    """Apply aging adjustments to ``player`` in place."""
+
+    age = calculate_age(player.birthdate)
+    adjustments = AGE_ADJUSTMENTS.get(age)
+    if not adjustments:
+        return
+    for attr, change in adjustments.items():
+        if hasattr(player, attr):
+            value = getattr(player, attr)
+            setattr(player, attr, max(0, value + change))
+
+
+def age_players(players: Iterable) -> None:
+    """Age all players in ``players`` according to the aging table."""
+
+    for player in players:
+        age_player(player)

--- a/tests/test_aging.py
+++ b/tests/test_aging.py
@@ -1,0 +1,56 @@
+from datetime import date
+
+from logic.aging import age_player
+from models.player import Player
+
+
+def _make_player(age: int) -> Player:
+    today = date.today()
+    birthdate = date(today.year - age, today.month, today.day).isoformat()
+    return Player(
+        player_id="p",
+        first_name="Test",
+        last_name="Player",
+        birthdate=birthdate,
+        height=72,
+        weight=180,
+        bats="R",
+        primary_position="1b",
+        other_positions=[],
+        gf=0,
+        ch=50,
+        ph=50,
+        sp=50,
+        fa=50,
+        arm=50,
+    )
+
+
+def test_age_24_increases_ratings():
+    player = _make_player(24)
+    age_player(player)
+    assert player.ch == 54
+    assert player.ph == 59
+    assert player.sp == 51
+    assert player.arm == 51
+    assert player.fa == 56
+
+
+def test_age_30_declines_speed_and_power():
+    player = _make_player(30)
+    age_player(player)
+    assert player.ch == 50
+    assert player.ph == 52
+    assert player.sp == 48
+    assert player.arm == 50
+    assert player.fa == 51
+
+
+def test_age_40_declines_all():
+    player = _make_player(40)
+    age_player(player)
+    assert player.ch == 44
+    assert player.ph == 46
+    assert player.sp == 44
+    assert player.arm == 47
+    assert player.fa == 46


### PR DESCRIPTION
## Summary
- implement ARR-based aging adjustments for player ratings
- provide helper functions to age single players or groups
- add tests for rating changes at ages 24, 30, and 40

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bcrypt')*

------
https://chatgpt.com/codex/tasks/task_e_68a66f068b88832e9f7d7fab7252353f