### PR TITLE
Add pandas dependency for player generator

### DIFF
--- a/logic/player_generator.py
+++ b/logic/player_generator.py
@@ -5,6 +5,8 @@ from typing import Dict, List, Tuple, Set, Optional
 import csv
 from pathlib import Path
 
+import pandas as pd
+
 from utils.path_utils import get_base_dir
 
 # Constants


### PR DESCRIPTION
## Summary
- import pandas for the player generator's draft pool export

## Testing
- `python logic/player_generator.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas'; ModuleNotFoundError: No module named 'bcrypt')*

------
https://chatgpt.com/codex/tasks/task_e_68a7af02cb04832e94e2409b5948d567