### PR TITLE
Add season manager with phase persistence

### DIFF
--- a/data/season_state.json
+++ b/data/season_state.json
@@ -1,0 +1,3 @@
+{
+  "phase": "PRESEASON"
+}

--- a/logic/season_manager.py
+++ b/logic/season_manager.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from enum import Enum
+from pathlib import Path
+
+from utils.path_utils import get_base_dir
+
+
+class SeasonPhase(Enum):
+    """Enumeration of the different phases of a season."""
+
+    PRESEASON = "PRESEASON"
+    REGULAR_SEASON = "REGULAR_SEASON"
+    PLAYOFFS = "PLAYOFFS"
+    OFFSEASON = "OFFSEASON"
+
+    def next(self) -> "SeasonPhase":
+        """Return the next phase, cycling back to ``PRESEASON``."""
+        members = list(type(self))
+        index = members.index(self)
+        return members[(index + 1) % len(members)]
+
+
+class SeasonManager:
+    """Manage the current season phase and persist it to disk."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        base_dir = get_base_dir()
+        self.path = Path(path) if path is not None else base_dir / "data" / "season_state.json"
+        self.phase = SeasonPhase.PRESEASON
+        self.load()
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+    def load(self) -> SeasonPhase:
+        """Load the season phase from disk.
+
+        If the file does not exist or contains invalid data the phase
+        defaults to ``PRESEASON`` and is saved to disk.
+        """
+        try:
+            with self.path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            self.phase = SeasonPhase(data.get("phase", SeasonPhase.PRESEASON.value))
+        except (OSError, json.JSONDecodeError, ValueError, KeyError):
+            self.phase = SeasonPhase.PRESEASON
+            self.save()
+        return self.phase
+
+    def save(self) -> None:
+        """Persist the current season phase to disk."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("w", encoding="utf-8") as f:
+            json.dump({"phase": self.phase.value}, f, indent=2)
+
+    # ------------------------------------------------------------------
+    # Phase advancement
+    # ------------------------------------------------------------------
+    def advance_phase(self) -> SeasonPhase:
+        """Advance to the next season phase and persist it."""
+        self.phase = self.phase.next()
+        self.save()
+        return self.phase

--- a/tests/test_season_manager.py
+++ b/tests/test_season_manager.py
@@ -1,0 +1,24 @@
+import json
+from logic.season_manager import SeasonManager, SeasonPhase
+
+
+def test_cycle_phases(tmp_path):
+    path = tmp_path / "state.json"
+    manager = SeasonManager(path)
+    assert manager.phase == SeasonPhase.PRESEASON
+    assert manager.advance_phase() == SeasonPhase.REGULAR_SEASON
+    assert manager.advance_phase() == SeasonPhase.PLAYOFFS
+    assert manager.advance_phase() == SeasonPhase.OFFSEASON
+    assert manager.advance_phase() == SeasonPhase.PRESEASON
+
+
+def test_state_persistence(tmp_path):
+    path = tmp_path / "state.json"
+    manager = SeasonManager(path)
+    manager.advance_phase()
+    assert path.exists()
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert data["phase"] == "REGULAR_SEASON"
+    new_manager = SeasonManager(path)
+    assert new_manager.phase == SeasonPhase.REGULAR_SEASON


### PR DESCRIPTION
## Summary
- Add `SeasonPhase` enum and `SeasonManager` for managing season lifecycle
- Persist current phase to `data/season_state.json` and provide helpers for loading and advancing
- Add tests verifying phase cycling and state persistence

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas', No module named 'bcrypt')*


------
https://chatgpt.com/codex/tasks/task_e_68a7c7be2e90832eaf14d221a4029467