### PR TITLE
Add season progress UI and phase handlers

### DIFF
--- a/logic/season_manager.py
+++ b/logic/season_manager.py
@@ -63,3 +63,36 @@ class SeasonManager:
         self.phase = self.phase.next()
         self.save()
         return self.phase
+
+    # ------------------------------------------------------------------
+    # Phase handlers
+    # ------------------------------------------------------------------
+    def handle_preseason(self) -> str:
+        """Handle tasks specific to the preseason phase."""
+        return "Preseason: prepare teams and rosters for the year ahead."
+
+    def handle_regular_season(self) -> str:
+        """Handle tasks specific to the regular season."""
+        return "Regular Season: games are underway."
+
+    def handle_playoffs(self) -> str:
+        """Handle tasks specific to the playoffs."""
+        return "Playoffs: the top teams compete for the championship."
+
+    def handle_offseason(self) -> str:
+        """Handle tasks specific to the offseason."""
+        return "Offseason: review performance and plan for next year."
+
+    def handle_phase(self) -> str:
+        """Dispatch to the handler for the current phase.
+
+        Returns a descriptive note for the phase so a user interface can
+        display progress information.
+        """
+        handlers = {
+            SeasonPhase.PRESEASON: self.handle_preseason,
+            SeasonPhase.REGULAR_SEASON: self.handle_regular_season,
+            SeasonPhase.PLAYOFFS: self.handle_playoffs,
+            SeasonPhase.OFFSEASON: self.handle_offseason,
+        }
+        return handlers[self.phase]()

--- a/tests/test_season_manager.py
+++ b/tests/test_season_manager.py
@@ -22,3 +22,15 @@ def test_state_persistence(tmp_path):
     assert data["phase"] == "REGULAR_SEASON"
     new_manager = SeasonManager(path)
     assert new_manager.phase == SeasonPhase.REGULAR_SEASON
+
+
+def test_phase_handlers(tmp_path):
+    path = tmp_path / "state.json"
+    manager = SeasonManager(path)
+    assert "Preseason" in manager.handle_phase()
+    manager.advance_phase()
+    assert "Regular Season" in manager.handle_phase()
+    manager.advance_phase()
+    assert "Playoffs" in manager.handle_phase()
+    manager.advance_phase()
+    assert "Offseason" in manager.handle_phase()

--- a/ui/season_progress_window.py
+++ b/ui/season_progress_window.py
@@ -1,15 +1,54 @@
-from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel
+from __future__ import annotations
+
+from PyQt6.QtWidgets import (
+    QDialog,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+)
+
+from logic.season_manager import SeasonManager
 
 
 class SeasonProgressWindow(QDialog):
-    """Placeholder dialog for season progress information."""
+    """Dialog displaying the current season phase and progress notes."""
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None) -> None:
         super().__init__(parent)
         try:
             self.setWindowTitle("Season Progress")
-        except Exception:  # pragma: no cover
+        except Exception:  # pragma: no cover - harmless in headless tests
             pass
 
+        self.manager = SeasonManager()
+
         layout = QVBoxLayout(self)
-        layout.addWidget(QLabel("Season progress details are not available."))
+
+        self.phase_label = QLabel()
+        layout.addWidget(self.phase_label)
+
+        self.notes_label = QLabel()
+        self.notes_label.setWordWrap(True)
+        layout.addWidget(self.notes_label)
+
+        self.next_button = QPushButton("Next Phase")
+        self.next_button.clicked.connect(self._next_phase)
+        layout.addWidget(self.next_button)
+
+        self._update_ui()
+
+    # ------------------------------------------------------------------
+    # UI helpers
+    # ------------------------------------------------------------------
+    def _update_ui(self) -> None:
+        """Refresh the label and notes for the current phase."""
+        phase_name = self.manager.phase.name.replace("_", " ").title()
+        self.phase_label.setText(f"Current Phase: {phase_name}")
+        notes = self.manager.handle_phase()
+        self.notes_label.setText(notes)
+
+    def _next_phase(self) -> None:
+        """Advance to the next phase and update the display."""
+        self.manager.advance_phase()
+        self._update_ui()
+


### PR DESCRIPTION
## Summary
- add individual phase handlers to `SeasonManager`
- implement `SeasonProgressWindow` showing current phase and notes with a Next Phase button
- add tests for phase handler output

## Testing
- `pip install pandas bcrypt` *(fails: Could not find a version that satisfies the requirement pandas; No matching distribution found for pandas)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas'; ModuleNotFoundError: No module named 'bcrypt')*


------
https://chatgpt.com/codex/tasks/task_e_68a7c92131c0832ebe1569c4a37f6423