### PR TITLE
Add midseason schedule simulation and progress tracking

### DIFF
--- a/logic/season_simulator.py
+++ b/logic/season_simulator.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Callable, Dict, Iterable, List
+import random
+
+from models.player import Player
+from models.pitcher import Pitcher
+from logic.simulation import GameSimulation, TeamState
+
+
+class SeasonSimulator:
+    """Simulate scheduled games up to the season's midpoint.
+
+    Parameters
+    ----------
+    schedule:
+        Iterable of schedule entries with ``date``, ``home`` and ``away`` keys.
+    simulate_game:
+        Optional callback accepting ``home`` and ``away`` team identifiers.  If
+        not provided a minimal game simulation using :class:`GameSimulation`
+        from :mod:`logic.simulation` is performed.
+    """
+
+    def __init__(
+        self,
+        schedule: Iterable[Dict[str, str]],
+        simulate_game: Callable[[str, str], None] | None = None,
+    ) -> None:
+        self.schedule = list(schedule)
+        self.dates: List[str] = sorted({g["date"] for g in self.schedule})
+        self._mid = len(self.dates) // 2
+        self._index = 0
+        self.simulate_game = simulate_game or self._default_simulate_game
+
+    # ------------------------------------------------------------------
+    def remaining_days(self) -> int:
+        """Return the number of days left until midseason."""
+        return max(self._mid - self._index, 0)
+
+    def simulate_next_day(self) -> None:
+        """Simulate games for the next scheduled day.
+
+        Simulation stops automatically once the midpoint of the season is
+        reached.
+        """
+
+        if self._index >= self._mid:
+            return
+        current_date = self.dates[self._index]
+        games = [g for g in self.schedule if g["date"] == current_date]
+        for game in games:
+            self.simulate_game(game["home"], game["away"])
+        self._index += 1
+
+    # ------------------------------------------------------------------
+    def _default_simulate_game(self, home_id: str, away_id: str) -> None:
+        """Run a minimal game simulation between two placeholder teams."""
+        batter_h = Player(first_name="Home", last_name=home_id)
+        pitcher_h = Pitcher(first_name="Home", last_name=home_id)
+        batter_a = Player(first_name="Away", last_name=away_id)
+        pitcher_a = Pitcher(first_name="Away", last_name=away_id)
+        home = TeamState(lineup=[batter_h], bench=[], pitchers=[pitcher_h])
+        away = TeamState(lineup=[batter_a], bench=[], pitchers=[pitcher_a])
+        sim = GameSimulation(home, away, {}, random.Random())
+        sim.simulate_game()
+
+
+__all__ = ["SeasonSimulator"]

--- a/tests/test_season_progress_window.py
+++ b/tests/test_season_progress_window.py
@@ -1,0 +1,123 @@
+import sys, types
+
+# ---- Stub PyQt6 modules ----
+class DummySignal:
+    def __init__(self):
+        self._slot = None
+
+    def connect(self, slot):
+        self._slot = slot
+
+    def emit(self):
+        if self._slot:
+            self._slot()
+
+
+class Dummy:
+    def __init__(self, *args, **kwargs):
+        self.clicked = DummySignal()
+
+    def __getattr__(self, name):
+        return Dummy()
+
+    def setVisible(self, *a, **k):
+        pass
+
+    def setWordWrap(self, *a, **k):
+        pass
+
+    def setText(self, *a, **k):
+        pass
+
+    def text(self):
+        return ""
+
+    def addWidget(self, *a, **k):
+        pass
+
+    def connect(self, *a, **k):
+        pass
+
+    def setWindowTitle(self, *a, **k):
+        pass
+
+
+class QLabel(Dummy):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._text = ""
+
+    def setText(self, text):
+        self._text = text
+
+    def text(self):
+        return self._text
+
+
+class QPushButton(Dummy):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
+class QDialog(Dummy):
+    pass
+
+
+class QVBoxLayout(Dummy):
+    pass
+
+
+qtwidgets = types.ModuleType("PyQt6.QtWidgets")
+qtwidgets.QDialog = QDialog
+qtwidgets.QLabel = QLabel
+qtwidgets.QPushButton = QPushButton
+qtwidgets.QVBoxLayout = QVBoxLayout
+sys.modules["PyQt6"] = types.ModuleType("PyQt6")
+sys.modules["PyQt6.QtWidgets"] = qtwidgets
+
+# ---- Import window after stubs ----
+from logic.season_manager import SeasonPhase
+import ui.season_progress_window as spw
+
+
+class DummyManager:
+    def __init__(self):
+        self.phase = SeasonPhase.REGULAR_SEASON
+
+    def handle_phase(self):
+        return "Regular Season"
+
+    def advance_phase(self):
+        pass
+
+
+spw.SeasonManager = DummyManager
+
+
+def test_simulate_day_until_midseason():
+    schedule = [
+        {"date": "2024-04-01", "home": "A", "away": "B"},
+        {"date": "2024-04-02", "home": "A", "away": "B"},
+        {"date": "2024-04-03", "home": "A", "away": "B"},
+        {"date": "2024-04-04", "home": "A", "away": "B"},
+    ]
+
+    games = []
+
+    def fake_sim(home, away):
+        games.append((home, away))
+
+    win = spw.SeasonProgressWindow(schedule=schedule, simulate_game=fake_sim)
+    assert win.remaining_label.text() == "Days until Midseason: 2"
+
+    win.simulate_day_button.clicked.emit()
+    assert games == [("A", "B")]
+    assert win.remaining_label.text() == "Days until Midseason: 1"
+
+    win.simulate_day_button.clicked.emit()
+    assert games == [("A", "B"), ("A", "B")]
+    assert win.remaining_label.text() == "Days until Midseason: 0"
+
+    # Further clicks should not simulate more games
+    win.simulate_day_button.clicked.emit()
+    assert games == [("A", "B"), ("A", "B")]


### PR DESCRIPTION
## Summary
- Implement SeasonSimulator to run scheduled games until midseason using GameSimulation
- Enhance SeasonProgressWindow with remaining day tracking and daily simulation button
- Add tests covering regular season progress behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7ceefd3f8832ea9ff98bd2959dc5a