### PR TITLE
Add trade deadline and extend season simulation

### DIFF
--- a/logic/season_manager.py
+++ b/logic/season_manager.py
@@ -4,8 +4,13 @@ import json
 from enum import Enum
 from pathlib import Path
 import shutil
+from datetime import date
 
 from utils.path_utils import get_base_dir
+
+
+# Trades are prohibited after this date.
+TRADE_DEADLINE = date(date.today().year, 7, 31)
 
 
 class SeasonPhase(Enum):

--- a/logic/season_simulator.py
+++ b/logic/season_simulator.py
@@ -48,14 +48,13 @@ class SeasonSimulator:
 
         When the midpoint of the season is reached the optional
         ``on_all_star_break`` callback is invoked and regular-season play
-        automatically resumes on the next invocation.
+        automatically resumes immediately afterward.
         """
 
         if self._index == self._mid and not self._all_star_played:
             if self.on_all_star_break is not None:
                 self.on_all_star_break()
             self._all_star_played = True
-            return
 
         if self._index >= len(self.dates):
             return

--- a/tests/test_season_progress_window.py
+++ b/tests/test_season_progress_window.py
@@ -118,6 +118,13 @@ def test_simulate_day_until_midseason():
     assert games == [("A", "B"), ("A", "B")]
     assert win.remaining_label.text() == "Days until Midseason: 0"
 
+    # After the break the season continues
+    win.simulate_day_button.clicked.emit()
+    assert games == [("A", "B"), ("A", "B"), ("A", "B")]
+
+    win.simulate_day_button.clicked.emit()
+    assert games == [("A", "B"), ("A", "B"), ("A", "B"), ("A", "B")]
+
     # Further clicks should not simulate more games
     win.simulate_day_button.clicked.emit()
-    assert games == [("A", "B"), ("A", "B")]
+    assert games == [("A", "B"), ("A", "B"), ("A", "B"), ("A", "B")]

--- a/tests/test_season_simulator.py
+++ b/tests/test_season_simulator.py
@@ -1,0 +1,19 @@
+from logic.season_simulator import SeasonSimulator
+
+
+def test_simulate_regular_season_to_completion():
+    schedule = [
+        {"date": "2024-04-01", "home": "A", "away": "B"},
+        {"date": "2024-05-01", "home": "C", "away": "D"},
+        {"date": "2024-06-01", "home": "E", "away": "F"},
+    ]
+    played = []
+
+    sim = SeasonSimulator(schedule, simulate_game=lambda h, a: played.append((h, a)))
+
+    for _ in range(len({g["date"] for g in schedule})):
+        sim.simulate_next_day()
+
+    assert len(played) == len(schedule)
+    sim.simulate_next_day()
+    assert len(played) == len(schedule)

--- a/tests/test_trade_utils.py
+++ b/tests/test_trade_utils.py
@@ -1,14 +1,21 @@
 import tempfile
 import random
+from datetime import timedelta
+
+import pytest
 
 from models.trade import Trade
 from utils.trade_utils import get_pending_trades, load_trades, save_trade
+from logic.season_manager import TRADE_DEADLINE
 
 # Reseed RNG so earlier tests that modify random state don't influence later ones
 random.seed()
 
 
-def test_save_trade_updates_existing(tmp_path):
+def test_save_trade_updates_existing(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "utils.trade_utils._today", lambda: TRADE_DEADLINE - timedelta(days=1)
+    )
     path = tmp_path / "trades.csv"
     t = Trade("1", "A", "B", ["p1"], ["p2"])
     save_trade(t, str(path))
@@ -23,7 +30,10 @@ def test_save_trade_updates_existing(tmp_path):
     assert trades[0].status == "accepted"
 
 
-def test_get_pending_trades(tmp_path):
+def test_get_pending_trades(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "utils.trade_utils._today", lambda: TRADE_DEADLINE - timedelta(days=1)
+    )
     path = tmp_path / "trades.csv"
     save_trade(Trade("1", "A", "B", ["p1"], ["p2"]), str(path))
     save_trade(Trade("2", "C", "A", ["p3"], ["p4"]), str(path))
@@ -31,3 +41,13 @@ def test_get_pending_trades(tmp_path):
     pending = get_pending_trades("A", str(path))
     assert len(pending) == 1
     assert pending[0].trade_id == "2"
+
+
+def test_trade_blocked_after_deadline(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "utils.trade_utils._today", lambda: TRADE_DEADLINE + timedelta(days=1)
+    )
+    path = tmp_path / "trades.csv"
+    t = Trade("1", "A", "B", ["p1"], ["p2"])
+    with pytest.raises(RuntimeError):
+        save_trade(t, str(path))

--- a/utils/trade_utils.py
+++ b/utils/trade_utils.py
@@ -1,8 +1,14 @@
 import csv
+from datetime import date
 from pathlib import Path
 
 from models.trade import Trade
 from utils.path_utils import get_base_dir
+from logic.season_manager import TRADE_DEADLINE
+
+
+def _today() -> date:
+    return date.today()
 
 
 def _resolve(file_path: str | Path) -> Path:
@@ -41,6 +47,9 @@ def save_trade(trade: Trade, file_path: str | Path = "data/trades_pending.csv"):
     rejected a proposal).  We now remove any trade with the same ``trade_id``
     before writing the updated list back to disk.
     """
+
+    if _today() > TRADE_DEADLINE:
+        raise RuntimeError("Trade deadline has passed")
 
     path = _resolve(file_path)
     existing = [t for t in load_trades(path) if t.trade_id != trade.trade_id]


### PR DESCRIPTION
## Summary
- add configurable trade deadline to season manager
- block saving trades once the deadline passes
- allow season simulator to continue play immediately after the All-Star break

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7d13e4390832e85ee36c62656d16b