### PR TITLE
Add playoff series simulation and offseason transition

### DIFF
--- a/tests/test_playoff_manager.py
+++ b/tests/test_playoff_manager.py
@@ -1,4 +1,7 @@
+import random
+
 from logic.playoff_manager import PlayoffManager
+from logic.season_manager import SeasonManager, SeasonPhase
 
 
 def test_playoff_flow(tmp_path):
@@ -29,4 +32,29 @@ def test_playoff_flow(tmp_path):
     assert path.exists()
     loaded = manager.load_bracket()
     assert loaded == bracket
+
+
+def test_playoff_simulation_advances_state(tmp_path):
+    standings = {
+        "A": {"wins": 10, "losses": 5},
+        "B": {"wins": 9, "losses": 6},
+        "C": {"wins": 12, "losses": 3},
+        "D": {"wins": 7, "losses": 8},
+    }
+    manager = PlayoffManager(standings, path=tmp_path / "bracket.json")
+    qualifiers = manager.determine_qualifiers()
+    manager.create_bracket(qualifiers)
+
+    season_state = tmp_path / "state.json"
+    season_manager = SeasonManager(season_state)
+    season_manager.phase = SeasonPhase.PLAYOFFS
+    season_manager.save()
+
+    champion = manager.simulate_playoffs(
+        best_of=1, rng=random.Random(0), season_manager=season_manager
+    )
+
+    assert champion in qualifiers
+    season_manager.load()
+    assert season_manager.phase == SeasonPhase.OFFSEASON
 


### PR DESCRIPTION
## Summary
- simulate playoff series and entire bracket with game engine utilities
- log the playoff champion and push the season into the offseason phase
- test playoff simulation and offseason state transition

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7d4b38dd8832ea1576892eeaee294