### PR TITLE
Add injury manager and DL/IR roster handling

### DIFF
--- a/models/roster.py
+++ b/models/roster.py
@@ -7,7 +7,26 @@ class Roster:
     act: List[str] = field(default_factory=list)
     aaa: List[str] = field(default_factory=list)
     low: List[str] = field(default_factory=list)
+    dl: List[str] = field(default_factory=list)
+    ir: List[str] = field(default_factory=list)
 
     def move_player(self, player_id: str, from_level: str, to_level: str):
         getattr(self, from_level).remove(player_id)
         getattr(self, to_level).append(player_id)
+
+    def promote_replacements(self, target_size: int = 26) -> None:
+        """Promote players from the minors to fill active roster vacancies.
+
+        Parameters
+        ----------
+        target_size:
+            Desired size of the active roster. Players are promoted from
+            ``aaa`` first and then ``low`` until this size is met or no more
+            players are available.
+        """
+
+        while len(self.act) < target_size and (self.aaa or self.low):
+            if self.aaa:
+                self.act.append(self.aaa.pop(0))
+            else:
+                self.act.append(self.low.pop(0))

--- a/services/injury_manager.py
+++ b/services/injury_manager.py
@@ -1,0 +1,76 @@
+"""Utilities for handling player injuries during simulations.
+
+This module contains helper functions that move players between the active
+roster and the disabled list (DL) or injured reserve (IR). When a player is
+placed on an injury list a replacement is automatically promoted from the
+minors. When that player recovers, the replacement is optionally returned to
+AAA to keep roster sizes consistent.
+"""
+
+from __future__ import annotations
+
+from models.player import Player
+from models.roster import Roster
+
+
+def place_on_injury_list(player: Player, roster: Roster, list_name: str = "dl") -> None:
+    """Move *player* to an injury list and promote a replacement.
+
+    Parameters
+    ----------
+    player:
+        The player who has been injured.
+    roster:
+        Team roster containing the player.
+    list_name:
+        Either ``"dl"`` for the disabled list or ``"ir"`` for injured reserve.
+    """
+
+    if list_name not in {"dl", "ir"}:
+        raise ValueError("list_name must be 'dl' or 'ir'")
+
+    for level in ("act", "aaa", "low"):
+        level_list = getattr(roster, level)
+        if player.player_id in level_list:
+            level_list.remove(player.player_id)
+            break
+
+    getattr(roster, list_name).append(player.player_id)
+    player.injured = True
+
+    roster.promote_replacements()
+
+
+def recover_from_injury(player: Player, roster: Roster, destination: str = "act") -> None:
+    """Return *player* from an injury list to the roster.
+
+    Parameters
+    ----------
+    player:
+        Player who is ready to return.
+    roster:
+        Team roster to update.
+    destination:
+        Roster level to place the player on return. Defaults to the active
+        roster.
+    """
+
+    for list_name in ("dl", "ir"):
+        injury_list = getattr(roster, list_name)
+        if player.player_id in injury_list:
+            injury_list.remove(player.player_id)
+            break
+
+    player.injured = False
+    player.injury_description = None
+    player.return_date = None
+
+    getattr(roster, destination).append(player.player_id)
+
+    if destination == "act":
+        for idx in range(len(roster.act) - 1, -1, -1):
+            pid = roster.act[idx]
+            if pid != player.player_id:
+                roster.aaa.append(roster.act.pop(idx))
+                break
+

--- a/tests/test_injury_manager.py
+++ b/tests/test_injury_manager.py
@@ -1,0 +1,36 @@
+from models.player import Player
+from models.roster import Roster
+from services.injury_manager import place_on_injury_list, recover_from_injury
+
+
+def _make_player(pid: str) -> Player:
+    return Player(
+        player_id=pid,
+        first_name="A",
+        last_name="B",
+        birthdate="2000-01-01",
+        height=72,
+        weight=180,
+        bats="R",
+        primary_position="P",
+        other_positions=[],
+        gf=0,
+    )
+
+
+def test_injury_and_recovery_flow():
+    p1 = _make_player("p1")
+    p2 = _make_player("p2")
+    roster = Roster(team_id="T", act=["p1"], aaa=["p2"], low=[])
+
+    place_on_injury_list(p1, roster)
+
+    assert p1.injured is True
+    assert "p1" in roster.dl
+    assert "p2" in roster.act  # replacement promoted
+
+    recover_from_injury(p1, roster)
+
+    assert p1.injured is False
+    assert "p1" in roster.act
+    assert "p2" in roster.aaa  # replacement returned to AAA

--- a/tests/test_roster_loader_injuries.py
+++ b/tests/test_roster_loader_injuries.py
@@ -1,0 +1,26 @@
+import csv
+
+from utils.roster_loader import load_roster
+
+
+def test_load_roster_promotes_replacements(tmp_path):
+    roster_file = tmp_path / "T.csv"
+    rows = [
+        ["p1", "ACT"],
+        ["p2", "AAA"],
+        ["p3", "DL"],
+        ["p4", "IR"],
+        ["p5", "LOW"],
+    ]
+    with roster_file.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerows(rows)
+
+    roster = load_roster("T", roster_dir=tmp_path)
+
+    assert roster.dl == ["p3"]
+    assert roster.ir == ["p4"]
+    assert "p2" in roster.act
+    assert "p5" in roster.act
+    assert roster.aaa == []
+    assert roster.low == []

--- a/utils/roster_loader.py
+++ b/utils/roster_loader.py
@@ -3,8 +3,11 @@ from pathlib import Path
 
 from models.roster import Roster
 from utils.path_utils import get_base_dir
+ACTIVE_ROSTER_SIZE = 26
+
+
 def load_roster(team_id, roster_dir: str | Path = "data/rosters"):
-    act, aaa, low = [], [], []
+    act, aaa, low, dl, ir = [], [], [], [], []
     roster_dir = Path(roster_dir)
     if not roster_dir.is_absolute():
         roster_dir = get_base_dir() / roster_dir
@@ -25,14 +28,26 @@ def load_roster(team_id, roster_dir: str | Path = "data/rosters"):
                 aaa.append(pid)
             elif level == "LOW":
                 low.append(pid)
+            elif level == "DL":
+                dl.append(pid)
+            elif level == "IR":
+                ir.append(pid)
 
-    return Roster(team_id=team_id, act=act, aaa=aaa, low=low)
+    roster = Roster(team_id=team_id, act=act, aaa=aaa, low=low, dl=dl, ir=ir)
+    roster.promote_replacements(target_size=ACTIVE_ROSTER_SIZE)
+    return roster
 
 
 def save_roster(team_id, roster: Roster):
     filepath = get_base_dir() / "data" / "rosters" / f"{team_id}.csv"
     with filepath.open(mode="w", newline="") as f:
         writer = csv.writer(f)
-        for level, group in [("ACT", roster.act), ("AAA", roster.aaa), ("LOW", roster.low)]:
+        for level, group in [
+            ("ACT", roster.act),
+            ("AAA", roster.aaa),
+            ("LOW", roster.low),
+            ("DL", roster.dl),
+            ("IR", roster.ir),
+        ]:
             for player_id in group:
                 writer.writerow([player_id, level])


### PR DESCRIPTION
## Summary
- extend `Roster` and roster loader to include DL/IR lists and auto-promote replacements
- add `injury_manager` service to place and recover players from injury lists
- cover new behaviour with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7d9823ecc832ea734e605c2ece1b4