### PR TITLE
Add award and contract management utilities

### DIFF
--- a/logic/awards_manager.py
+++ b/logic/awards_manager.py
@@ -1,0 +1,88 @@
+"""Utilities for determining end-of-season awards.
+
+This module provides simple helpers that select award winners based on
+season statistics.  The goal is not to perfectly emulate real-world award
+voting but to offer a deterministic way to highlight top performers.
+
+Example
+-------
+>>> manager = AwardsManager(players, batting_stats, pitching_stats)
+>>> manager.select_award_winners()
+{"MVP": Player(...), "CY_YOUNG": Player(...)}
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping
+
+from models.player import Player
+
+
+@dataclass
+class AwardWinner:
+    """Container storing the winning player and their key metric."""
+
+    player: Player
+    metric: float
+
+
+class AwardsManager:
+    """Select season awards based on provided statistics.
+
+    Parameters
+    ----------
+    players:
+        Mapping of player identifiers to :class:`~models.player.Player`
+        instances.
+    batting_stats:
+        Statistics keyed by player identifier containing at minimum an
+        ``"ops"`` value.
+    pitching_stats:
+        Statistics keyed by player identifier containing at minimum an
+        ``"era"`` value.
+    """
+
+    def __init__(
+        self,
+        players: Mapping[str, Player],
+        batting_stats: Mapping[str, Mapping[str, float]],
+        pitching_stats: Mapping[str, Mapping[str, float]],
+    ) -> None:
+        self.players = players
+        self.batting_stats = batting_stats
+        self.pitching_stats = pitching_stats
+
+    # ------------------------------------------------------------------
+    # Award selection helpers
+    # ------------------------------------------------------------------
+    def select_mvp(self) -> AwardWinner:
+        """Return the Most Valuable Player based on OPS."""
+
+        if not self.batting_stats:
+            raise ValueError("No batting statistics provided")
+        winner_id = max(
+            self.batting_stats, key=lambda pid: self.batting_stats[pid].get("ops", 0)
+        )
+        metric = self.batting_stats[winner_id].get("ops", 0.0)
+        return AwardWinner(self.players[winner_id], metric)
+
+    def select_cy_young(self) -> AwardWinner:
+        """Return the top pitcher based on ERA."""
+
+        if not self.pitching_stats:
+            raise ValueError("No pitching statistics provided")
+        winner_id = min(
+            self.pitching_stats,
+            key=lambda pid: self.pitching_stats[pid].get("era", float("inf")),
+        )
+        metric = self.pitching_stats[winner_id].get("era", 0.0)
+        return AwardWinner(self.players[winner_id], metric)
+
+    def select_award_winners(self) -> Dict[str, AwardWinner]:
+        """Return a dictionary of award names mapped to winners."""
+
+        return {
+            "MVP": self.select_mvp(),
+            "CY_YOUNG": self.select_cy_young(),
+        }

--- a/services/contract_negotiator.py
+++ b/services/contract_negotiator.py
@@ -1,0 +1,69 @@
+"""Utilities for handling contract decisions during the offseason.
+
+The functions in this module provide very small abstractions that help with
+common contract related tasks in simulations:
+
+* :func:`find_expiring_contracts` identifies which players need new deals.
+* :func:`evaluate_free_agent_bids` picks the winning team for an unsigned
+  player based on competing salary offers.
+
+These routines are intentionally lightweight – they do not attempt to model
+complex negotiations or arbitration systems but rather serve as building
+blocks for a more detailed front office simulation.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Iterable, List, Mapping
+
+from models.player import Player
+from models.team import Team
+
+
+def find_expiring_contracts(
+    players: Iterable[Player], current_year: int
+) -> List[Player]:
+    """Return players whose contracts expire in *current_year*.
+
+    A player is considered to have an expiring contract if they have an
+    attribute ``contract_expiration`` equal to ``current_year``.  Players
+    lacking the attribute are ignored.
+    """
+
+    return [
+        player
+        for player in players
+        if getattr(player, "contract_expiration", -1) == current_year
+    ]
+
+
+def evaluate_free_agent_bids(
+    player: Player, bids: Mapping[Team, float]
+) -> Team:
+    """Select the winning bid for a free agent.
+
+    Parameters
+    ----------
+    player:
+        The free agent being bid on.
+    bids:
+        Mapping of :class:`~models.team.Team` objects to salary offers.
+
+    Returns
+    -------
+    Team
+        The team that wins the bidding.  The player's ``team_id`` attribute
+        is updated to reflect the signing.
+    """
+
+    if not bids:
+        raise ValueError("No bids submitted")
+
+    max_offer = max(bids.values())
+    top_teams = [team for team, offer in bids.items() if offer == max_offer]
+    winner = random.choice(top_teams)
+
+    player.team_id = winner.team_id
+    player.salary = max_offer
+    return winner


### PR DESCRIPTION
## Summary
- Add `AwardsManager` for selecting MVP and Cy Young winners from season statistics
- Introduce `ContractNegotiator` helpers to find expiring contracts and evaluate free-agent bids

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7da72a7e4832e8ee557ee7d80d622