### PR TITLE
Fix default admin password for login

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ The executable will be written to the `dist/` directory.
 
 ### Default Admin Credentials
 When a new league is created or user accounts are cleared, the system rewrites
-`data/users.txt` to contain a single administrator account. Passwords are
-stored as `bcrypt` hashes. Use these fallback credentials to log in after a
-reset:
+`data/users.txt` to contain a single administrator account. Most passwords are
+stored as `bcrypt` hashes, but the default administrator account keeps a
+plain-text password so the app can always be accessed. Use these fallback
+credentials to log in after a reset:
 
 ```
 username: admin

--- a/data/users.txt
+++ b/data/users.txt
@@ -1,1 +1,1 @@
-admin,$2b$12$abcdefghijklmnopqrstuuSrPAZy1p14MzYlzK1ZPFXzC33T34RXS,admin,
+admin,pass,admin,

--- a/docs/owner_admin_guide.md
+++ b/docs/owner_admin_guide.md
@@ -53,8 +53,10 @@ Administrators control league configuration and high-level operations.
 - **Simulate Exhibition Game**: run a quick simulation between two teams.
 
 ## Default Administrator Login
-When user data is reset, a default administrator account is created. Passwords
-are stored using `bcrypt` hashes. Use these credentials to access the Admin
+When user data is reset, a default administrator account is created. Although
+most passwords are stored using `bcrypt` hashes, the fallback administrator
+record is saved in plain text so the app remains accessible even if the
+`bcrypt` dependency is missing. Use these credentials to access the Admin
 Dashboard if no other accounts exist:
 
 ```


### PR DESCRIPTION
## Summary
- replace invalid hashed admin password with plain text default
- clarify docs that default admin uses plain-text password for accessibility

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a88df5bfac832e9aacb54e675fb0f1