### PR TITLE
Fix missing QProgressDialog import in admin dashboard

### DIFF
--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -11,6 +11,7 @@ from PyQt6.QtWidgets import (
     QLineEdit,
     QComboBox,
     QMenuBar,
+    QProgressDialog,
     QApplication,
 )
 from PyQt6.QtCore import Qt


### PR DESCRIPTION
## Summary
- import QProgressDialog for team logo generation progress feedback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a88f7939b0832e80f5d150d0fcdc32