### PR TITLE
Ensure team logos are generated at 1024px and resized

### DIFF
--- a/tests/test_logo_generator_openai.py
+++ b/tests/test_logo_generator_openai.py
@@ -35,11 +35,12 @@ def test_generates_logo_and_calls_callback(tmp_path, monkeypatch):
 
     calls = {}
     logo_size = 256
+    api_size = 1024
 
     class DummyImages:
         def generate(self, **kwargs):
             calls.update(kwargs)
-            return SimpleNamespace(data=[SimpleNamespace(b64_json=_fake_b64_png(logo_size))])
+            return SimpleNamespace(data=[SimpleNamespace(b64_json=_fake_b64_png(api_size))])
 
     monkeypatch.setattr(logo_generator, "client", SimpleNamespace(images=DummyImages()))
 
@@ -51,7 +52,7 @@ def test_generates_logo_and_calls_callback(tmp_path, monkeypatch):
     out_dir = tmp_path
     logo_generator.generate_team_logos(out_dir=str(out_dir), size=logo_size, progress_callback=cb)
 
-    assert calls["size"] == f"{logo_size}x{logo_size}"
+    assert calls["size"] == "1024x1024"
     assert "Testville" in calls["prompt"]
     assert "Testers" in calls["prompt"]
     assert "#112233" in calls["prompt"]


### PR DESCRIPTION
## Summary
- always request 1024x1024 images from OpenAI and scale to the desired size
- update legacy auto logo fallback to generate at 1024px before resizing
- adjust logo generation tests for fixed 1024px API request

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a890ab4b78832e885cbde499b445ff