### PR TITLE
Enforce max player rating of 99 and add safeguards

### DIFF
--- a/logic/substitution_manager.py
+++ b/logic/substitution_manager.py
@@ -906,6 +906,8 @@ class SubstitutionManager:
                 if tracker is None or not tracker.is_ready():
                     return False
         from .simulation import PitcherState  # local import to avoid cycle
+        if not defense.pitchers:
+            return False
         defense.pitchers.pop(0)
         if defense.pitchers:
             new_pitcher = defense.pitchers[0]

--- a/models/base_player.py
+++ b/models/base_player.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass, field
-from typing import List, Optional
+from dataclasses import dataclass
+from typing import ClassVar, List, Optional
 
 @dataclass
 class BasePlayer:
@@ -19,3 +19,11 @@ class BasePlayer:
     return_date: Optional[str] = None
     # Flag indicating if the player is ready after training camp
     ready: bool = False
+
+    _rating_fields: ClassVar[set[str]] = {"gf"}
+
+    def __setattr__(self, name: str, value) -> None:
+        rating_fields = getattr(type(self), "_rating_fields", set())
+        if name in rating_fields and isinstance(value, (int, float)):
+            value = 99 if value > 99 else int(value)
+        super().__setattr__(name, value)

--- a/models/pitcher.py
+++ b/models/pitcher.py
@@ -1,9 +1,27 @@
 from dataclasses import dataclass, field
+from typing import ClassVar
+
 from models.base_player import BasePlayer
 
 
 @dataclass
 class Pitcher(BasePlayer):
+    _rating_fields: ClassVar[set[str]] = BasePlayer._rating_fields | {
+        "endurance",
+        "control",
+        "movement",
+        "hold_runner",
+        "fb",
+        "cu",
+        "cb",
+        "sl",
+        "si",
+        "scb",
+        "kn",
+        "arm",
+        "fa",
+    }
+
     endurance: int = 0
     control: int = 0
     movement: int = 0

--- a/models/player.py
+++ b/models/player.py
@@ -1,9 +1,28 @@
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import ClassVar, Optional
+
 from models.base_player import BasePlayer
 
 @dataclass
 class Player(BasePlayer):
+    _rating_fields: ClassVar[set[str]] = BasePlayer._rating_fields | {
+        "ch",
+        "ph",
+        "sp",
+        "pl",
+        "vl",
+        "sc",
+        "fa",
+        "arm",
+        "pot_ch",
+        "pot_ph",
+        "pot_sp",
+        "pot_fa",
+        "pot_arm",
+        "pot_sc",
+        "pot_gf",
+    }
+
     ch: int = 0
     ph: int = 0
     sp: int = 0

--- a/tests/test_pitcher_fatigue.py
+++ b/tests/test_pitcher_fatigue.py
@@ -45,7 +45,7 @@ def make_pitcher(pid: str) -> Pitcher:
         control=80,
         movement=70,
         hold_runner=50,
-        fb=100,
+        fb=99,
         cu=0,
         cb=0,
         sl=0,
@@ -87,7 +87,7 @@ def test_ratings_drop_when_tired():
     sim._update_fatigue(ps)
     fatigued = sim._fatigued_pitcher(ps.player)
     assert ps.player.fatigue == "tired"
-    assert fatigued.fb == 50  # 100 * 0.5
+    assert fatigued.fb == 49  # 99 * 0.5
     assert fatigued.arm == 72  # 90 * 0.8
     assert fatigued.control == 72  # 80 * 0.9
     assert fatigued.movement == 56  # 70 * 0.8
@@ -99,7 +99,7 @@ def test_ratings_drop_when_exhausted():
     sim._update_fatigue(ps)
     fatigued = sim._fatigued_pitcher(ps.player)
     assert ps.player.fatigue == "exhausted"
-    assert fatigued.fb == 25  # 100 * 0.25
+    assert fatigued.fb == 24  # 99 * 0.25
     assert fatigued.arm == 54  # 90 * 0.6
     assert fatigued.control == 72  # effCOPct still 0.9
     assert fatigued.movement == 56  # effMOPct 0.8

--- a/tests/test_rating_caps.py
+++ b/tests/test_rating_caps.py
@@ -1,0 +1,50 @@
+from models.player import Player
+from models.pitcher import Pitcher
+from logic.aging import spring_training_pitch
+
+
+def make_player(**kwargs):
+    defaults = {
+        "player_id": "1",
+        "first_name": "Test",
+        "last_name": "Player",
+        "birthdate": "2000-01-01",
+        "height": 72,
+        "weight": 180,
+        "bats": "R",
+        "primary_position": "OF",
+        "other_positions": [],
+        "gf": 50,
+    }
+    defaults.update(kwargs)
+    return Player(**defaults)
+
+
+def make_pitcher(**kwargs):
+    defaults = {
+        "player_id": "2",
+        "first_name": "Pitch",
+        "last_name": "Er",
+        "birthdate": "2000-01-01",
+        "height": 72,
+        "weight": 180,
+        "bats": "R",
+        "primary_position": "P",
+        "other_positions": [],
+        "gf": 50,
+    }
+    defaults.update(kwargs)
+    return Pitcher(**defaults)
+
+
+def test_player_ratings_capped_on_assignment():
+    player = make_player(ch=120)
+    assert player.ch == 99
+    player.sp = 150
+    assert player.sp == 99
+
+
+def test_pitch_training_capped_at_99():
+    pitcher = make_pitcher(fb=90)
+    spring_training_pitch(pitcher)
+    assert pitcher.fb == 99


### PR DESCRIPTION
## Summary
- Clamp all player ratings to a maximum of 99
- Handle empty pitching staffs during substitutions
- Add tests to verify rating limits and adjust fatigue expectations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab02d2145c832e80ec642937459354