### PR TITLE
Derive team abbreviations from city and add randomize-all option

### DIFF
--- a/logic/league_creator.py
+++ b/logic/league_creator.py
@@ -13,7 +13,13 @@ from utils.user_manager import clear_users
 
 
 def _abbr(city: str, name: str, existing: set) -> str:
-    base = (city[:1] + name[:2]).upper()
+    """Generate a unique team abbreviation based solely on the city name.
+
+    The abbreviation uses the first three letters of the *city* and appends
+    a number if necessary to ensure uniqueness. The *name* parameter is
+    ignored but kept for backward compatibility with callers.
+    """
+    base = city[:3].upper()
     candidate = base
     i = 1
     while candidate in existing:

--- a/tests/test_league_creator.py
+++ b/tests/test_league_creator.py
@@ -1,7 +1,7 @@
 import csv
 from collections import Counter
 from datetime import date
-from logic.league_creator import create_league, _dict_to_model
+from logic.league_creator import create_league, _dict_to_model, _abbr
 from models.pitcher import Pitcher
 from logic.player_generator import reset_name_cache
 from utils.team_loader import load_teams
@@ -59,6 +59,15 @@ def test_create_league_generates_files(tmp_path):
                 assert 18 <= age <= 21
     with open(league_path) as f:
         assert f.read() == "Test League"
+
+
+def test_abbr_uses_city_only():
+    existing = set()
+    assert _abbr("Dallas", "Wolves", existing) == "DAL"
+    # Subsequent team from a different city uses that city's letters
+    assert _abbr("Denver", "Wolves", existing) == "DEN"
+    # A repeat city receives a numeric suffix
+    assert _abbr("Dallas", "Bears", existing) == "DAL1"
 
 
 def test_create_league_assigns_unique_color_pairs(tmp_path):

--- a/ui/team_entry_dialog.py
+++ b/ui/team_entry_dialog.py
@@ -41,12 +41,15 @@ class TeamEntryDialog(QDialog):
                 )
 
         btn_row = QHBoxLayout()
+        random_all_btn = QPushButton("Randomize All")
         save_btn = QPushButton("Save")
         cancel_btn = QPushButton("Cancel")
+        btn_row.addWidget(random_all_btn)
         btn_row.addWidget(save_btn)
         btn_row.addWidget(cancel_btn)
         layout.addLayout(btn_row)
 
+        random_all_btn.clicked.connect(self._random_fill_all)
         save_btn.clicked.connect(self._handle_save)
         cancel_btn.clicked.connect(self.reject)
 
@@ -61,6 +64,18 @@ class TeamEntryDialog(QDialog):
             return
         city_edit.setText(city)
         name_edit.setText(nickname)
+
+    def _random_fill_all(self) -> None:
+        """Populate all team fields with random names."""
+        for fields in self._inputs.values():
+            for city_edit, name_edit in fields:
+                try:
+                    city, nickname = random_team()
+                except RuntimeError as exc:
+                    QMessageBox.warning(self, "Names Exhausted", str(exc))
+                    return
+                city_edit.setText(city)
+                name_edit.setText(nickname)
 
     def _handle_save(self):
         for fields in self._inputs.values():


### PR DESCRIPTION
## Summary
- derive team abbreviations solely from the city name when creating leagues
- allow randomizing all team locations and mascots at once in the team entry dialog
- cover new abbreviation behavior with dedicated tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab06c5ed9c832eb9162d04c4ff624d