### PR TITLE
Use Admin-Dashboard logo as dashboard background

### DIFF
--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -53,6 +53,13 @@ class AdminDashboard(QMainWindow):
         layout.setContentsMargins(20, 20, 20, 20)
         layout.setSpacing(15)
         central_widget.setLayout(layout)
+        bg_path = get_base_dir() / "logo" / "Admin-Dashboard.png"
+        bg_url = bg_path.as_posix()
+        central_widget.setStyleSheet(
+            f"background-image: url('{bg_url}');"
+            "background-repeat: no-repeat;"
+            "background-position: center;"
+        )
         icon_dir = get_base_dir() / "images" / "buttons"
         icon_size = QSize(24, 24)
 


### PR DESCRIPTION
## Summary
- Add logo/Admin-Dashboard.png as the background image for the admin dashboard window

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab0e83d2f0832e9cb1df449dfc0a0d