### PR TITLE
Ensure admin dashboard background scales to fit window

### DIFF
--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -59,6 +59,7 @@ class AdminDashboard(QMainWindow):
             f"background-image: url('{bg_url}');"
             "background-repeat: no-repeat;"
             "background-position: center;"
+            "background-size: contain;"
         )
         icon_dir = get_base_dir() / "images" / "buttons"
         icon_size = QSize(24, 24)


### PR DESCRIPTION
## Summary
- scale admin dashboard background image to fit window

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab0f9a9bb8832eb492d8913a7a3261