### PR TITLE
Avoid geometry warnings for SeasonProgressWindow

### DIFF
--- a/ui/season_progress_window.py
+++ b/ui/season_progress_window.py
@@ -28,6 +28,7 @@ class SeasonProgressWindow(QDialog):
         super().__init__(parent)
         try:
             self.setWindowTitle("Season Progress")
+            self.setMinimumSize(300, 200)
         except Exception:  # pragma: no cover - harmless in headless tests
             pass
 


### PR DESCRIPTION
## Summary
- Ensure SeasonProgressWindow respects Windows minimum tracking size by setting a 300x200 minimum size

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab146c42a4832e9f039cb63e42aae1