### PR TITLE
Log season progress actions to league news feed

### DIFF
--- a/ui/owner_dashboard.py
+++ b/ui/owner_dashboard.py
@@ -407,8 +407,10 @@ class OwnerDashboard(QWidget):
             QMessageBox.critical(self, "Error", f"Failed to sign free agent: {e}")
 
     def load_news_feed(self):
+        """Load the latest league news into the dashboard."""
         try:
-            self.news_feed.setPlainText(read_latest_news("data/news_feed.txt"))
+            lines = read_latest_news(file_path="data/news_feed.txt")
+            self.news_feed.setPlainText("".join(lines))
         except Exception as e:
             self.news_feed.setPlainText(f"(Failed to load news)\n{e}")
 

--- a/ui/season_progress_window.py
+++ b/ui/season_progress_window.py
@@ -14,6 +14,7 @@ from logic.season_manager import SeasonManager, SeasonPhase
 from logic.training_camp import run_training_camp
 from services.free_agency import list_unsigned_players
 from logic.season_simulator import SeasonSimulator
+from utils.news_logger import log_news_event
 
 
 class SeasonProgressWindow(QDialog):
@@ -98,6 +99,9 @@ class SeasonProgressWindow(QDialog):
             self.manager.save()
         else:
             self.manager.advance_phase()
+        log_news_event(
+            f"Season advanced to {self.manager.phase.name.replace('_', ' ').title()}"
+        )
         self._update_ui()
 
     # ------------------------------------------------------------------
@@ -111,14 +115,19 @@ class SeasonProgressWindow(QDialog):
         if agents:
             names = ", ".join(f"{p.first_name} {p.last_name}" for p in agents)
             self.notes_label.setText(f"Unsigned Players: {names}")
+            log_news_event(
+                f"Listed unsigned players: {len(agents)} available"
+            )
         else:
             self.notes_label.setText("No unsigned players available.")
+            log_news_event("No unsigned players available")
 
     def _run_training_camp(self) -> None:
         """Run the training camp and mark players as ready."""
         players = getattr(self.manager, "players", {})
         run_training_camp(players.values())
         self.notes_label.setText("Training camp completed. Players marked ready.")
+        log_news_event("Training camp completed; players marked ready")
 
     # ------------------------------------------------------------------
     # Regular season actions
@@ -128,4 +137,7 @@ class SeasonProgressWindow(QDialog):
         self.simulator.simulate_next_day()
         remaining = self.simulator.remaining_days()
         self.remaining_label.setText(f"Days until Midseason: {remaining}")
+        log_news_event(
+            f"Simulated a regular season day; {remaining} days until Midseason"
+        )
 


### PR DESCRIPTION
## Summary
- Log phase changes and actions from the Season Progress window to the league news feed
- Fix owner dashboard news feed loader so messages display correctly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab16b9ae60832eb736b9cc1542f606