### PR TITLE
Purge old league files on new league creation

### DIFF
--- a/data/news_feed.txt
+++ b/data/news_feed.txt
@@ -1,0 +1,6 @@
+[2025-08-24 13:56:36] Simulated a regular season day; 1 days until Midseason
+[2025-08-24 13:56:36] Simulated a regular season day; 0 days until Midseason
+[2025-08-24 13:56:36] Simulated a regular season day; 0 days until Midseason
+[2025-08-24 13:56:36] Simulated a regular season day; 0 days until Midseason
+[2025-08-24 13:56:36] Simulated a regular season day; 0 days until Midseason
+[2025-08-24 13:56:36] Season advanced to Preseason

--- a/logic/league_creator.py
+++ b/logic/league_creator.py
@@ -1,5 +1,4 @@
 import colorsys
-import os
 import csv
 import shutil
 from pathlib import Path
@@ -105,12 +104,27 @@ def _dict_to_model(data: dict):
         )
 
 
+def _purge_old_league(base_dir: Path) -> None:
+    """Remove remnants of a previous league from ``base_dir``.
+
+    Static resources required for league generation are preserved. Player
+    avatars reside outside ``base_dir`` and are therefore untouched.
+    """
+    keep = {"names.csv", "ballparks.py", "MLB_avg"}
+    for item in base_dir.iterdir():
+        if item.name in keep:
+            continue
+        if item.is_dir():
+            shutil.rmtree(item)
+        else:
+            item.unlink()
+
+
 def create_league(base_dir: str | Path, divisions: Dict[str, List[Tuple[str, str]]], league_name: str):
     base_dir = Path(base_dir)
     base_dir.mkdir(parents=True, exist_ok=True)
+    _purge_old_league(base_dir)
     rosters_dir = base_dir / "rosters"
-    if rosters_dir.exists():
-        shutil.rmtree(rosters_dir)
     rosters_dir.mkdir(parents=True, exist_ok=True)
 
     clear_users()

--- a/tests/test_league_creator.py
+++ b/tests/test_league_creator.py
@@ -157,3 +157,26 @@ def test_create_league_clears_users_and_rosters(tmp_path, monkeypatch):
     assert users_file.exists()
     assert users_file.read_text() == "admin,pass,admin,\n"
     assert not stray.exists()
+
+
+def test_create_league_purges_old_files_but_keeps_avatars(tmp_path):
+    root_dir = tmp_path
+    data_dir = root_dir / "data"
+    data_dir.mkdir()
+    old_file = data_dir / "old.txt"
+    old_file.write_text("old")
+    old_dir = data_dir / "lineups"
+    old_dir.mkdir()
+    (old_dir / "dummy.csv").write_text("x")
+
+    avatars_dir = root_dir / "images" / "avatars"
+    avatars_dir.mkdir(parents=True)
+    avatar = avatars_dir / "p1.png"
+    avatar.write_text("img")
+
+    divisions = {"East": [("CityA", "Cats")]}
+    create_league(str(data_dir), divisions, "Test League")
+
+    assert not old_file.exists()
+    assert not old_dir.exists()
+    assert avatar.exists()


### PR DESCRIPTION
## Summary
- Remove previous league data before generating a new league, preserving static resources and player avatars
- Add regression test ensuring stale league files are cleared while avatars remain

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab1973c980832e889343037b885f09