### PR TITLE
Convert schedule windows to HTML viewers and improve progress feedback

### DIFF
--- a/tests/test_schedule_windows.py
+++ b/tests/test_schedule_windows.py
@@ -117,9 +117,24 @@ for name in widget_names:
 qtwidgets.QMenuBar = QMenuBar
 qtwidgets.QMenu = QMenu
 qtwidgets.QAction = QAction
+# Provide a simple QTextEdit capable of storing HTML for assertions
+class QTextEdit(Dummy):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._html = ""
+
+    def setHtml(self, html):
+        self._html = html
+
+    def toHtml(self):
+        return self._html
+
+    def setPlainText(self, text):
+        self._html = text
+
+qtwidgets.QTextEdit = QTextEdit
 qtwidgets.QTableWidget = QTableWidget
 qtwidgets.QTableWidgetItem = QTableWidgetItem
-
 class QListWidgetItem:
     def __init__(self, text):
         self._text = text
@@ -210,13 +225,15 @@ def test_schedule_windows_show_data(monkeypatch, tmp_path):
     dashboard = owner_dashboard.OwnerDashboard('A')
     dashboard.schedule_action.trigger()
     league = opened['league']
-    assert league.table.item(0,0).text() == '2024-04-01'
-    assert league.table.item(0,1).text() == 'B'
-    assert league.table.item(0,2).text() == 'A'
+    html = league.viewer.toHtml()
+    assert '2024-04-01' in html
+    assert 'B' in html
+    assert 'A' in html
 
     dashboard.team_schedule_action.trigger()
     team = opened['team']
-    assert team.table.item(0,0).text() == '2024-04-01'
-    assert team.table.item(0,1).text() == 'vs B'
-    assert team.table.item(0,2).text() == 'W 3-2'
-    assert team.table.item(1,1).text() == 'at C'
+    html = team.viewer.toHtml()
+    assert '2024-04-01' in html
+    assert 'vs B' in html
+    assert 'W 3-2' in html
+    assert 'at C' in html

--- a/tests/test_season_progress_window.py
+++ b/tests/test_season_progress_window.py
@@ -218,13 +218,16 @@ def test_preseason_actions_require_sequence():
 
     win.free_agency_button.clicked.emit()
     assert win.training_camp_button.isEnabled()
+    assert "No unsigned players available" in win.notes_label.text()
 
     win.training_camp_button.clicked.emit()
     assert win.generate_schedule_button.isEnabled()
+    assert "Training camp completed" in win.notes_label.text()
 
     win.generate_schedule_button.clicked.emit()
     assert len(win.simulator.schedule) == 162
     assert win.next_button.isEnabled()
+    assert "Schedule generated with" in win.notes_label.text()
 
 
 def test_generate_schedule_loads_teams_from_csv(monkeypatch, tmp_path):

--- a/ui/schedule_window.py
+++ b/ui/schedule_window.py
@@ -1,9 +1,4 @@
-from PyQt6.QtWidgets import (
-    QDialog,
-    QTableWidget,
-    QTableWidgetItem,
-    QVBoxLayout,
-)
+from PyQt6.QtWidgets import QDialog, QVBoxLayout, QTextEdit
 import csv
 from pathlib import Path
 
@@ -11,33 +6,47 @@ SCHEDULE_FILE = Path(__file__).resolve().parents[1] / "data" / "schedule.csv"
 
 
 class ScheduleWindow(QDialog):
-    """Dialog displaying the full league schedule."""
+    """Dialog displaying the full league schedule as HTML."""
 
     def __init__(self, parent=None):
         super().__init__(parent)
         try:
             self.setWindowTitle("Schedule")
+            self.setGeometry(100, 100, 800, 600)
         except Exception:  # pragma: no cover - stubs without this method
             pass
 
         layout = QVBoxLayout(self)
 
-        self.schedule_data: list[dict[str, str]] = []
+        self.viewer = QTextEdit()
+        try:
+            self.viewer.setReadOnly(True)
+            self.viewer.setMinimumHeight(560)
+        except Exception:  # pragma: no cover
+            pass
+        layout.addWidget(self.viewer)
+
+        schedule_data: list[dict[str, str]] = []
         if SCHEDULE_FILE.exists():
             with SCHEDULE_FILE.open(newline="") as fh:
                 reader = csv.DictReader(fh)
-                self.schedule_data = list(reader)
+                schedule_data = list(reader)
 
-        table = QTableWidget()
-        table.setColumnCount(3)
-        table.setRowCount(len(self.schedule_data))
-        table.setHorizontalHeaderLabels(["Date", "Away", "Home"])
-        for row, game in enumerate(self.schedule_data):
-            table.setItem(row, 0, QTableWidgetItem(game.get("date", "")))
-            table.setItem(row, 1, QTableWidgetItem(game.get("away", "")))
-            table.setItem(row, 2, QTableWidgetItem(game.get("home", "")))
-        table.resizeColumnsToContents()
+        parts = [
+            "<html><head><title>League Schedule</title></head><body>",
+            "<b><font size=\"+2\"><center>League Schedule</center></font></b>",
+            "<hr><pre><b>Date       Away  Home</b>",
+        ]
 
-        self.table = table
-        layout.addWidget(table)
+        for game in schedule_data:
+            date = game.get("date", "")
+            away = game.get("away", "")
+            home = game.get("home", "")
+            parts.append(f"{date:<10}{away:<5}{home}")
+
+        parts.extend(["</pre></body></html>"])
+        try:
+            self.viewer.setHtml("\n".join(parts))
+        except Exception:  # pragma: no cover - dummy widgets
+            pass
 


### PR DESCRIPTION
## Summary
- Render league and team schedules as HTML inside QTextEdit viewers
- Preserve completion messages for preseason actions in the season progress window
- Update tests for new HTML schedule windows and message behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab20619c24832e8d7652f0c953db68