### PR TITLE
Persist season data after each simulated game

### DIFF
--- a/logic/schedule_generator.py
+++ b/logic/schedule_generator.py
@@ -202,8 +202,20 @@ def save_schedule(schedule: Iterable[Dict[str, str]], path: str | Path) -> None:
 
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
+    # Include optional result/played columns so that schedule files can track
+    # outcomes as the season progresses.  Unknown fields default to blank
+    # strings to keep the CSV consistent.
+    fieldnames = ["date", "home", "away", "result", "played"]
     with path.open("w", newline="", encoding="utf-8") as f:
-        writer = csv.writer(f)
-        writer.writerow(["date", "home", "away"])
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
         for game in schedule:
-            writer.writerow([game["date"], game["home"], game["away"]])
+            writer.writerow(
+                {
+                    "date": game.get("date", ""),
+                    "home": game.get("home", ""),
+                    "away": game.get("away", ""),
+                    "result": game.get("result", ""),
+                    "played": game.get("played", ""),
+                }
+            )


### PR DESCRIPTION
## Summary
- allow `SeasonSimulator` to invoke a callback after each game so standings and stats can be saved incrementally
- extend schedule CSV saving with `result` and `played` fields
- have `SeasonProgressWindow` persist schedule, team standings, and player stats after every simulated game

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab2e3a86f8832ea691f287a21cc6ae