### PR TITLE
Use detailed logic for season simulations

### DIFF
--- a/tests/test_season_simulator.py
+++ b/tests/test_season_simulator.py
@@ -20,10 +20,10 @@ def test_simulate_regular_season_to_completion():
 
 
 def test_default_simulation_runs_without_callback():
-    """Ensure the built-in placeholder game simulation runs without error."""
-    schedule = [{"date": "2024-04-01", "home": "A", "away": "B"}]
+    """Ensure the built-in season simulation runs using full game logic."""
+    schedule = [{"date": "2024-04-01", "home": "DRO", "away": "CEA"}]
 
     sim = SeasonSimulator(schedule)
 
-    # Should not raise any exceptions even though player data is minimal
+    # Should execute without raising exceptions using real roster data
     sim.simulate_next_day()


### PR DESCRIPTION
## Summary
- Align season game simulation with exhibition games by constructing full team states and running the pitch-by-pitch `GameSimulation`.
- Update season simulator tests to exercise the new default simulation using real roster data.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab32c46f2c832ea78ee603b33ebbf8