### PR TITLE
Show simulation progress messages and clean box score placeholders

### DIFF
--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -1553,6 +1553,8 @@ def render_boxscore_html(
     for key, value in repl.items():
         template = template.replace(f"{{{{{key}}}}}", str(value))
 
+    # Remove any unreplaced placeholders to avoid leaking template tokens
+    template = re.sub(r"{{[^{}]+}}", "", template)
     return template
 
 

--- a/ui/season_progress_window.py
+++ b/ui/season_progress_window.py
@@ -274,9 +274,12 @@ class SeasonProgressWindow(QDialog):
             return
         remaining = self.simulator.remaining_days()
         self.remaining_label.setText(f"Days until Midseason: {remaining}")
-        log_news_event(
-            f"Simulated a regular season day; {remaining} days until Midseason"
+        message = (
+            f"Simulated a regular season day; {remaining} "
+            "days until Midseason"
         )
+        self.notes_label.setText(message)
+        log_news_event(message)
         self._save_progress()
         season_done = self.simulator._index >= len(self.simulator.dates)
         if remaining <= 0 or season_done:
@@ -289,11 +292,20 @@ class SeasonProgressWindow(QDialog):
         """Simulate multiple days with a progress dialog."""
         if self.simulator.remaining_days() <= 0:
             return
-        progress = QProgressDialog(
-            f"Simulating {label}...", None, 0, days, self
-        )
+        progress = QProgressDialog("", "", 0, days, self)
         try:  # pragma: no cover - harmless in headless tests
             progress.setWindowTitle("Simulation Progress")
+        except Exception:  # pragma: no cover
+            pass
+        try:  # pragma: no cover - gui only
+            progress.setCancelButton(None)
+        except Exception:  # pragma: no cover
+            pass
+        try:  # pragma: no cover - gui only
+            progress.setLabelText(f"Simulating {label}...")
+        except Exception:  # pragma: no cover
+            pass
+        try:  # pragma: no cover - gui only
             progress.setValue(0)
             progress.show()
         except Exception:  # pragma: no cover
@@ -318,9 +330,12 @@ class SeasonProgressWindow(QDialog):
             pass
         remaining = self.simulator.remaining_days()
         self.remaining_label.setText(f"Days until Midseason: {remaining}")
-        log_news_event(
-            f"Simulated {label.lower()}; {remaining} days until Midseason"
+        message = (
+            f"Simulated {label.lower()}; {remaining} "
+            "days until Midseason"
         )
+        self.notes_label.setText(message)
+        log_news_event(message)
         self._save_progress()
         season_done = self.simulator._index >= len(self.simulator.dates)
         if remaining <= 0 or season_done:


### PR DESCRIPTION
## Summary
- show user feedback during simulations by labeling progress dialog and updating notes
- strip unreplaced tokens from box score HTML to prevent placeholder leakage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab38a13fd0832ebfa0c2c754677a94