### PR TITLE
Add per-game progress tracking and ESPN-style box score template

### DIFF
--- a/samples/espn_boxscore_template.html
+++ b/samples/espn_boxscore_template.html
@@ -6,17 +6,17 @@
   <title>{{league}} Box Score — {{away.abbr}} @ {{home.abbr}}</title>
   <style>
     :root{
-      --bg:#0b0d12;
-      --card:#11141b;
-      --muted:#7f8ca3;
-      --text:#e8eef9;
-      --accent:#39a2ff;
-      --good:#21c55d;
-      --bad:#ef4444;
+      --bg:#fff;
+      --card:#f5f5f5;
+      --muted:#444;
+      --text:#000;
+      --accent:#cf0a2c;
+      --good:#0f7c0f;
+      --bad:#d0021b;
       --grid-gap:16px;
-      --radius:14px;
-      --table-stripe: rgba(255,255,255,0.04);
-      --border:1px solid rgba(255,255,255,0.08)
+      --radius:4px;
+      --table-stripe:#f9f9f9;
+      --border:1px solid #ccc
     }
     *{box-sizing:border-box}
     body{margin:0;background:var(--bg);color:var(--text);font:14px/1.5 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial,"Noto Sans","Apple Color Emoji","Segoe UI Emoji"}
@@ -25,7 +25,7 @@
 
     .game-header{display:grid;grid-template-columns:1fr auto 1fr;gap:20px;align-items:center}
     .team{display:flex;align-items:center;gap:12px}
-    .team img{width:56px;height:56px;border-radius:12px;background:#222;object-fit:contain}
+    .team img{width:56px;height:56px;border-radius:12px;background:var(--card);object-fit:contain}
     .team .name{font-size:18px;font-weight:650}
     .team .record{color:var(--muted);font-size:12px;margin-top:2px}
     .score{display:flex;align-items:baseline;gap:8px;padding:10px 16px;border-radius:14px;background:linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.02));border:var(--border)}
@@ -33,7 +33,7 @@
     .score .tag{font-size:12px;color:var(--muted)}
 
     .nav{display:flex;gap:16px;flex-wrap:wrap;margin-top:10px}
-    .pill{padding:6px 10px;border-radius:999px;background:#0f131b;border:var(--border);color:var(--text)}
+    .pill{padding:6px 10px;border-radius:999px;background:var(--card);border:var(--border);color:var(--text)}
 
     .card{background:var(--card);border:var(--border);border-radius:var(--radius);padding:14px}
     .linescore{overflow:auto}


### PR DESCRIPTION
## Summary
- Show a simulation progress dialog that advances after each individual game
- Restyle HTML box scores with an ESPN-inspired light theme

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab3d0ee170832e85f2653355bf70b7