### PR TITLE
Add selectable UI color schemes

### DIFF
--- a/tests/test_color_scheme.py
+++ b/tests/test_color_scheme.py
@@ -1,0 +1,26 @@
+import pytest
+from types import SimpleNamespace
+
+owner_dashboard = pytest.importorskip("ui.owner_dashboard")
+
+
+def test_apply_color_scheme_updates_stylesheet():
+    dash = owner_dashboard.OwnerDashboard.__new__(owner_dashboard.OwnerDashboard)
+    dash.setStyleSheet = lambda s: setattr(dash, "_style", s)
+    owner_dashboard.OwnerDashboard.apply_color_scheme(dash, "#111111", "#222222")
+    assert "#111111" in dash._style
+    assert "#222222" in dash._style
+
+
+def test_apply_team_colors_uses_team_values():
+    dash = owner_dashboard.OwnerDashboard.__new__(owner_dashboard.OwnerDashboard)
+    dash.team = SimpleNamespace(primary_color="#333333", secondary_color="#444444")
+    captured = {}
+
+    def fake_apply(primary, secondary):
+        captured["primary"] = primary
+        captured["secondary"] = secondary
+
+    dash.apply_color_scheme = fake_apply
+    owner_dashboard.OwnerDashboard.apply_team_colors(dash)
+    assert captured == {"primary": "#333333", "secondary": "#444444"}

--- a/tests/test_schedule_windows.py
+++ b/tests/test_schedule_windows.py
@@ -75,6 +75,8 @@ class QAction:
 class QMenu(Dummy):
     def addAction(self, *args, **kwargs):
         return QAction()
+    def addMenu(self, *args, **kwargs):
+        return QMenu()
 
 class QMenuBar(Dummy):
     def addMenu(self, *args, **kwargs):

--- a/tests/test_standings_window.py
+++ b/tests/test_standings_window.py
@@ -92,6 +92,8 @@ class QAction:
 class QMenu(Dummy):
     def addAction(self, *args, **kwargs):
         return QAction()
+    def addMenu(self, *args, **kwargs):
+        return QMenu()
 
 class QMenuBar(Dummy):
     def addMenu(self, *args, **kwargs):

--- a/ui/owner_dashboard.py
+++ b/ui/owner_dashboard.py
@@ -62,6 +62,13 @@ def _contrast_text_color(hex_color: str) -> str:
     return "#000000" if luminance > 180 else "#ffffff"
 
 
+PREDEFINED_COLOR_SCHEMES: dict[str, tuple[str, str]] = {
+    "Light": ("#f5f5f5", "#d0d0d0"),
+    "Dark": ("#2e3440", "#4c566a"),
+    "Classic": ("#003366", "#cccccc"),
+}
+
+
 class OwnerDashboard(QWidget):
     """Owner-facing dashboard showing roster and quick actions.
 
@@ -99,6 +106,14 @@ class OwnerDashboard(QWidget):
         file_menu = menubar.addMenu("File")
         exit_action = file_menu.addAction("Exit")
         exit_action.triggered.connect(QApplication.quit)
+        color_menu = file_menu.addMenu("Color Scheme")
+        for name, (primary, secondary) in PREDEFINED_COLOR_SCHEMES.items():
+            action = color_menu.addAction(name)
+            action.triggered.connect(
+                lambda _=False, p=primary, s=secondary: self.apply_color_scheme(p, s)
+            )
+        team_colors_action = color_menu.addAction("Team Colors")
+        team_colors_action.triggered.connect(self.apply_team_colors)
         team_menu = menubar.addMenu("Team")
         pos_action = team_menu.addAction("Position Players")
         pit_action = team_menu.addAction("Pitchers")
@@ -227,8 +242,10 @@ class OwnerDashboard(QWidget):
         """Apply the team's color scheme to the dashboard."""
         if not self.team:
             return
-        primary = self.team.primary_color
-        secondary = self.team.secondary_color
+        self.apply_color_scheme(self.team.primary_color, self.team.secondary_color)
+
+    def apply_color_scheme(self, primary: str, secondary: str):
+        """Apply a custom color scheme to the dashboard."""
         text_color = _contrast_text_color(primary)
         button_text = _contrast_text_color(secondary)
         self.setStyleSheet(


### PR DESCRIPTION
## Summary
- Allow owners to choose from built-in color schemes via File → Color Scheme
- Provide helper to apply arbitrary color schemes and reuse for team colors
- Extend QMenu test stubs and add tests for color scheme application

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab3e3c9478832e846a72b151fb128b