### PR TITLE
Add team and league stats pages with leaders

### DIFF
--- a/tests/test_stats_windows.py
+++ b/tests/test_stats_windows.py
@@ -1,0 +1,121 @@
+import sys
+import types
+from types import SimpleNamespace
+
+# ---- Stub PyQt6 modules ----
+class Dummy:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __getattr__(self, name):
+        return Dummy()
+
+    # Methods used in windows
+    def addTab(self, *args, **kwargs):
+        pass
+
+    def setRowCount(self, *args, **kwargs):
+        pass
+
+    def setColumnCount(self, *args, **kwargs):
+        pass
+
+    def setHorizontalHeaderLabels(self, *args, **kwargs):
+        pass
+
+    def setItem(self, *args, **kwargs):
+        pass
+
+    def setSortingEnabled(self, *args, **kwargs):
+        pass
+
+    def addWidget(self, *args, **kwargs):
+        pass
+
+    def setLayout(self, *args, **kwargs):
+        pass
+
+    def setWindowTitle(self, *args, **kwargs):
+        pass
+
+qtwidgets = types.ModuleType("PyQt6.QtWidgets")
+for name in [
+    "QDialog",
+    "QTabWidget",
+    "QTableWidget",
+    "QTableWidgetItem",
+    "QVBoxLayout",
+]:
+    setattr(qtwidgets, name, Dummy)
+
+sys.modules.setdefault("PyQt6", types.ModuleType("PyQt6"))
+sys.modules["PyQt6.QtWidgets"] = qtwidgets
+sys.modules["PyQt6.QtCore"] = types.ModuleType("PyQt6.QtCore")
+sys.modules["PyQt6.QtGui"] = types.ModuleType("PyQt6.QtGui")
+
+# ---- Imports after stubbing ----
+import importlib
+import ui.team_stats_window as team_stats_window
+import ui.league_stats_window as league_stats_window
+import ui.league_leaders_window as league_leaders_window
+from models.team import Team
+from models.roster import Roster
+
+# Reload modules to ensure they pick up the testing stubs
+importlib.reload(team_stats_window)
+importlib.reload(league_stats_window)
+importlib.reload(league_leaders_window)
+
+from ui.team_stats_window import TeamStatsWindow
+from ui.league_stats_window import LeagueStatsWindow
+from ui.league_leaders_window import LeagueLeadersWindow
+
+
+def _sample_team() -> Team:
+    team = Team(
+        team_id="T",
+        name="Testers",
+        city="Test",
+        abbreviation="TST",
+        division="D",
+        stadium="Stadium",
+        primary_color="#000000",
+        secondary_color="#ffffff",
+        owner_id="OWN",
+    )
+    team.season_stats = {"w": 1, "l": 0}
+    return team
+
+
+def _sample_players():
+    batter = SimpleNamespace(
+        first_name="A",
+        last_name="B",
+        is_pitcher=False,
+        season_stats={"g": 1, "ab": 2, "r": 1, "h": 1, "avg": 0.5},
+    )
+    pitcher = SimpleNamespace(
+        first_name="C",
+        last_name="D",
+        is_pitcher=True,
+        season_stats={"w": 1, "era": 3.0, "so": 5},
+    )
+    return {"b1": batter, "p1": pitcher}
+
+
+def test_team_stats_window_instantiates():
+    team = _sample_team()
+    players = _sample_players()
+    roster = Roster(team_id="T", act=["b1", "p1"])
+    TeamStatsWindow(team, players, roster)
+
+
+def test_league_stats_window_instantiates():
+    team = _sample_team()
+    players = _sample_players()
+    LeagueStatsWindow([team], players.values())
+
+
+def test_league_leaders_window_instantiates():
+    players = _sample_players()
+    LeagueLeadersWindow(players.values())

--- a/ui/league_leaders_window.py
+++ b/ui/league_leaders_window.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Iterable, List, Tuple
+
+from PyQt6.QtWidgets import (
+    QDialog,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
+
+from models.base_player import BasePlayer
+
+
+class LeagueLeadersWindow(QDialog):
+    """Dialog showing leaders in common statistical categories."""
+
+    def __init__(
+        self,
+        players: Iterable[BasePlayer],
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("League Leaders")
+
+        layout = QVBoxLayout(self)
+        self.table = QTableWidget()
+        layout.addWidget(self.table)
+
+        player_list = list(players)
+        rows = self._gather_leaders(player_list)
+
+        self.table.setRowCount(len(rows))
+        self.table.setColumnCount(3)
+        self.table.setHorizontalHeaderLabels(["Category", "Player", "Value"])
+        for row, (cat, name, value) in enumerate(rows):
+            self.table.setItem(row, 0, QTableWidgetItem(cat))
+            self.table.setItem(row, 1, QTableWidgetItem(name))
+            self.table.setItem(row, 2, QTableWidgetItem(value))
+        self.table.setSortingEnabled(True)
+
+    # ------------------------------------------------------------------
+    def _gather_leaders(self, players: List[BasePlayer]) -> List[Tuple[str, str, str]]:
+        categories = [
+            ("AVG", "avg", False, False),
+            ("HR", "hr", True, False),
+            ("RBI", "rbi", True, False),
+            ("ERA", "era", False, True),
+            ("SO", "so", True, True),
+        ]
+        rows: List[Tuple[str, str, str]] = []
+        for label, key, high, pitcher_only in categories:
+            candidates = [
+                p
+                for p in players
+                if getattr(p, "is_pitcher", False) == pitcher_only
+                and key in (getattr(p, "season_stats", {}) or {})
+            ]
+            if not candidates:
+                continue
+            if high:
+                best = max(candidates, key=lambda p: p.season_stats.get(key, 0))
+            else:
+                best = min(candidates, key=lambda p: p.season_stats.get(key, float("inf")))
+            value = best.season_stats.get(key, 0)
+            name = f"{getattr(best, 'first_name', '')} {getattr(best, 'last_name', '')}".strip()
+            rows.append((label, name, str(value)))
+        return rows

--- a/ui/league_stats_window.py
+++ b/ui/league_stats_window.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from PyQt6.QtWidgets import (
+    QDialog,
+    QTabWidget,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
+
+from models.team import Team
+from models.base_player import BasePlayer
+
+_BATTING_COLS: List[str] = [
+    "g",
+    "ab",
+    "r",
+    "h",
+    "2b",
+    "3b",
+    "hr",
+    "rbi",
+    "bb",
+    "so",
+    "avg",
+    "obp",
+    "slg",
+]
+
+_PITCHING_COLS: List[str] = [
+    "w",
+    "l",
+    "era",
+    "g",
+    "gs",
+    "sv",
+    "ip",
+    "h",
+    "er",
+    "bb",
+    "so",
+    "whip",
+]
+
+_TEAM_COLS: List[str] = ["g", "w", "l", "r", "ra"]
+
+
+class LeagueStatsWindow(QDialog):
+    """Dialog showing statistics for teams and players across the league."""
+
+    def __init__(
+        self,
+        teams: Iterable[Team],
+        players: Iterable[BasePlayer],
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("League Statistics")
+
+        layout = QVBoxLayout(self)
+        self.tabs = QTabWidget()
+        layout.addWidget(self.tabs)
+
+        team_list = list(teams)
+        player_list = list(players)
+
+        self.tabs.addTab(self._build_team_table(team_list), "Teams")
+        batters = [p for p in player_list if not getattr(p, "is_pitcher", False)]
+        pitchers = [p for p in player_list if getattr(p, "is_pitcher", False)]
+        self.tabs.addTab(self._build_player_table(batters, _BATTING_COLS), "Batters")
+        self.tabs.addTab(self._build_player_table(pitchers, _PITCHING_COLS), "Pitchers")
+
+    # ------------------------------------------------------------------
+    def _build_team_table(self, teams: List[Team]) -> QTableWidget:
+        table = QTableWidget(len(teams), len(_TEAM_COLS) + 1)
+        headers = ["Team"] + [c.upper() for c in _TEAM_COLS]
+        table.setHorizontalHeaderLabels(headers)
+        for row, team in enumerate(teams):
+            name = f"{team.city} {team.name}".strip()
+            table.setItem(row, 0, QTableWidgetItem(name))
+            stats = getattr(team, "season_stats", {}) or {}
+            for col, key in enumerate(_TEAM_COLS, start=1):
+                table.setItem(row, col, QTableWidgetItem(str(stats.get(key, 0))))
+        table.setSortingEnabled(True)
+        return table
+
+    def _build_player_table(
+        self, players: Iterable[BasePlayer], columns: List[str]
+    ) -> QTableWidget:
+        players = list(players)
+        table = QTableWidget(len(players), len(columns) + 1)
+        headers = ["Name"] + [c.upper() for c in columns]
+        table.setHorizontalHeaderLabels(headers)
+        for row, player in enumerate(players):
+            name = f"{getattr(player, 'first_name', '')} {getattr(player, 'last_name', '')}".strip()
+            table.setItem(row, 0, QTableWidgetItem(name))
+            stats = getattr(player, "season_stats", {}) or {}
+            for col, key in enumerate(columns, start=1):
+                value = stats.get(key, 0)
+                table.setItem(row, col, QTableWidgetItem(str(value)))
+        table.setSortingEnabled(True)
+        return table

--- a/ui/owner_dashboard.py
+++ b/ui/owner_dashboard.py
@@ -37,6 +37,9 @@ from ui.standings_window import StandingsWindow
 from ui.schedule_window import ScheduleWindow
 from ui.team_schedule_window import TeamScheduleWindow
 from ui.trade_dialog import TradeDialog
+from ui.team_stats_window import TeamStatsWindow
+from ui.league_stats_window import LeagueStatsWindow
+from ui.league_leaders_window import LeagueLeadersWindow
 from utils.roster_loader import load_roster, save_roster
 from utils.player_loader import load_players_from_csv
 from utils.news_reader import read_latest_news
@@ -121,6 +124,7 @@ class OwnerDashboard(QWidget):
         pitch_staff_action = team_menu.addAction("Pitching Staff")
         trans_action = team_menu.addAction("Transactions")
         settings_action = team_menu.addAction("Settings")
+        stats_action = team_menu.addAction("Stats")
         self.team_schedule_action = team_menu.addAction("Schedule")
         self.team_schedule_action.triggered.connect(self.open_team_schedule_window)
         pos_action.triggered.connect(self.open_position_players_dialog)
@@ -129,11 +133,16 @@ class OwnerDashboard(QWidget):
         pitch_staff_action.triggered.connect(self.open_pitching_editor)
         trans_action.triggered.connect(self.open_transactions_page)
         settings_action.triggered.connect(self.open_team_settings)
+        stats_action.triggered.connect(self.open_team_stats_window)
         league_menu = menubar.addMenu("League")
         self.standings_action = league_menu.addAction("Standings")
         self.schedule_action = league_menu.addAction("Schedule")
+        self.league_stats_action = league_menu.addAction("Statistics")
+        self.league_leaders_action = league_menu.addAction("Leaders")
         self.standings_action.triggered.connect(self.open_standings_window)
         self.schedule_action.triggered.connect(self.open_schedule_window)
+        self.league_stats_action.triggered.connect(self.open_league_stats_window)
+        self.league_leaders_action.triggered.connect(self.open_league_leaders_window)
         main.setMenuBar(menubar)
 
         logo_path = get_base_dir() / "logo" / "teams" / f"{team_id.lower()}.png"
@@ -322,6 +331,19 @@ class OwnerDashboard(QWidget):
             QMessageBox.warning(self, "Error", "Team information not available.")
             return
         TeamScheduleWindow(self.team_id, self).exec()
+
+    def open_team_stats_window(self):
+        """Open the team statistics window."""
+        TeamStatsWindow(self.team, self.players, self.roster, self).exec()
+
+    def open_league_stats_window(self):
+        """Open the league-wide statistics window."""
+        teams = load_teams()
+        LeagueStatsWindow(teams, self.players.values(), self).exec()
+
+    def open_league_leaders_window(self):
+        """Open the league leaders window."""
+        LeagueLeadersWindow(self.players.values(), self).exec()
 
     def open_team_settings(self):
         if not self.team:

--- a/ui/team_stats_window.py
+++ b/ui/team_stats_window.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+from PyQt6.QtWidgets import (
+    QDialog,
+    QTabWidget,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
+
+from models.team import Team
+from models.roster import Roster
+from models.base_player import BasePlayer
+
+
+_BATTING_COLS: List[str] = [
+    "g",
+    "ab",
+    "r",
+    "h",
+    "2b",
+    "3b",
+    "hr",
+    "rbi",
+    "bb",
+    "so",
+    "avg",
+    "obp",
+    "slg",
+]
+
+_PITCHING_COLS: List[str] = [
+    "w",
+    "l",
+    "era",
+    "g",
+    "gs",
+    "sv",
+    "ip",
+    "h",
+    "er",
+    "bb",
+    "so",
+    "whip",
+]
+
+
+class TeamStatsWindow(QDialog):
+    """Dialog showing player and team statistics for a single team."""
+
+    def __init__(
+        self,
+        team: Team,
+        players: Dict[str, BasePlayer],
+        roster: Roster,
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self.team = team
+        self.players = players
+        self.roster = roster
+
+        self.setWindowTitle("Team Statistics")
+
+        layout = QVBoxLayout(self)
+        self.tabs = QTabWidget()
+        layout.addWidget(self.tabs)
+
+        batter_ids = [
+            pid
+            for pid in roster.act
+            if pid in players and not getattr(players[pid], "is_pitcher", False)
+        ]
+        pitcher_ids = [
+            pid
+            for pid in roster.act
+            if pid in players and getattr(players[pid], "is_pitcher", False)
+        ]
+
+        batters = [players[pid] for pid in batter_ids]
+        pitchers = [players[pid] for pid in pitcher_ids]
+
+        self.tabs.addTab(self._build_player_table(batters, _BATTING_COLS), "Batting")
+        self.tabs.addTab(self._build_player_table(pitchers, _PITCHING_COLS), "Pitching")
+        self.tabs.addTab(self._build_team_table(team.season_stats), "Team")
+
+    # ------------------------------------------------------------------
+    def _build_player_table(
+        self, players: Iterable[BasePlayer], columns: List[str]
+    ) -> QTableWidget:
+        players = list(players)
+        table = QTableWidget(len(players), len(columns) + 1)
+        headers = ["Name"] + [c.upper() for c in columns]
+        table.setHorizontalHeaderLabels(headers)
+        for row, player in enumerate(players):
+            name = f"{getattr(player, 'first_name', '')} {getattr(player, 'last_name', '')}".strip()
+            table.setItem(row, 0, QTableWidgetItem(name))
+            stats = getattr(player, "season_stats", {}) or {}
+            for col, key in enumerate(columns, start=1):
+                value = stats.get(key, 0)
+                table.setItem(row, col, QTableWidgetItem(str(value)))
+        table.setSortingEnabled(True)
+        return table
+
+    def _build_team_table(self, stats: Dict[str, float]) -> QTableWidget:
+        items = sorted(stats.items())
+        table = QTableWidget(len(items), 2)
+        table.setHorizontalHeaderLabels(["Stat", "Value"])
+        for row, (key, value) in enumerate(items):
+            table.setItem(row, 0, QTableWidgetItem(str(key)))
+            table.setItem(row, 1, QTableWidgetItem(str(value)))
+        table.setSortingEnabled(True)
+        return table


### PR DESCRIPTION
## Summary
- add team statistics window with sortable player and team tables
- provide league-wide stats and leaders pages
- expose new stats windows through OwnerDashboard menus

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab5957fff4832ea30a8da263e958e5