### PR TITLE
Persist season statistics and enlarge stats windows

### DIFF
--- a/data/news_feed.txt
+++ b/data/news_feed.txt
@@ -4,3 +4,13 @@
 [2025-08-24 13:56:36] Simulated a regular season day; 0 days until Midseason
 [2025-08-24 13:56:36] Simulated a regular season day; 0 days until Midseason
 [2025-08-24 13:56:36] Season advanced to Preseason
+[2025-08-24 18:54:41] Simulated a regular season day; 1 days until Midseason
+[2025-08-24 18:54:41] Simulated a regular season day; 0 days until Midseason
+[2025-08-24 18:54:41] Simulated week; 0 days until Midseason
+[2025-08-24 18:54:41] Simulated month; 0 days until Midseason
+[2025-08-24 18:54:41] Season advanced to Preseason
+[2025-08-24 18:54:41] No unsigned players available
+[2025-08-24 18:54:41] Training camp completed; players marked ready
+[2025-08-24 18:54:41] Generated regular season schedule with 162 games
+[2025-08-24 18:54:41] Generated regular season schedule with 162 games
+[2025-08-24 18:54:41] No unsigned players available

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -17,6 +17,7 @@ from logic.batter_ai import BatterAI
 from logic.bullpen import WarmupTracker
 from logic.fielding_ai import FieldingAI
 from utils.path_utils import get_base_dir
+from utils.stats_persistence import save_stats
 from .stats import (
     compute_batting_derived,
     compute_batting_rates,
@@ -541,6 +542,17 @@ class GameSimulation:
             team.team_stats = season
             if team.team is not None:
                 team.team.season_stats = season
+
+        players: Dict[str, Player] = {}
+        for state in (self.home, self.away):
+            for bs in state.lineup_stats.values():
+                players[bs.player.player_id] = bs.player
+            for ps in state.pitcher_stats.values():
+                players[ps.player.player_id] = ps.player
+            for fs in state.fielding_stats.values():
+                players[fs.player.player_id] = fs.player
+        teams = [t.team for t in (self.home, self.away) if t.team is not None]
+        save_stats(players.values(), teams)
 
     def _play_half(self, offense: TeamState, defense: TeamState) -> None:
         # Allow the defensive team to consider a late inning defensive swap

--- a/ui/league_leaders_window.py
+++ b/ui/league_leaders_window.py
@@ -23,6 +23,8 @@ class LeagueLeadersWindow(QDialog):
     ) -> None:
         super().__init__(parent)
         self.setWindowTitle("League Leaders")
+        if callable(getattr(self, "resize", None)):
+            self.resize(1000, 600)
 
         layout = QVBoxLayout(self)
         self.table = QTableWidget()

--- a/ui/league_stats_window.py
+++ b/ui/league_stats_window.py
@@ -58,6 +58,8 @@ class LeagueStatsWindow(QDialog):
     ) -> None:
         super().__init__(parent)
         self.setWindowTitle("League Statistics")
+        if callable(getattr(self, "resize", None)):
+            self.resize(1000, 600)
 
         layout = QVBoxLayout(self)
         self.tabs = QTabWidget()

--- a/ui/team_stats_window.py
+++ b/ui/team_stats_window.py
@@ -64,6 +64,8 @@ class TeamStatsWindow(QDialog):
         self.roster = roster
 
         self.setWindowTitle("Team Statistics")
+        if callable(getattr(self, "resize", None)):
+            self.resize(1000, 600)
 
         layout = QVBoxLayout(self)
         self.tabs = QTabWidget()

--- a/utils/player_loader.py
+++ b/utils/player_loader.py
@@ -2,8 +2,9 @@ import csv
 from pathlib import Path
 
 from models.player import Player
-from utils.path_utils import get_base_dir
 from models.pitcher import Pitcher
+from utils.path_utils import get_base_dir
+from utils.stats_persistence import load_stats
 
 
 def _required_int(row, key):
@@ -146,4 +147,9 @@ def load_players_from_csv(file_path):
                 )
 
             players.append(player)
+    stats = load_stats()
+    for player in players:
+        season = stats["players"].get(player.player_id)
+        if season:
+            player.season_stats = season
     return players

--- a/utils/stats_persistence.py
+++ b/utils/stats_persistence.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+from utils.path_utils import get_base_dir
+
+
+def _resolve_path(path: str | Path) -> Path:
+    base_dir = get_base_dir()
+    p = Path(path)
+    if not p.is_absolute():
+        p = base_dir / p
+    return p
+
+
+def load_stats(path: str | Path = "data/season_stats.json") -> Dict[str, Any]:
+    file_path = _resolve_path(path)
+    try:
+        with file_path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        data = {}
+    return {
+        "players": data.get("players", {}),
+        "teams": data.get("teams", {}),
+        "history": data.get("history", []),
+    }
+
+
+def save_stats(
+    players: Iterable[Any],
+    teams: Iterable[Any],
+    path: str | Path = "data/season_stats.json",
+) -> None:
+    file_path = _resolve_path(path)
+    stats = load_stats(file_path)
+    player_stats = stats.get("players", {})
+    for player in players:
+        season = getattr(player, "season_stats", None)
+        if season:
+            player_stats[player.player_id] = season
+    team_stats = stats.get("teams", {})
+    for team in teams:
+        season = getattr(team, "season_stats", None)
+        if season:
+            team_stats[team.team_id] = season
+    history = stats.get("history", [])
+    history.append(
+        {
+            "players": {
+                p.player_id: getattr(p, "season_stats", {}) for p in players
+            },
+            "teams": {t.team_id: getattr(t, "season_stats", {}) for t in teams},
+        }
+    )
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    with file_path.open("w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "players": player_stats,
+                "teams": team_stats,
+                "history": history,
+            },
+            f,
+            indent=2,
+        )

--- a/utils/team_loader.py
+++ b/utils/team_loader.py
@@ -4,6 +4,7 @@ import re
 from pathlib import Path
 from models.team import Team
 from utils.path_utils import get_base_dir
+from utils.stats_persistence import load_stats
 
 
 def _resolve_path(file_path: str | Path) -> Path:
@@ -33,6 +34,11 @@ def load_teams(file_path: str | Path = "data/teams.csv"):
                 owner_id=row["owner_id"],
             )
             teams.append(team)
+    stats = load_stats()
+    for team in teams:
+        season = stats["teams"].get(team.team_id)
+        if season:
+            team.season_stats = season
     return teams
 
 


### PR DESCRIPTION
## Summary
- Enlarge team, league, and leader stats dialogs so all data is visible
- Persist player and team stats across games with load/save utilities
- Save updated stats after each simulated game and load them when players or teams are read

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab5f05aa20832e93f0e7db7955475c