### PR TITLE
Handle missing player positions in profile dialog

### DIFF
--- a/tests/test_player_profile_dialog.py
+++ b/tests/test_player_profile_dialog.py
@@ -113,3 +113,27 @@ def test_player_profile_dialog_uses_history(monkeypatch):
     assert "Year 1 Stats" in calls
     assert "Year 2 Ratings" in calls
     assert "Year 2 Stats" in calls
+
+
+def test_player_profile_dialog_handles_missing_positions(monkeypatch):
+    """Ensure dialog renders even if position data is missing."""
+
+    monkeypatch.setattr(
+        ppd, "load_stats", lambda: {"players": {}, "teams": {}, "history": []}
+    )
+
+    player = SimpleNamespace(
+        player_id="p2",
+        first_name="A",
+        last_name="B",
+        birthdate="2000-01-01",
+        height=70,
+        weight=180,
+        bats="R",
+        primary_position=None,
+        other_positions=[None],
+        gf=40,
+    )
+
+    dlg = ppd.PlayerProfileDialog(player)
+    assert dlg is not None

--- a/ui/player_profile_dialog.py
+++ b/ui/player_profile_dialog.py
@@ -91,10 +91,12 @@ class PlayerProfileDialog(QDialog):
             QLabel(f"Bats: {getattr(self.player, 'bats', '?')}")
         )
         positions = ", ".join(
-            [
+            p
+            for p in [
                 self.player.primary_position,
                 *getattr(self.player, "other_positions", []),
             ]
+            if p
         )
         info_layout.addWidget(QLabel(f"Positions: {positions}"))
         layout.addLayout(info_layout)


### PR DESCRIPTION
## Summary
- avoid errors when players lack primary or secondary positions
- test profile dialog rendering with missing position data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab6d3d7760832eb9f6e25fcabebe46