### PR TITLE
Fix missing text in player profile dialog

### DIFF
--- a/ui/resources/espn.qss
+++ b/ui/resources/espn.qss
@@ -5,6 +5,10 @@ QDialog {
     font-family: Arial, sans-serif;
 }
 
+QLabel {
+    color: #1a1a1a;
+}
+
 QTableWidget {
     gridline-color: #e0e0e0;
     background-color: #ffffff;
@@ -22,6 +26,7 @@ QHeaderView::section {
 QGroupBox {
     border: 1px solid #e0e0e0;
     margin-top: 10px;
+    color: #1a1a1a;
 }
 
 QGroupBox::title {


### PR DESCRIPTION
## Summary
- Ensure labels and group boxes use dark text in ESPN theme so player profile info is visible

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab6e7b9290832e80c551336dd8b032