### PR TITLE
Enable extra-base hits with configurable distribution

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -122,6 +122,11 @@ _DEFAULTS: Dict[str, Any] = {
     "throwSpeedOFBase": 52,
     "throwSpeedOFDistPct": 3,
     "throwSpeedOFMax": 92,
+    # Hit type distribution (percentages summing to ~100)
+    "hit1BProb": 64,
+    "hit2BProb": 20,
+    "hit3BProb": 2,
+    "hitHRProb": 14,
     # Pitcher AI ------------------------------------------------------
     "pitchRatVariationCount": 1,
     "pitchRatVariationFaces": 3,


### PR DESCRIPTION
## Summary
- allow simulation to generate doubles, triples, and home runs
- add configurable hit-type percentages in `PlayBalanceConfig`
- cover new behaviour with tests, including a home run scoring test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab9370f8f8832ea67f1fa7935ced53