### PR TITLE
Fix missing extra-base hit stats

### DIFF
--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -482,6 +482,10 @@ class GameSimulation:
         for team in (self.home, self.away):
             for bs in team.lineup_stats.values():
                 season = getattr(bs.player, "season_stats", {})
+                for f in fields(BatterState):
+                    if f.name == "player":
+                        continue
+                    season[f.name] = season.get(f.name, 0) + getattr(bs, f.name)
                 season_state = BatterState(bs.player)
                 for f in fields(BatterState):
                     if f.name == "player":
@@ -489,6 +493,8 @@ class GameSimulation:
                     setattr(season_state, f.name, season.get(f.name, 0))
                 season.update(compute_batting_derived(season_state))
                 season.update(compute_batting_rates(season_state))
+                season["2b"] = season.get("b2", 0)
+                season["3b"] = season.get("b3", 0)
                 bs.player.season_stats = season
 
             for ps in team.pitcher_stats.values():

--- a/ui/player_profile_dialog.py
+++ b/ui/player_profile_dialog.py
@@ -169,10 +169,17 @@ class PlayerProfileDialog(QDialog):
 
     def _stats_to_dict(self, stats: Any) -> Dict[str, Any]:
         if isinstance(stats, dict):
-            return stats
-        if is_dataclass(stats):
-            return asdict(stats)
-        return {}
+            data = dict(stats)
+        elif is_dataclass(stats):
+            data = asdict(stats)
+        else:
+            return {}
+        # Normalize key names for extra-base hits
+        if "b2" in data and "2b" not in data:
+            data["2b"] = data.get("b2", 0)
+        if "b3" in data and "3b" not in data:
+            data["3b"] = data.get("b3", 0)
+        return data
 
     def _format_stat(self, value: Any) -> str:
         """Return a string, formatting floats to three decimals."""


### PR DESCRIPTION
## Summary
- accumulate batter season stats and expose doubles/triples for display
- normalize stat keys so UIs show extra-base hits

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab967a4908832e8a5efcb29ac577f4