### PR TITLE
Fix path resolution for season simulation script

### DIFF
--- a/scripts/simulate_season_avg.py
+++ b/scripts/simulate_season_avg.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from collections import Counter
 from datetime import date
+from pathlib import Path
 import random
+import sys
+
+# Ensure project root is on the path when running this script directly
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from logic.schedule_generator import generate_mlb_schedule
 from logic.season_simulator import SeasonSimulator


### PR DESCRIPTION
## Summary
- ensure `scripts/simulate_season_avg.py` adds project root to `sys.path` before importing project modules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab9a5adf54832e9e8ed4164791667e