### PR TITLE
Add progress bar to season simulator script

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ diskcache
 certifi>=2024.2.2
 pyinstaller
 bcrypt
+tqdm

--- a/scripts/simulate_season_avg.py
+++ b/scripts/simulate_season_avg.py
@@ -8,6 +8,12 @@ from pathlib import Path
 import random
 import sys
 
+try:
+    from tqdm import tqdm
+except ModuleNotFoundError:  # pragma: no cover
+    def tqdm(iterable, **kwargs):
+        return iterable
+
 # Ensure project root is on the path when running this script directly
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
@@ -77,7 +83,7 @@ def simulate_season_average() -> None:
         return box["home"]["score"], box["away"]["score"]
 
     simulator = SeasonSimulator(schedule, simulate_game=simulate_game)
-    for _ in range(len(simulator.dates)):
+    for _ in tqdm(range(len(simulator.dates)), desc="Simulating season"):
         simulator.simulate_next_day()
 
     averages = {k: totals[k] / total_games for k in STAT_ORDER}


### PR DESCRIPTION
## Summary
- show progress while simulating an MLB season using a tqdm progress bar
- include `tqdm` in development dependencies

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab9b3ed7f8832e95813dbd5ecac9e5