### PR TITLE
Use default extra-base hit probabilities

### DIFF
--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -1189,10 +1189,10 @@ class GameSimulation:
         if rand >= hit_prob:
             return 0
 
-        single = self.config.get("hit1BProb", 100) / 100.0
-        double = self.config.get("hit2BProb", 0) / 100.0
-        triple = self.config.get("hit3BProb", 0) / 100.0
-        hr = self.config.get("hitHRProb", 0) / 100.0
+        single = self.config.hit1BProb / 100.0
+        double = self.config.hit2BProb / 100.0
+        triple = self.config.hit3BProb / 100.0
+        hr = self.config.hitHRProb / 100.0
         power_adj = (batter.ph - 50) / 100.0
         hr *= 1 + power_adj
         double *= 1 + power_adj / 2

--- a/tests/util/pbini_factory.py
+++ b/tests/util/pbini_factory.py
@@ -9,11 +9,14 @@ from logic.pbini_loader import load_pbini
 def make_cfg(**entries: int) -> PlayBalanceConfig:
     """Return a :class:`PlayBalanceConfig` with ``entries`` overridden.
 
-    Only the provided entries are included; unspecified keys fall back to the
-    defaults provided by :class:`PlayBalanceConfig` when accessed.
+    Tests expect deterministic at-bats, so base hit probabilities default to a
+    guaranteed single unless explicitly overridden.  Remaining unspecified keys
+    fall back to :class:`PlayBalanceConfig` defaults when accessed.
     """
 
-    return PlayBalanceConfig.from_dict({"PlayBalance": entries})
+    base_entries = {"hit1BProb": 100, "hit2BProb": 0, "hit3BProb": 0, "hitHRProb": 0}
+    base_entries.update(entries)
+    return PlayBalanceConfig.from_dict({"PlayBalance": base_entries})
 
 
 def load_config(path: Path | None = None) -> PlayBalanceConfig:
@@ -27,6 +30,8 @@ def load_config(path: Path | None = None) -> PlayBalanceConfig:
     path = Path("logic/PBINI.txt") if path is None else Path(path)
     pbini = load_pbini(path)
     cfg = PlayBalanceConfig.from_dict(pbini)
+    # Default to singles only for deterministic tests unless overridden later
+    cfg.values.update({"hit1BProb": 100, "hit2BProb": 0, "hit3BProb": 0, "hitHRProb": 0})
     # The real configuration contains pitch objective weights which would
     # introduce additional randomness via :class:`PitcherAI`.  Tests expect
     # deterministic behaviour so clear all such weights.


### PR DESCRIPTION
## Summary
- Use `PlayBalanceConfig` attribute access in the simulation so missing hit-type entries fall back to built-in defaults
- Adjust test PBINI helpers to default to singles-only for deterministic behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aba2d08fe0832eaf878e4a14099b45