### PR TITLE
Account for pitch break when aiming pitches

### DIFF
--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -940,6 +940,9 @@ class GameSimulation:
                 width, height = self.physics.expand_control_box(width, height, miss_amt)
             x_off = (frac * 2 - 1) * width
             y_off = (frac * 2 - 1) * height
+            exp_dx, exp_dy = self.physics.pitch_break(pitch_type, rand=0.5)
+            x_off -= exp_dx
+            y_off -= exp_dy
             dx, dy = self.physics.pitch_break(pitch_type, rand=loc_r)
             x_off += dx
             y_off += dy


### PR DESCRIPTION
## Summary
- compensate for expected pitch break when computing pitch location
- test break variation and reduced walk rates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acfd93fcb4832ea709b67f5ec9dce5