### PR TITLE
docs: recommend PyPy or python -O for long simulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ Run a full 162-game season and print average box score statistics with:
 python scripts/simulate_season_avg.py
 ```
 
+For lengthy headless simulations consider running under
+[PyPy](https://www.pypy.org/) or invoking CPython with
+`python -O` to enable optimizations and remove asserts. PyPy's JIT can
+significantly speed up the pure Python simulation loop, but some
+CPython-specific C extensions such as `PyQt6` may be unavailable. The
+season script itself depends only on PyPy-friendly modules (e.g. `bcrypt`
+via cffi), so it can be executed without the GUI stack.
+
 ### Building an executable
 Install PyInstaller and create a standalone binary with:
 

--- a/scripts/simulate_season_avg.py
+++ b/scripts/simulate_season_avg.py
@@ -1,4 +1,10 @@
-"""Simulate a full 162-game season and report average box score stats."""
+"""Simulate a full 162-game season and report average box score stats.
+
+For lengthy runs this script can benefit from PyPy's JIT or by invoking
+CPython with ``python -O`` to skip asserts. When using PyPy ensure required
+C extensions such as ``bcrypt`` are available; GUI-focused modules like
+``PyQt6`` are not needed here.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- document using PyPy or CPython `-O` for long-running season simulations
- note PyPy C-extension compatibility in season simulation script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad15e013b8832eb2371d811247865b