### PR TITLE
Allow balls in play to result in hits

### DIFF
--- a/scripts/simulate_season_avg.py
+++ b/scripts/simulate_season_avg.py
@@ -106,7 +106,7 @@ def simulate_season_average(use_tqdm: bool = True) -> None:
     base_states = {tid: build_default_game_state(tid) for tid in teams}
 
     cfg = PlayBalanceConfig.from_file(get_base_dir() / "logic" / "PBINI.txt")
-    cfg.ballInPlayOuts = 1
+    cfg.ballInPlayOuts = 0
     rng = random.Random(42)
 
     totals: Counter[str] = Counter()


### PR DESCRIPTION
## Summary
- stop forcing balls in play to become outs in season average simulation

## Testing
- `pytest`
- `python - <<'PY'
from scripts import simulate_season_avg as s
from datetime import date
from logic.schedule_generator import generate_mlb_schedule
from utils.lineup_loader import build_default_game_state
from utils.team_loader import load_teams
from logic.season_simulator import SeasonSimulator
from logic.simulation import GameSimulation
from logic.playbalance_config import PlayBalanceConfig
from utils.path_utils import get_base_dir
import random
teams=[t.team_id for t in load_teams()][:2]
schedule = generate_mlb_schedule(teams, date(2025,4,1))
schedule = schedule[:1]
base_states = {tid: build_default_game_state(tid) for tid in teams}
cfg = PlayBalanceConfig.from_file(get_base_dir()/'logic'/'PBINI.txt')
cfg.ballInPlayOuts = 0
rng = random.Random(42)
def simulate_game(home_id, away_id):
    home = s.clone_team_state(base_states[home_id])
    away = s.clone_team_state(base_states[away_id])
    sim = GameSimulation(home, away, cfg, rng)
    sim.simulate_game()
    box = s.generate_boxscore(home, away)
    totals = {'Runs': box['home']['score'] + box['away']['score'],
              'Hits': sum(p['h'] for p in box['home']['batting']) + sum(p['h'] for p in box['away']['batting'])}
    return totals
simulator = SeasonSimulator(schedule, simulate_game=lambda h,a: simulate_game(h,a))
simulator.simulate_next_day()
res = simulate_game(teams[0], teams[1])
print(res)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ad33aabc2c832e970692a304459e66