### PR TITLE
Widen strike zone to promote more strikes

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -141,9 +141,9 @@ _DEFAULTS: Dict[str, Any] = {
     "pitchObj00CountFastCenterWeight": 0,
     "pitchObj00CountPlusWeight": 60,
     # Batter AI -------------------------------------------------------
-    "sureStrikeDist": 3,
-    "closeStrikeDist": 4,
-    "closeBallDist": 5,
+    "sureStrikeDist": 4,
+    "closeStrikeDist": 5,
+    "closeBallDist": 4,
     "lookPrimaryType00CountAdjust": 0,
     "lookPrimaryType01CountAdjust": 0,
     "lookPrimaryType02CountAdjust": 0,

--- a/tests/test_playbalance_config.py
+++ b/tests/test_playbalance_config.py
@@ -16,7 +16,7 @@ def test_playbalance_config_defaults():
     assert cfg.pitchObj00CountEstablishWeight == 0
 
     # Batter AI defaults
-    assert cfg.sureStrikeDist == 3
+    assert cfg.sureStrikeDist == 4
     assert cfg.lookPrimaryType00CountAdjust == 0
     assert cfg.lookBestType30CountAdjust == 15
 


### PR DESCRIPTION
## Summary
- Expand default strike-zone thresholds to favor more swings by raising `sureStrikeDist`, increasing `closeStrikeDist`, and tightening `closeBallDist`.
- Update play balance config unit test for new strike-zone defaults.

## Testing
- `pytest`
- `timeout 180 python scripts/simulate_season_avg.py --disable-tqdm` *(timeout)*
- Simulated 50 games to estimate walks per game.


------
https://chatgpt.com/codex/tasks/task_e_68ad36a201e8832e940e9d40ab42c6ef