### PR TITLE
Align hit probabilities with MLB distribution

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -122,11 +122,11 @@ _DEFAULTS: Dict[str, Any] = {
     "throwSpeedOFBase": 52,
     "throwSpeedOFDistPct": 3,
     "throwSpeedOFMax": 92,
-    # Hit type distribution (percentages summing to ~100)
+    # Hit type distribution reflecting MLB averages
     "hit1BProb": 64,
-    "hit2BProb": 22,
-    "hit3BProb": 3,
-    "hitHRProb": 18,
+    "hit2BProb": 20,
+    "hit3BProb": 2,
+    "hitHRProb": 14,
     "ballInPlayOuts": 0,
     # Pitcher AI ------------------------------------------------------
     "pitchRatVariationCount": 1,


### PR DESCRIPTION
## Summary
- Tune default hit probabilities to reflect MLB breakdown (64% singles, 20% doubles, 2% triples, 14% HR)

## Testing
- `pytest`
- `python scripts/simulate_season_avg.py --disable-tqdm` *(fails: Can't get local object 'simulate_season_average.<locals>.simulate_game')*

------
https://chatgpt.com/codex/tasks/task_e_68ad3a4bd0d8832ea4d659976be3812b