### PR TITLE
Fix season simulation game counting

### DIFF
--- a/logic/season_simulator.py
+++ b/logic/season_simulator.py
@@ -110,8 +110,11 @@ class SeasonSimulator:
                 if isinstance(result, tuple):
                     if len(result) >= 2:
                         game["result"] = f"{result[0]}-{result[1]}"
-                    if len(result) >= 3 and isinstance(result[2], str):
-                        game["boxscore_html"] = result[2]
+                    if len(result) >= 3:
+                        if isinstance(result[2], str):
+                            game["boxscore_html"] = result[2]
+                        else:
+                            game["extra"] = result[2]
                 if self.after_game is not None:
                     try:
                         self.after_game(game)
@@ -123,8 +126,11 @@ class SeasonSimulator:
                 if isinstance(result, tuple):
                     if len(result) >= 2:
                         game["result"] = f"{result[0]}-{result[1]}"
-                    if len(result) >= 3 and isinstance(result[2], str):
-                        game["boxscore_html"] = result[2]
+                    if len(result) >= 3:
+                        if isinstance(result[2], str):
+                            game["boxscore_html"] = result[2]
+                        else:
+                            game["extra"] = result[2]
                 if self.after_game is not None:
                     try:
                         self.after_game(game)


### PR DESCRIPTION
## Summary
- Preserve additional per-game data in `SeasonSimulator` so callbacks can access box scores
- Rework season averaging script to collect stats via callback and track progress by total games

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae1de33120832ea1cb5d27bd2aed97