### PR TITLE
Reduce strike rate and improve batter discipline

### DIFF
--- a/logic/batter_ai.py
+++ b/logic/batter_ai.py
@@ -329,7 +329,12 @@ class BatterAI:
                 "close ball": 0.25,
                 "sure ball": 0.0,
             }
-            swing = rand_type < swing_probs[p_class]
+            swing_prob = swing_probs[p_class]
+            if p_class in {"close ball", "sure ball"}:
+                swing_prob = max(
+                    0.0, swing_prob - getattr(batter, "ch", 0) / 400.0
+                )
+            swing = rand_type < swing_prob
 
         if swing and p_class in {"close ball", "sure ball"}:
             disc_roll = (random_value + 0.99) % 1

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -931,7 +931,7 @@ class GameSimulation:
             pitch_speed = self.physics.pitch_velocity(
                 pitch_type, pitcher.arm, rand=loc_r
             )
-            control_chance = pitcher.control / 100.0
+            control_chance = pitcher.control / 100.0 * 0.9  # encourage more balls
             width, height = self.physics.control_box(pitch_type)
             frac = loc_r
             miss_amt = 0.0

--- a/tests/test_batter_ai.py
+++ b/tests/test_batter_ai.py
@@ -255,6 +255,53 @@ def test_discipline_ratings_increase_takes():
     assert takes_high > takes_low
 
 
+def test_high_ch_batters_take_close_balls():
+    cfg = make_cfg(
+        idRatingBase=0,
+        idRatingCHPct=0,
+        idRatingExpPct=0,
+        idRatingPitchRatPct=0,
+        disciplineRatingBase=0,
+        disciplineRatingCHPct=0,
+        disciplineRatingExpPct=0,
+        disciplineRatingPct=100,
+    )
+    ai = BatterAI(cfg)
+    pitcher = make_pitcher("p1")
+
+    batter_low = make_player("low")
+    batter_low.ch = 0
+    batter_high = make_player("high")
+    batter_high.ch = 100
+
+    values = [0.0, 0.1, 0.2, 0.3, 0.4]
+    takes_low = 0
+    takes_high = 0
+    for rv in values:
+        swing_low, _ = ai.decide_swing(
+            batter_low,
+            pitcher,
+            pitch_type="fb",
+            balls=0,
+            strikes=0,
+            dist=5,
+            random_value=rv,
+        )
+        swing_high, _ = ai.decide_swing(
+            batter_high,
+            pitcher,
+            pitch_type="fb",
+            balls=0,
+            strikes=0,
+            dist=5,
+            random_value=rv,
+        )
+        takes_low += int(not swing_low)
+        takes_high += int(not swing_high)
+
+    assert takes_high > takes_low
+
+
 @pytest.mark.parametrize(
     "base,expected",
     [

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -382,7 +382,7 @@ def test_pitch_aim_uses_control_box_dimensions(ptype, cfg_key, width, height):
     batter = make_player("b")
     away = TeamState(lineup=[batter], bench=[], pitchers=[make_pitcher("ap")])
     home = TeamState(lineup=[make_player("h1")], bench=[], pitchers=[pitcher])
-    rng = MockRandom([0.9, 0.0])
+    rng = MockRandom([0.899, 0.0])
     sim = GameSimulation(home, away, cfg, rng)
     tracker = TrackingBatterAI(cfg)
     sim.batter_ai = tracker
@@ -509,7 +509,8 @@ def test_missed_control_expands_box_and_reduces_velocity():
     sim.batter_ai = tracker
     with pytest.raises(CaptureDist):
         sim.play_at_bat(away, home)
-    miss_amt = (0.9 - 0.5) * 100
+    control_chance = pitcher.control / 100.0 * 0.9
+    miss_amt = (0.9 - control_chance) * 100
     inc = miss_amt * cfg.controlBoxIncreaseEffCOPct / 100
     expected_dist = int(round((max(2, 3) + inc) * 0.8))
     assert tracker.last_dist == expected_dist

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -114,7 +114,7 @@ def test_pinch_hitter_not_used():
     sim.play_at_bat(away, home)
     assert away.lineup[0].player_id == "start"
     stats = away.lineup_stats["start"]
-    assert stats.so == 1
+    assert stats.bb == 1
 
 
 def test_pinch_hit_need_hit_used():


### PR DESCRIPTION
## Summary
- lower pitcher control to yield more balls
- scale ball swing probability by batter contact
- cover high-CH takes and update tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae2154395c832e97c56dfdee978d6c