### PR TITLE
Bias pitcher AI toward outside pitches when ahead in count

### DIFF
--- a/logic/pitcher_ai.py
+++ b/logic/pitcher_ai.py
@@ -148,12 +148,21 @@ class PitcherAI:
         # real game uses weighted randomness for this selection so we gather the
         # weights for all objectives and perform a single weighted roll.
         prefix = f"pitchObj{balls}{strikes}Count"
+        outside_weight = self.config.get(prefix + "OutsideWeight", 0)
+        if strikes > balls:
+            outside_weight *= 2
         weights = [
             ("establish", self.config.get(prefix + "EstablishWeight", 0)),
-            ("outside", self.config.get(prefix + "OutsideWeight", 0)),
+            ("outside", outside_weight),
             ("best", self.config.get(prefix + "BestWeight", 0)),
-            ("best_center", self.config.get(prefix + "BestCenterWeight", 0)),
-            ("fast_center", self.config.get(prefix + "FastCenterWeight", 0)),
+            (
+                "best_center",
+                self.config.get(prefix + "BestCenterWeight", 0),
+            ),
+            (
+                "fast_center",
+                self.config.get(prefix + "FastCenterWeight", 0),
+            ),
             ("plus", self.config.get(prefix + "PlusWeight", 0)),
         ]
 

--- a/tests/test_pitcher_ai.py
+++ b/tests/test_pitcher_ai.py
@@ -143,3 +143,24 @@ def test_pitch_variation_cached_per_game():
     pitch4, _ = ai.select_pitch(pitcher)
     assert pitch3 == pitch4 == "fb"
 
+
+def test_ahead_count_prefers_outside():
+    pitcher = make_pitcher("p4")
+    cfg = make_cfg(
+        pitchRatVariationCount=0,
+        pitchObj02CountOutsideWeight=10,
+        pitchObj02CountBestWeight=10,
+        pitchObj20CountOutsideWeight=10,
+        pitchObj20CountBestWeight=10,
+    )
+    ai = PitcherAI(cfg, SeqRandom([], floats=[0.5, 0.5]))
+
+    ai.new_game()
+    _, obj1 = ai.select_pitch(pitcher, balls=0, strikes=2)
+
+    ai.new_game()
+    _, obj2 = ai.select_pitch(pitcher, balls=2, strikes=0)
+
+    assert obj1 == "outside"
+    assert obj2 == "best"
+


### PR DESCRIPTION
## Summary
- Increase probability of choosing the `outside` pitch objective when the pitcher has more strikes than balls
- Add unit test ensuring pitchers prefer outside pitches in favorable counts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae5fb25c3c832eb039d8319122c272