### PR TITLE
Display MLB averages and differences in season simulation output

### DIFF
--- a/scripts/simulate_season_avg.py
+++ b/scripts/simulate_season_avg.py
@@ -13,6 +13,7 @@ from copy import deepcopy
 from datetime import date
 from pathlib import Path
 import argparse
+import csv
 import os
 import random
 import sys
@@ -159,9 +160,25 @@ def simulate_season_average(use_tqdm: bool = True) -> None:
 
     averages = {k: totals[k] / total_games for k in STAT_ORDER}
 
+    csv_path = (
+        get_base_dir()
+        / "data"
+        / "MLB_avg"
+        / "mlb_avg_boxscore_2020_2024_both_teams.csv"
+    )
+    with csv_path.open(newline="") as f:
+        row = next(csv.DictReader(f))
+    mlb_averages = {stat: float(val) for stat, val in row.items() if stat}
+    diffs = {k: averages[k] - mlb_averages.get(k, 0.0) for k in STAT_ORDER}
+
     print("Average box score per game (both teams):")
     for key in STAT_ORDER:
-        print(f"{key}: {averages[key]:.2f}")
+        mlb_val = mlb_averages[key]
+        sim_val = averages[key]
+        diff = diffs[key]
+        print(
+            f"{key}: MLB {mlb_val:.2f}, Sim {sim_val:.2f}, Diff {diff:+.2f}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_simulation_averages.py
+++ b/tests/test_simulation_averages.py
@@ -33,13 +33,17 @@ def test_simulated_averages_close_to_mlb(monkeypatch):
     with contextlib.redirect_stdout(buf):
         ssa.simulate_season_average(use_tqdm=False)
     lines = [
-        line for line in buf.getvalue().splitlines() if ":" in line and line.split(":", 1)[1].strip()
+        line
+        for line in buf.getvalue().splitlines()
+        if ":" in line and line.split(":", 1)[0] in ssa.STAT_ORDER
     ]
 
     simulated = {}
     for line in lines:
-        stat, value = line.split(":", 1)
-        simulated[stat.strip()] = float(value.strip())
+        stat, rest = line.split(":", 1)
+        parts = [p.strip() for p in rest.split(",")]
+        sim_part = next(p for p in parts if p.startswith("Sim"))
+        simulated[stat.strip()] = float(sim_part.split()[1])
 
     # Load MLB benchmark averages from CSV
     csv_path = (


### PR DESCRIPTION
## Summary
- Print MLB benchmark averages alongside simulated results in `simulate_season_avg`
- Compute and display per-stat differences between simulation and MLB averages
- Update tests to parse new output format

## Testing
- `pytest` *(fails: command not found; attempted installation but proxy blocked access)*

------
https://chatgpt.com/codex/tasks/task_e_68ae61518c18832eb4e2821b975a05ca