### PR TITLE
Enable ball-in-play outs by default

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -127,7 +127,7 @@ _DEFAULTS: Dict[str, Any] = {
     "hit2BProb": 20,
     "hit3BProb": 2,
     "hitHRProb": 14,
-    "ballInPlayOuts": 0,
+    "ballInPlayOuts": 1,
     # Pitcher AI ------------------------------------------------------
     "pitchRatVariationCount": 1,
     "pitchRatVariationFaces": 3,

--- a/scripts/simulate_season_avg.py
+++ b/scripts/simulate_season_avg.py
@@ -107,7 +107,7 @@ def simulate_season_average(use_tqdm: bool = True) -> None:
     base_states = {tid: build_default_game_state(tid) for tid in teams}
 
     cfg = PlayBalanceConfig.from_file(get_base_dir() / "logic" / "PBINI.txt")
-    cfg.ballInPlayOuts = 0
+    cfg.ballInPlayOuts = 1
     rng = random.Random(42)
 
     totals: Counter[str] = Counter()


### PR DESCRIPTION
## Summary
- Enable ball-in-play outs by default in play balance configuration
- Ensure season simulation script does not disable ball-in-play outs

## Testing
- `pytest`
- Simulated 50 games with ball-in-play outs off vs on to confirm strikeouts drop

------
https://chatgpt.com/codex/tasks/task_e_68ae8beed904832e9aec5011206726ad