### PR TITLE
Add foul ball handling with rating-based foul probability

### DIFF
--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -1050,6 +1050,12 @@ class GameSimulation:
                             defense, inning=inning, run_diff=run_diff, home_team=home_team
                         )
                         return outs
+                    foul_chance = self._foul_probability(batter, pitcher)
+                    if self.rng.random() < foul_chance:
+                        pitcher_state.strikes_thrown += 1
+                        if strikes < 2:
+                            strikes += 1
+                        continue
                     if self.config.get("ballInPlayOuts", False):
                         if dist <= 3:
                             pitcher_state.strikes_thrown += 1
@@ -1162,6 +1168,13 @@ class GameSimulation:
     # ------------------------------------------------------------------
     # Swing outcome
     # ------------------------------------------------------------------
+    def _foul_probability(self, batter: Player, pitcher: Pitcher) -> float:
+        """Return foul ball probability based on batter and pitcher ratings."""
+
+        base = 0.05
+        prob = base + (getattr(batter, "ch", 50) + getattr(pitcher, "movement", 50)) / 1000.0
+        return max(0.05, min(0.5, prob))
+
     def _swing_result(
         self,
         batter: Player,

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -114,7 +114,7 @@ def test_swing_result_respects_bat_speed():
     batter1 = make_player("b1")
     home1 = TeamState(lineup=[make_player("h1")], bench=[], pitchers=[make_pitcher("hp1")])
     away1 = TeamState(lineup=[batter1], bench=[], pitchers=[make_pitcher("ap1")])
-    rng1 = MockRandom([0.0, 0.4, 0.0, 0.4, 0.0, 0.4])
+    rng1 = MockRandom([0.0, 0.4, 0.9, 0.0, 0.4, 0.9, 0.0, 0.4, 0.9])
     sim1 = GameSimulation(home1, away1, cfg_slow, rng1)
     outs1 = sim1.play_at_bat(away1, home1)
     assert outs1 == 1
@@ -132,7 +132,7 @@ def test_swing_result_respects_bat_speed():
     batter2 = make_player("b2")
     home2 = TeamState(lineup=[make_player("h2")], bench=[], pitchers=[make_pitcher("hp2")])
     away2 = TeamState(lineup=[batter2], bench=[], pitchers=[make_pitcher("ap2")])
-    rng2 = MockRandom([0.0, 0.0, 0.9, 0.1])
+    rng2 = MockRandom([0.0, 0.0, 0.9, 0.1, 0.9])
     sim2 = GameSimulation(home2, away2, cfg_fast, rng2)
     outs2 = sim2.play_at_bat(away2, home2)
     assert outs2 == 0

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -477,9 +477,9 @@ def test_run_tracking_and_boxscore():
     away.lineup_stats[runner.player_id] = runner_state
     away.bases[2] = runner_state
 
-    sim = GameSimulation(home, away, cfg, MockRandom([0.0, 0.0, 0.0, 0.9]))
+    sim = GameSimulation(home, away, cfg, MockRandom([0.0, 0.0, 0.9, 0.0, 0.9]))
     outs = sim.play_at_bat(away, home)  # run scores, runner thrown out
-    strike_seq = [0.0, 0.9, 0.0, 0.9, 0.0, 0.9]
+    strike_seq = [0.0, 0.9, 0.9] * 4
     sim = GameSimulation(home, away, cfg, MockRandom(strike_seq))
     outs += sim.play_at_bat(away, home)  # strikeout
     sim = GameSimulation(home, away, cfg, MockRandom(strike_seq))
@@ -546,7 +546,7 @@ def test_pitch_control_affects_location():
         lineup=[make_player("h1")], bench=[], pitchers=[make_pitcher("hp", control=70)]
     )
     away_high = TeamState(lineup=[batter1], bench=[], pitchers=[make_pitcher("ap")])
-    rng_high = MockRandom([0.4, 0.9, 0.4, 0.9, 0.4, 0.9])
+    rng_high = MockRandom([0.4, 0.9, 0.9, 0.4, 0.9, 0.9, 0.4, 0.9, 0.9])
     sim_high = GameSimulation(home_high, away_high, cfg, rng_high)
     outs_high = sim_high.play_at_bat(away_high, home_high)
     assert outs_high == 1
@@ -556,7 +556,7 @@ def test_pitch_control_affects_location():
         lineup=[make_player("h1")], bench=[], pitchers=[make_pitcher("hp", control=30)]
     )
     away_low = TeamState(lineup=[batter2], bench=[], pitchers=[make_pitcher("ap")])
-    rng_low = MockRandom([0.99, 0.99, 0.99, 0.99, 0.99, 0.99, 0.99, 0.99])
+    rng_low = MockRandom([0.99, 0.99, 0.99] * 4)
     sim_low = GameSimulation(home_low, away_low, cfg, rng_low)
     outs_low = sim_low.play_at_bat(away_low, home_low)
     stats_low = away_low.lineup_stats[batter2.player_id]
@@ -627,7 +627,25 @@ def test_fielding_stats_tracking():
     offense.lineup_stats[runner.player_id] = runner_state
     offense.bases[0] = runner_state
     offense.base_pitchers[0] = defense.current_pitcher_state
-    rng = MockRandom([0.9, 0.0, 0.9, 0.0, 0.9, 0.0, 0.9])
+    rng = MockRandom(
+        [
+            0.9,
+            0.0,
+            0.9,
+            0.0,
+            0.9,
+            0.0,
+            0.0,
+            0.9,
+            0.9,
+            0.0,
+            0.9,
+            0.9,
+            0.0,
+            0.9,
+            0.9,
+        ]
+    )
     sim = GameSimulation(defense, offense, cfg, rng)
     res = sim._attempt_steal(offense, defense, defense.current_pitcher_state.player, force=True)
     assert res is False

--- a/tests/test_simulation_foul_balls.py
+++ b/tests/test_simulation_foul_balls.py
@@ -1,0 +1,65 @@
+import csv
+import random
+from pathlib import Path
+
+import logic.simulation as sim
+from logic.simulation import GameSimulation, generate_boxscore
+from logic.playbalance_config import PlayBalanceConfig
+from scripts.simulate_season_avg import clone_team_state
+from utils.lineup_loader import build_default_game_state
+from utils.path_utils import get_base_dir
+from utils.team_loader import load_teams
+
+
+def _simulate(monkeypatch, foul_lambda=None, games: int = 20):
+    teams = [t.team_id for t in load_teams()][:2]
+    base_states = {tid: build_default_game_state(tid) for tid in teams}
+
+    cfg = PlayBalanceConfig.from_file(get_base_dir() / "logic" / "PBINI.txt")
+    cfg.ballInPlayOuts = 0
+
+    rng = random.Random(42)
+    total_pitches = 0
+    total_strikeouts = 0
+
+    with monkeypatch.context() as m:
+        m.setattr(sim, "save_stats", lambda players, teams: None)
+        if foul_lambda is not None:
+            m.setattr(GameSimulation, "_foul_probability", foul_lambda)
+
+        for _ in range(games):
+            home = clone_team_state(base_states[teams[0]])
+            away = clone_team_state(base_states[teams[1]])
+            game = GameSimulation(home, away, cfg, rng)
+            game.simulate_game()
+            box = generate_boxscore(home, away)
+            for side in ("home", "away"):
+                batting = box[side]["batting"]
+                pitching = box[side]["pitching"]
+                total_strikeouts += sum(p["so"] for p in batting)
+                total_pitches += sum(p["pitches"] for p in pitching)
+
+    return total_pitches / games, total_strikeouts / games
+
+
+def test_fouls_increase_pitches_reduce_strikeouts(monkeypatch):
+    no_foul_p, no_foul_k = _simulate(monkeypatch, foul_lambda=lambda self, b, p: 0.0)
+    foul_p, foul_k = _simulate(monkeypatch)
+
+    csv_path = (
+        Path(__file__).resolve().parents[1]
+        / "data"
+        / "MLB_avg"
+        / "mlb_avg_boxscore_2020_2024_both_teams.csv"
+    )
+    with csv_path.open(newline="") as f:
+        row = next(csv.DictReader(f))
+    mlb_pitch = float(row["TotalPitchesThrown"])
+    mlb_ks = float(row["Strikeouts"])
+
+    assert foul_p > no_foul_p
+    assert abs(foul_p - mlb_pitch) < abs(no_foul_p - mlb_pitch)
+
+    assert foul_k < no_foul_k
+    assert abs(foul_k - mlb_ks) < abs(no_foul_k - mlb_ks)
+


### PR DESCRIPTION
## Summary
- Introduce foul-ball branch when swings make contact but no hit, only adding strikes below two and always recording the pitch
- Calculate foul chance from batter contact and pitcher movement ratings
- Add simulation test ensuring foul balls boost pitch counts and reduce strikeouts toward MLB averages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae931dff80832e9a7d90c0432ba44f