### PR TITLE
Add basic ball flight physics and fielding integration

### DIFF
--- a/logic/field_geometry.py
+++ b/logic/field_geometry.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from math import sqrt
+
+# Coordinates are measured in feet with home plate at (0, 0).
+# The x-axis extends toward first base and the y-axis toward third base.
+HOME = (0.0, 0.0)
+FIRST_BASE = (90.0, 0.0)
+SECOND_BASE = (90.0, 90.0)
+THIRD_BASE = (0.0, 90.0)
+PITCHER = (60.5 / sqrt(2), 60.5 / sqrt(2))
+
+# Approximate default defensive positions.
+DEFAULT_POSITIONS = {
+    "P": PITCHER,
+    "C": (-5.0, 0.0),
+    "1B": FIRST_BASE,
+    "2B": (100.0, 40.0),
+    "3B": THIRD_BASE,
+    "SS": (40.0, 100.0),
+    "LF": (0.0, 300.0),
+    "CF": (283.0, 283.0),
+    "RF": (300.0, 0.0),
+}
+
+__all__ = [
+    "HOME",
+    "FIRST_BASE",
+    "SECOND_BASE",
+    "THIRD_BASE",
+    "PITCHER",
+    "DEFAULT_POSITIONS",
+]


### PR DESCRIPTION
## Summary
- add projectile-based launch_vector and landing_point helpers in Physics
- introduce field_geometry module with constant coordinates and default defensive positions
- extend GameSimulation swing_result to compute ball landing, fielder run times and catch probability

## Testing
- `pycodestyle logic/physics.py logic/field_geometry.py logic/simulation.py` *(fails: command not found)*
- `pytest` *(fails: interrupted after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_68ae97a78140832ea31c51671154edb1