### PR TITLE
Add physics and simulation tests

### DIFF
--- a/tests/test_coordinate_simulation.py
+++ b/tests/test_coordinate_simulation.py
@@ -1,0 +1,77 @@
+import math
+import random
+
+import pytest
+
+from logic.physics import Physics
+from logic.fielding_ai import FieldingAI
+from logic.playbalance_config import PlayBalanceConfig
+
+
+def make_config() -> PlayBalanceConfig:
+    cfg = PlayBalanceConfig()
+    cfg.catchBaseChance = 90
+    cfg.catchFADiv = 10
+    cfg.catchChanceDiving = -40
+    cfg.catchChanceLeaping = -15
+    cfg.catchChanceLessThan1Sec = -10
+    cfg.catchChancePerTenth = -1
+    cfg.catchChancePitcherAdjust = -10
+    cfg.catchChanceCatcherAdjust = 10
+    cfg.catchChanceLeftFieldAdjust = 5
+    cfg.catchChanceCenterFieldAdjust = 5
+    cfg.catchChanceRightFieldAdjust = 5
+    cfg.automaticCatchDist = 15
+    cfg.generalSlop = 0
+    cfg.shouldBeCaughtSlop = 0
+    cfg.couldBeCaughtSlop = 0
+    return cfg
+
+
+def test_routine_fly_caught():
+    cfg = make_config()
+    physics = Physics(cfg)
+    ai = FieldingAI(cfg, random.Random(0))
+    vx, vy, vz = physics.launch_vector(50, 50, 50)
+    x, y, hang = physics.landing_point(vx, vy, vz)
+    fielder = (150.0, 0.0)
+    distance = math.hypot(fielder[0] - x, fielder[1] - y)
+    speed = physics.player_speed(50)
+    run_time = distance / speed
+    action = ai.catch_action(hang, run_time, position="CF", distance=distance)
+    assert action == "catch"
+    prob = ai.catch_probability("CF", 80, hang, action)
+    assert prob == pytest.approx(1.0)
+    assert ai.resolve_fly_ball("CF", 80, hang, action)
+
+
+def test_diving_attempt_fails():
+    cfg = make_config()
+    cfg.couldBeCaughtSlop = -18
+    physics = Physics(cfg)
+    ai = FieldingAI(cfg, random.Random(0))
+    vx, vy, vz = physics.launch_vector(80, 30, 80)
+    x, y, hang = physics.landing_point(vx, vy, vz)
+    fielder = (85.0, 40.0)
+    distance = math.hypot(fielder[0] - x, fielder[1] - y)
+    speed = physics.player_speed(50)
+    run_time = distance / speed
+    action = ai.catch_action(hang, run_time, position="LF", distance=distance)
+    assert action == "dive"
+    prob = ai.catch_probability("LF", 50, hang, action)
+    assert prob == pytest.approx(0.46, abs=0.01)
+    assert ai.resolve_fly_ball("LF", 50, hang, action) is False
+
+
+def test_distant_ball_no_attempt():
+    cfg = make_config()
+    physics = Physics(cfg)
+    ai = FieldingAI(cfg)
+    vx, vy, vz = physics.launch_vector(80, 30, 80)
+    x, y, hang = physics.landing_point(vx, vy, vz)
+    fielder = (150.0, 0.0)
+    distance = math.hypot(fielder[0] - x, fielder[1] - y)
+    speed = physics.player_speed(50)
+    run_time = distance / speed
+    action = ai.catch_action(hang, run_time, position="LF", distance=distance)
+    assert action == "no_attempt"

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -83,6 +83,37 @@ def make_pitcher(pid: str) -> Pitcher:
     )
 
 
+@pytest.mark.parametrize(
+    "ph,gf,pl,vx,vy,vz",
+    [
+        (50, 50, 50, 108.33, 0.0, 19.10),
+        (80, 30, 80, 117.54, 59.89, 4.61),
+    ],
+)
+def test_launch_vector_returns_expected_components(ph, gf, pl, vx, vy, vz):
+    physics = Physics(make_cfg(), random.Random(0))
+    result = physics.launch_vector(ph, gf, pl)
+    assert result[0] == pytest.approx(vx, abs=0.01)
+    assert result[1] == pytest.approx(vy, abs=0.01)
+    assert result[2] == pytest.approx(vz, abs=0.01)
+
+
+@pytest.mark.parametrize(
+    "ph,gf,pl,x,y,t",
+    [
+        (50, 50, 50, 143.84, 0.0, 1.3278),
+        (80, 30, 80, 70.31, 35.82, 0.5981),
+    ],
+)
+def test_landing_point_returns_expected_coordinates(ph, gf, pl, x, y, t):
+    physics = Physics(make_cfg(), random.Random(0))
+    vx, vy, vz = physics.launch_vector(ph, gf, pl)
+    lx, ly, ht = physics.landing_point(vx, vy, vz)
+    assert lx == pytest.approx(x, abs=0.01)
+    assert ly == pytest.approx(y, abs=0.01)
+    assert ht == pytest.approx(t, abs=0.001)
+
+
 def test_swing_angle_varies_with_range():
     cfg = make_cfg(
         swingAngleTenthDegreesBase=100,

--- a/tests/test_simulation_averages.py
+++ b/tests/test_simulation_averages.py
@@ -60,3 +60,35 @@ def test_simulated_averages_close_to_mlb(monkeypatch):
     for stat, mlb_val in benchmarks.items():
         sim_val = simulated[stat]
         assert math.isclose(sim_val, mlb_val, rel_tol=3.0), stat
+
+    # Derived rate statistics using simple approximations
+    hits = simulated["Hits"]
+    doubles = simulated["Doubles"]
+    triples = simulated["Triples"]
+    homers = simulated["HomeRuns"]
+
+    mlb_hits = benchmarks["Hits"]
+    mlb_doubles = benchmarks["Doubles"]
+    mlb_triples = benchmarks["Triples"]
+    mlb_homers = benchmarks["HomeRuns"]
+
+    ab = hits + 54
+    mlb_ab = mlb_hits + 54
+    singles = hits - doubles - triples - homers
+    mlb_singles = mlb_hits - mlb_doubles - mlb_triples - mlb_homers
+    total_bases = singles + 2 * doubles + 3 * triples + 4 * homers
+    mlb_total_bases = mlb_singles + 2 * mlb_doubles + 3 * mlb_triples + 4 * mlb_homers
+
+    ba = hits / ab if ab else 0.0
+    mlb_ba = mlb_hits / mlb_ab if mlb_ab else 0.0
+    slg = total_bases / ab if ab else 0.0
+    mlb_slg = mlb_total_bases / mlb_ab if mlb_ab else 0.0
+    hr_rate = homers / ab if ab else 0.0
+    mlb_hr_rate = mlb_homers / mlb_ab if mlb_ab else 0.0
+
+    for stat, sim_val, mlb_val in [
+        ("BA", ba, mlb_ba),
+        ("SLG", slg, mlb_slg),
+        ("HR_rate", hr_rate, mlb_hr_rate),
+    ]:
+        assert math.isclose(sim_val, mlb_val, rel_tol=3.0), stat


### PR DESCRIPTION
## Summary
- add unit tests for launch_vector and landing_point physics helpers
- add coordinate simulation integration tests for fielder outcomes
- verify season simulation averages against MLB benchmarks including BA/SLG/HR rate

## Testing
- `pytest tests/test_coordinate_simulation.py tests/test_physics.py tests/test_simulation_averages.py`

------
https://chatgpt.com/codex/tasks/task_e_68aea4c0b26c832eb3d0bcd8498ebb69