### PR TITLE
Fix recursion in PlayBalanceConfig.__getattr__

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -560,7 +560,8 @@ class PlayBalanceConfig:
         return self.values.get(key, default)
 
     def __getattr__(self, item: str) -> Any:  # pragma: no cover - simple delegation
-        return self.values.get(item, _DEFAULTS.get(item, 0))
+        values = self.__dict__.get("values", {})
+        return values.get(item, _DEFAULTS.get(item, 0))
 
     def __setattr__(self, key: str, value: Any) -> None:  # pragma: no cover - simple
         if key == "values":


### PR DESCRIPTION
## Summary
- prevent infinite recursion when PlayBalanceConfig falls back to defaults

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0fd98f58c832ea8b7781f831ab4ca