### PR TITLE
feat: scale contact quality

### DIFF
--- a/logic/batter_ai.py
+++ b/logic/batter_ai.py
@@ -344,10 +344,17 @@ class BatterAI:
 
         if not swing:
             contact = 0.0
-        elif type_id and loc_id and time_id:
-            contact = timing_quality
         else:
-            contact = 0.0
+            success = int(type_id) + int(loc_id) + int(time_id)
+            if success == 0:
+                contact = 0.0
+            else:
+                ch_factor = getattr(batter, "ch", 0) / 100.0
+                weights = [
+                    1.0 if ident else ch_factor * 0.5
+                    for ident in (type_id, loc_id, time_id)
+                ]
+                contact = timing_quality * sum(weights) / 3.0
 
         if swing and not self.can_adjust_swing(
             batter, dx, dy, swing_type=swing_type

--- a/tests/test_batter_ai.py
+++ b/tests/test_batter_ai.py
@@ -80,7 +80,7 @@ def test_primary_look_adjust_increases_swings():
         random_value=0.4,
     )
     assert swing is True
-    assert contact == 0.0
+    assert contact == pytest.approx(0.25666666666666665)
 
 
 def test_best_look_adjust_increases_swings():
@@ -110,7 +110,7 @@ def test_best_look_adjust_increases_swings():
         random_value=0.4,
     )
     assert swing is True
-    assert contact == 0.0
+    assert contact == pytest.approx(0.25666666666666665)
 
 
 def test_ch_and_exp_ratings_increase_identification():
@@ -191,8 +191,8 @@ def test_pitch_rating_makes_identification_harder():
         random_value=0.9,
     )
 
-    assert swing_e is True and contact_e > 0
-    assert swing_h is True and contact_h == 0.0
+    assert swing_e is True and contact_e > contact_h
+    assert swing_h is True and contact_h > 0
 
 
 def test_pitch_classification():


### PR DESCRIPTION
## Summary
- allow partial pitch identification to yield reduced contact quality, weighted by batter's contact rating
- adjust batter AI tests for nuanced contact outcomes

## Testing
- `pytest tests/test_batter_ai.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1318514bc832ea603073550176826