### PR TITLE
Incorporate swing angles into batted-ball trajectories

### DIFF
--- a/logic/physics.py
+++ b/logic/physics.py
@@ -419,19 +419,29 @@ class Physics:
     # ------------------------------------------------------------------
     # Batted ball trajectory helpers
     # ------------------------------------------------------------------
-    def launch_vector(self, ph: int, gf: int, pl: int) -> tuple[float, float, float]:
+    def launch_vector(
+        self,
+        ph: int,
+        pl: int,
+        swing_angle: float,
+        vertical_hit_angle: float,
+    ) -> tuple[float, float, float]:
         """Return velocity components for a batted ball.
 
-        ``ph`` is the batter's power rating, ``gf`` their ground/fly
-        tendency and ``pl`` the pull tendency.  The calculation keeps the
-        numbers intentionally small and deterministic and is not a realistic
-        model of actual exit velocities.
+        ``ph`` is the batter's power rating and ``pl`` their pull tendency.
+        ``swing_angle`` represents the angle of the bat through the zone while
+        ``vertical_hit_angle`` is the rolled launch angle offset.  Both angles
+        are combined with a power based adjustment allowing strong hitters to
+        generate higher trajectories.  The calculation keeps the numbers small
+        and deterministic and is not a realistic model of actual exit
+        velocities.
         """
 
         speed_mph = 50 + ph * 0.5
         speed_fps = speed_mph * 5280 / 3600
 
-        vert_angle = -10 + gf * 0.4
+        power_adjust = (ph - 50) * 0.1
+        vert_angle = swing_angle + vertical_hit_angle + power_adjust
         horiz_angle = -45 + pl * 0.9
 
         v_rad = math.radians(vert_angle)

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -1246,8 +1246,9 @@ class GameSimulation:
 
         vx, vy, vz = self.physics.launch_vector(
             getattr(batter, "ph", 50),
-            getattr(batter, "gf", 50),
             getattr(batter, "pl", 50),
+            swing_angle,
+            vert_angle,
         )
         x, y, hang_time = self.physics.landing_point(vx, vy, vz)
         landing_dist = math.hypot(x, y)
@@ -1278,11 +1279,11 @@ class GameSimulation:
             if self.rng.random() < prob:
                 return 0
 
-        if landing_dist >= 360:
+        if landing_dist >= 380:
             return 4
-        if landing_dist >= 250:
+        if landing_dist >= 300:
             return 3
-        if landing_dist >= 160:
+        if landing_dist >= 200:
             return 2
         return 1
 

--- a/tests/test_coordinate_simulation.py
+++ b/tests/test_coordinate_simulation.py
@@ -30,9 +30,11 @@ def make_config() -> PlayBalanceConfig:
 
 def test_routine_fly_caught():
     cfg = make_config()
-    physics = Physics(cfg)
+    physics = Physics(cfg, random.Random(0))
     ai = FieldingAI(cfg, random.Random(0))
-    vx, vy, vz = physics.launch_vector(50, 50, 50)
+    swing = physics.swing_angle(50)
+    vert = physics.vertical_hit_angle()
+    vx, vy, vz = physics.launch_vector(50, 50, swing, vert)
     x, y, hang = physics.landing_point(vx, vy, vz)
     fielder = (150.0, 0.0)
     distance = math.hypot(fielder[0] - x, fielder[1] - y)
@@ -48,9 +50,11 @@ def test_routine_fly_caught():
 def test_diving_attempt_fails():
     cfg = make_config()
     cfg.couldBeCaughtSlop = -18
-    physics = Physics(cfg)
+    physics = Physics(cfg, random.Random(0))
     ai = FieldingAI(cfg, random.Random(0))
-    vx, vy, vz = physics.launch_vector(80, 30, 80)
+    swing = physics.swing_angle(30)
+    vert = physics.vertical_hit_angle()
+    vx, vy, vz = physics.launch_vector(80, 80, swing, vert)
     x, y, hang = physics.landing_point(vx, vy, vz)
     fielder = (85.0, 40.0)
     distance = math.hypot(fielder[0] - x, fielder[1] - y)
@@ -59,15 +63,17 @@ def test_diving_attempt_fails():
     action = ai.catch_action(hang, run_time, position="LF", distance=distance)
     assert action == "dive"
     prob = ai.catch_probability("LF", 50, hang, action)
-    assert prob == pytest.approx(0.46, abs=0.01)
+    assert prob == pytest.approx(0.60, abs=0.01)
     assert ai.resolve_fly_ball("LF", 50, hang, action) is False
 
 
 def test_distant_ball_no_attempt():
     cfg = make_config()
-    physics = Physics(cfg)
+    physics = Physics(cfg, random.Random(0))
     ai = FieldingAI(cfg)
-    vx, vy, vz = physics.launch_vector(80, 30, 80)
+    swing = physics.swing_angle(30)
+    vert = physics.vertical_hit_angle()
+    vx, vy, vz = physics.launch_vector(80, 80, swing, vert)
     x, y, hang = physics.landing_point(vx, vy, vz)
     fielder = (150.0, 0.0)
     distance = math.hypot(fielder[0] - x, fielder[1] - y)


### PR DESCRIPTION
## Summary
- Combine swing and vertical hit angles with power to compute batted-ball trajectories
- Feed precomputed angles into launch vector and adjust hit distance thresholds
- Add home run test for power hitters and update physics coordinate tests

## Testing
- `pytest tests/test_physics.py::test_launch_vector_returns_expected_components tests/test_physics.py::test_landing_point_returns_expected_coordinates tests/test_physics.py::test_power_hitter_can_hit_home_run tests/test_coordinate_simulation.py -q`
- `pytest tests/test_physics.py -q` *(pass, though interrupted after completion)*

------
https://chatgpt.com/codex/tasks/task_e_68b135887670832e97fbe09309ba3a14