### PR TITLE
feat: add avatar appearance traits

### DIFF
--- a/tests/test_avatar_generator_openai.py
+++ b/tests/test_avatar_generator_openai.py
@@ -34,13 +34,24 @@ def test_generates_avatar_at_requested_size(tmp_path, monkeypatch):
     monkeypatch.setattr(avatar_generator, "client", SimpleNamespace(images=DummyImages()))
 
     out_file = tmp_path / "avatar.png"
-    avatar_generator.generate_avatar("Test Player", "TST", str(out_file), size=size)
+    avatar_generator.generate_avatar(
+        "Test Player",
+        "TST",
+        str(out_file),
+        size=size,
+        skin_tone="light",
+        hair_color="black",
+        facial_hair="goatee",
+    )
 
     assert calls["size"] == f"{size}x{size}"
     assert "Test Player" in calls["prompt"]
     assert "illustrated" in calls["prompt"].lower()
     assert "cartoon style" in calls["prompt"].lower()
     prompt = calls["prompt"].lower()
+    assert "light-skinned" in prompt
+    assert "black hair" in prompt
+    assert "goatee" in prompt
     assert "plain ball cap and jersey" in prompt
     assert "cap has no logo, image, or letters" in prompt
     assert "jersey has no names, letters, or numbers" in prompt
@@ -69,7 +80,15 @@ def test_512_falls_back_to_1024(tmp_path, monkeypatch):
     monkeypatch.setattr(avatar_generator, "client", SimpleNamespace(images=DummyImages()))
 
     out_file = tmp_path / "avatar.png"
-    avatar_generator.generate_avatar("Test Player", "TST", str(out_file), size=size)
+    avatar_generator.generate_avatar(
+        "Test Player",
+        "TST",
+        str(out_file),
+        size=size,
+        skin_tone="light",
+        hair_color="black",
+        facial_hair="goatee",
+    )
 
     assert calls["size"] == "1024x1024"
     assert out_file.exists()

--- a/utils/avatar_generator.py
+++ b/utils/avatar_generator.py
@@ -74,7 +74,14 @@ def _team_colors(team_id: str) -> Dict[str, str]:
 
 
 def generate_avatar(
-    name: str, team_id: str, out_file: str, size: int = 512, style: str = "illustrated"
+    name: str,
+    team_id: str,
+    out_file: str,
+    size: int = 512,
+    style: str = "illustrated",
+    skin_tone: str | None = None,
+    hair_color: str | None = None,
+    facial_hair: str | None = None,
 ) -> str:
     """Generate an avatar for ``name`` and save it to ``out_file``.
 
@@ -96,14 +103,32 @@ def generate_avatar(
     style:
         Art style for the portrait (e.g., ``"illustrated"``). The prompt always
         requests a cartoon style.
+    skin_tone:
+        Optional descriptor for the player's complexion (e.g., ``"light"``).
+    hair_color:
+        Optional hair color descriptor.
+    facial_hair:
+        Optional facial hair style (e.g., ``"goatee"``).
     """
     if client is None:  # pragma: no cover - depends on external package
         raise RuntimeError("OpenAI client is not configured")
 
     colors = _team_colors(team_id)
     ethnicity = _infer_ethnicity(name)
+
+    tone_part = f"{skin_tone}-skinned " if skin_tone else ""
+    trait_bits = []
+    if hair_color:
+        trait_bits.append(f"{hair_color} hair")
+    if facial_hair:
+        trait_bits.append(f"a {facial_hair}")
+    traits = ""
+    if trait_bits:
+        traits = " with " + " and ".join(trait_bits)
+
+    descriptor = f"{tone_part}{ethnicity} baseball player"
     prompt = (
-        f"{style.capitalize()} portrait of {name}, a {ethnicity} baseball player, "
+        f"{style.capitalize()} portrait of {name}, a {descriptor}{traits}, "
         "wearing a plain ball cap and jersey in team colors "
         f"{colors['primary']} and {colors['secondary']}. The cap has no logo, "
         "image, or letters and the jersey has no names, letters, or numbers. "


### PR DESCRIPTION
## Summary
- allow specifying skin tone, hair color, and facial hair when generating avatars
- include appearance traits in avatar prompt
- test avatar generation with new traits

## Testing
- `pytest tests/test_avatar_generator_openai.py::test_generates_avatar_at_requested_size -q` *(fails: command not found)*
- `pip install -q pytest pillow` *(fails: externally-managed-environment)*
- `python3 -m py_compile utils/avatar_generator.py tests/test_avatar_generator_openai.py`

------
https://chatgpt.com/codex/tasks/task_e_68b1be18e8c8832ebea11bf5b442d532