### PR TITLE
Add tests for ethnicity inference and appearance persistence

### DIFF
--- a/tests/test_avatar_generator.py
+++ b/tests/test_avatar_generator.py
@@ -1,0 +1,13 @@
+import sys
+import types
+
+pil_stub = types.ModuleType("PIL")
+pil_stub.Image = object
+sys.modules.setdefault("PIL", pil_stub)
+
+from utils.avatar_generator import _infer_ethnicity
+
+
+def test_infer_ethnicity_known_pairs():
+    assert _infer_ethnicity("Frederick Sullivan") == "Anglo"
+    assert _infer_ethnicity("Jim Thompson") == "Anglo"

--- a/tests/test_player_generator.py
+++ b/tests/test_player_generator.py
@@ -2,6 +2,8 @@ from collections import Counter
 from datetime import date
 import random
 
+import pytest
+
 from logic.player_generator import (
     generate_player,
     assign_primary_position,
@@ -235,9 +237,11 @@ def test_skin_tone_distribution_matches_weights():
         assert abs(counts[tone] / num_players - expected) < 0.05
 
 
-def test_generate_player_includes_appearance():
-    player = generate_player(is_pitcher=False)
+@pytest.mark.parametrize("is_pitcher", [True, False])
+def test_generate_player_includes_appearance(is_pitcher):
+    player = generate_player(is_pitcher=is_pitcher)
     assert player["ethnicity"]
+    assert player["skin_tone"]
     assert player["hair_color"] in pg.HAIR_COLOR_WEIGHTS[player["ethnicity"]]
     assert player["facial_hair"] in pg.FACIAL_HAIR_WEIGHTS[player["ethnicity"]]
 

--- a/tests/test_player_writer.py
+++ b/tests/test_player_writer.py
@@ -46,3 +46,70 @@ def test_save_players_to_csv_marks_pitchers(tmp_path):
     loaded_players = load_players_from_csv(file_path)
     roles = {p.player_id: getattr(p, "role", "") for p in loaded_players if isinstance(p, Pitcher)}
     assert roles["p1"] == "SP"
+
+
+def test_round_trip_preserves_appearance(tmp_path):
+    file_path = tmp_path / "players.csv"
+    pitcher = Pitcher(
+        player_id="p1",
+        first_name="Pitch",
+        last_name="Er",
+        birthdate="1990-01-01",
+        height=72,
+        weight=180,
+        bats="R",
+        primary_position="P",
+        other_positions=[],
+        gf=10,
+        arm=50,
+        role="SP",
+        endurance=40,
+        control=50,
+        movement=60,
+        hold_runner=55,
+        fb=70,
+        cu=60,
+        cb=50,
+        sl=40,
+        si=45,
+        scb=35,
+        kn=20,
+        fa=65,
+        ethnicity="Anglo",
+        skin_tone="medium",
+        hair_color="black",
+        facial_hair="mustache",
+    )
+    hitter = Player(
+        player_id="h1",
+        first_name="Hit",
+        last_name="Ter",
+        birthdate="1991-02-02",
+        height=70,
+        weight=175,
+        bats="L",
+        primary_position="1B",
+        other_positions=[],
+        gf=20,
+        arm=60,
+        ch=50,
+        ph=55,
+        sp=60,
+        pl=65,
+        vl=40,
+        sc=45,
+        fa=50,
+        ethnicity="Anglo",
+        skin_tone="light",
+        hair_color="brown",
+        facial_hair="beard",
+    )
+    save_players_to_csv([pitcher, hitter], file_path)
+    loaded = load_players_from_csv(file_path)
+    loaded_dict = {p.player_id: p for p in loaded}
+    for original in [pitcher, hitter]:
+        loaded_player = loaded_dict[original.player_id]
+        assert loaded_player.ethnicity == original.ethnicity
+        assert loaded_player.skin_tone == original.skin_tone
+        assert loaded_player.hair_color == original.hair_color
+        assert loaded_player.facial_hair == original.facial_hair


### PR DESCRIPTION
## Summary
- verify `_infer_ethnicity` returns expected values for known name pairs
- ensure `generate_player` fills appearance fields for pitchers and hitters
- confirm player CSV round-trip preserves ethnicity and appearance columns

## Testing
- `pytest tests/test_avatar_generator.py tests/test_player_generator.py::test_generate_player_includes_appearance tests/test_player_writer.py::test_round_trip_preserves_appearance -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1bf0a3a24832eb991ab8c5536acce