### PR TITLE
Support custom stadium geometry for hit outcomes

### DIFF
--- a/logic/field_geometry.py
+++ b/logic/field_geometry.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+from dataclasses import dataclass
 from math import sqrt
 
 # Coordinates are measured in feet with home plate at (0, 0).
@@ -23,6 +25,46 @@ DEFAULT_POSITIONS = {
     "RF": (300.0, 0.0),
 }
 
+
+@dataclass
+class Stadium:
+    """Basic outfield dimensions for a ballpark.
+
+    Distances are measured from home plate to the wall down the left field
+    line, straightaway centre field and down the right field line.  ``double``
+    and ``triple`` represent the fraction of the wall distance required for a
+    ball to be ruled a double or triple when it remains in the park.
+    """
+
+    left: float = 330.0
+    center: float = 400.0
+    right: float = 330.0
+    double: float = 200.0 / 380.0
+    triple: float = 300.0 / 380.0
+
+    def wall_distance(self, angle: float) -> float:
+        """Return the distance to the wall at ``angle`` in radians.
+
+        Angle ``0`` corresponds to the right field line (positive *x*) and
+        ``π/2`` to the left field line (positive *y*).  Values in between are
+        linearly interpolated between the provided corner distances.
+        """
+
+        half = math.pi / 4
+        if angle <= half:
+            return self.right + (self.center - self.right) * angle / half
+        return self.center + (self.left - self.center) * (angle - half) / half
+
+    def double_distance(self, angle: float) -> float:
+        """Threshold distance for a double at ``angle``."""
+
+        return self.wall_distance(angle) * self.double
+
+    def triple_distance(self, angle: float) -> float:
+        """Threshold distance for a triple at ``angle``."""
+
+        return self.wall_distance(angle) * self.triple
+
 __all__ = [
     "HOME",
     "FIRST_BASE",
@@ -30,4 +72,5 @@ __all__ = [
     "THIRD_BASE",
     "PITCHER",
     "DEFAULT_POSITIONS",
+    "Stadium",
 ]

--- a/tests/test_stadium_dimensions.py
+++ b/tests/test_stadium_dimensions.py
@@ -1,0 +1,90 @@
+import random
+
+from logic.field_geometry import Stadium
+from logic.simulation import GameSimulation, TeamState
+from models.player import Player
+from models.pitcher import Pitcher
+from tests.util.pbini_factory import make_cfg
+
+
+def make_player(pid: str, ph: int = 50) -> Player:
+    return Player(
+        player_id=pid,
+        first_name=f"F{pid}",
+        last_name=f"L{pid}",
+        birthdate="2000-01-01",
+        height=72,
+        weight=180,
+        bats="R",
+        primary_position="1B",
+        other_positions=[],
+        gf=50,
+        ch=50,
+        ph=ph,
+        sp=50,
+        pl=0,
+        vl=0,
+    )
+
+
+def make_pitcher(pid: str) -> Pitcher:
+    return Pitcher(
+        player_id=pid,
+        first_name=f"PF{pid}",
+        last_name=f"PL{pid}",
+        birthdate="2000-01-01",
+        height=72,
+        weight=180,
+        bats="R",
+        primary_position="P",
+        other_positions=[],
+        gf=50,
+        endurance=100,
+        control=50,
+        movement=50,
+        hold_runner=50,
+        fb=50,
+        cu=0,
+        cb=0,
+        sl=0,
+        si=0,
+        scb=0,
+        kn=0,
+        arm=50,
+    )
+
+
+def test_custom_stadium_affects_hit_value(monkeypatch):
+    batter = make_player("b", ph=80)
+    pitcher = make_pitcher("p")
+    home = TeamState(lineup=[make_player("h")], bench=[], pitchers=[pitcher])
+    away = TeamState(lineup=[batter], bench=[], pitchers=[make_pitcher("ap")])
+    cfg = make_cfg(swingSpeedBase=80, averagePitchSpeed=50)
+
+    sim = GameSimulation(home, away, cfg, random.Random())
+    monkeypatch.setattr(sim.fielding_ai, "catch_action", lambda *a, **k: "no_attempt")
+    monkeypatch.setattr(
+        sim.physics, "landing_point", lambda vx, vy, vz: (250.0, 250.0, 1.0)
+    )
+    monkeypatch.setattr(sim.physics, "ball_roll_distance", lambda *a, **k: 0.0)
+    monkeypatch.setattr(sim.physics, "ball_bounce", lambda *a, **k: (0.0, 0.0))
+
+    bases, _ = sim._swing_result(batter, pitcher, home, pitch_speed=50, rand=0.0)
+    assert bases == 3
+
+    small = Stadium(left=300.0, center=300.0, right=300.0)
+    sim_small = GameSimulation(home, away, cfg, random.Random(), stadium=small)
+    monkeypatch.setattr(sim_small.fielding_ai, "catch_action", lambda *a, **k: "no_attempt")
+    monkeypatch.setattr(
+        sim_small.physics, "landing_point", lambda vx, vy, vz: (250.0, 250.0, 1.0)
+    )
+    monkeypatch.setattr(sim_small.physics, "ball_roll_distance", lambda *a, **k: 0.0)
+    monkeypatch.setattr(
+        sim_small.physics, "ball_bounce", lambda *a, **k: (0.0, 0.0)
+    )
+
+    bases_small, _ = sim_small._swing_result(
+        batter, pitcher, home, pitch_speed=50, rand=0.0
+    )
+    assert bases_small == 4
+


### PR DESCRIPTION
## Summary
- add `Stadium` dataclass defining wall distances and base-hit thresholds
- allow `GameSimulation` to accept a stadium and calculate results against its walls
- test that smaller parks turn deep flies into home runs

## Testing
- `python -m py_compile logic/field_geometry.py logic/simulation.py tests/test_stadium_dimensions.py`
- `pytest tests/test_stadium_dimensions.py::test_custom_stadium_affects_hit_value -q`


------
https://chatgpt.com/codex/tasks/task_e_68b21c28239c832e82679cfd8d3a3fba