### PR TITLE
Fix undefined outs_from_pick reference in runner advancement

### DIFF
--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -1658,7 +1658,7 @@ class GameSimulation:
             offense.base_pitchers = new_bp
             if runs_scored and not error:
                 self._add_stat(batter_state, "rbi", runs_scored)
-            return outs + outs_from_pick
+            return outs
 
         for idx in range(2, -1, -1):
             runner = b[idx]
@@ -1692,7 +1692,7 @@ class GameSimulation:
 
         if runs_scored and not error:
             self._add_stat(batter_state, "rbi", runs_scored)
-        return outs + outs_from_pick
+        return outs
 
     def _advance_walk(
         self, offense: TeamState, defense: TeamState, batter_state: BatterState


### PR DESCRIPTION
## Summary
- prevent NameError in `_advance_runners` by returning local out count only

## Testing
- `pytest tests/test_runner_advancement.py -q`
- `pytest tests/test_simulation.py::test_simulate_game_skips_bottom_when_home_leads -q`


------
https://chatgpt.com/codex/tasks/task_e_68b256bcc238832e90e9028c53f5fc64