### PR TITLE
feat: scale baseline contact by hitter skill

### DIFF
--- a/logic/batter_ai.py
+++ b/logic/batter_ai.py
@@ -347,7 +347,7 @@ class BatterAI:
         else:
             success = int(type_id) + int(loc_id) + int(time_id)
             if success == 0:
-                contact = 0.0
+                contact = min(getattr(batter, "ch", 0) / 1000.0, 0.1)
             else:
                 ch_factor = getattr(batter, "ch", 0) / 100.0
                 weights = [


### PR DESCRIPTION
## Summary
- scale baseline contact on misidentified swings by batter CH rating and cap at 0.1 so contact hitters retain a small chance to connect

## Testing
- `pytest tests/test_batter_ai.py::test_misidentification_reduces_contact tests/test_batter_ai.py::test_failed_check_can_make_contact -q`
- `python -m pycodestyle logic/batter_ai.py` *(fails: No module named pycodestyle)*
- `pip install pycodestyle` *(fails: Could not find a version that satisfies the requirement pycodestyle)*

------
https://chatgpt.com/codex/tasks/task_e_68b30e05d904832eb8c231a74b5702e9