### PR TITLE
Raise hit probability floor

### DIFF
--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -1465,7 +1465,8 @@ class GameSimulation:
                     * contact_quality
                     * contact_factor
                     * movement_factor
-                ),
+                )
+                + 0.05,
             ),
         )
         # Modify hit probability based on current defensive alignment.


### PR DESCRIPTION
## Summary
- Increase base hit probability by adding a 0.05 floor term in `_swing_result` to reduce extreme strikeout rates.

## Testing
- `python - <<'PY'
import io, contextlib
from datetime import timedelta
import scripts.simulate_season_avg as ssa
import logic.simulation as sim

def short_schedule(teams, start_date):
    return [{"date": (start_date + timedelta(days=i)).isoformat(), "home": teams[0], "away": teams[1]} for i in range(30)]

ssa.generate_mlb_schedule = short_schedule
sim.save_stats = lambda players, teams: None

buf = io.StringIO()
with contextlib.redirect_stdout(buf):
    ssa.simulate_season_average(use_tqdm=False)
print(buf.getvalue())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b310420b60832ebc3f0cf2a31b64d3