### PR TITLE
Increase foul ball defaults and keep probability capped

### DIFF
--- a/docs/simulation_engine.md
+++ b/docs/simulation_engine.md
@@ -61,11 +61,12 @@ impact【F:logic/physics.py†L8-L75】【F:logic/physics.py†L92-L130】.
 Foul tips are modeled through `_foul_probability`, which derives the chance of a
 foul ball from player ratings and configuration. The formula starts with
 `foulStrikeBasePct`—the share of strikes that are fouls in MLB (27.8% in recent
-seasons)—and adjusts it by `foulContactTrendPct` for every 20 point contact edge
-the batter holds over the pitcher. The resulting percentage is converted to a
-foul-to-balls-in-play ratio and scaled so that an average matchup yields a 1:1
+seasons, with a 30% default to slightly boost foul rates)—and adjusts it by
+`foulContactTrendPct` (default 1.5 percentage points) for every 20 point contact
+edge the batter holds over the pitcher. The resulting percentage is converted to
+a foul-to-balls-in-play ratio and scaled so that an average matchup yields a 1:1
 split between foul balls and contacted pitches put in play, with the final
-probability clamped between 0 and 0.5 to avoid unrealistic extremes【F:logic/simulation.py†L1190-L1220】.
+probability clamped between 0 and 0.5 to avoid unrealistic extremes【F:logic/simulation.py†L1339-L1357】.
 
 Historical foul-strike rates have changed gradually over time:
 
@@ -80,7 +81,7 @@ Historical foul-strike rates have changed gradually over time:
 To explore these eras, tweak the `PlayBalanceConfig` values. Setting
 `foulStrikeBasePct` to one of the percentages above shifts the league-wide foul
 rate, while `foulContactTrendPct` controls how strongly batter contact versus
-pitcher movement affects foul frequency【F:logic/playbalance_config.py†L135-L137】.
+pitcher movement affects foul frequency【F:logic/playbalance_config.py†L136-L138】.
 
 ## Statistics
 

--- a/logic/PBINI.txt
+++ b/logic/PBINI.txt
@@ -1538,8 +1538,8 @@ failedCheckContactChance = 0   ; If a player checks his swing and the bat
 ;
 ; FOUL BALL RATES
 ; Base foul-strike percentage and change per 20 pt contact edge
-foulStrikeBasePct=27.8
-foulContactTrendPct=2.0
+foulStrikeBasePct=30.0
+foulContactTrendPct=1.5
 ;
 ; AVOIDING HIT BY PITCH
 ; The chance that the batter will be able to avoid being hit by a pitch.

--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -133,8 +133,8 @@ _DEFAULTS: Dict[str, Any] = {
     "hit3BProb": 2,
     "hitHRProb": 14,
     # Foul ball tuning -----------------------------------------------
-    "foulStrikeBasePct": 27.8,
-    "foulContactTrendPct": 2.0,
+    "foulStrikeBasePct": 30.0,
+    "foulContactTrendPct": 1.5,
     "ballInPlayOuts": 1,
     # Pitcher AI ------------------------------------------------------
     "pitchRatVariationCount": 1,

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -1337,8 +1337,8 @@ class GameSimulation:
         """Return foul ball probability derived from configuration and ratings.
 
         ``foulStrikeBasePct`` represents the percentage of strikes that are
-        fouls in the source data (roughly 27.8%). ``foulContactTrendPct`` adds
-        roughly ``+2`` percentage points for every 20 point edge in batter
+        fouls in the source data (roughly 30%). ``foulContactTrendPct`` adds
+        roughly ``+1.5`` percentage points for every 20 point edge in batter
         contact over pitcher movement. The percentage is converted to a
         foul-to-balls-in-play ratio and then scaled so that an average matchup
         produces a 1:1 split between foul balls and balls put in play.
@@ -1348,8 +1348,8 @@ class GameSimulation:
         """
 
         cfg = self.config
-        base_pct = float(cfg.get("foulStrikeBasePct", 27.8))
-        trend_pct = float(cfg.get("foulContactTrendPct", 2.0))
+        base_pct = float(cfg.get("foulStrikeBasePct", 30.0))
+        trend_pct = float(cfg.get("foulContactTrendPct", 1.5))
 
         contact_delta = getattr(batter, "ch", 50) - getattr(pitcher, "movement", 50)
         foul_pct = base_pct + (contact_delta / 20.0) * trend_pct

--- a/tests/test_playbalance_config.py
+++ b/tests/test_playbalance_config.py
@@ -14,8 +14,8 @@ def test_playbalance_config_defaults():
     assert cfg.exit_velo_ph_pct == 0
     assert cfg.vert_angle_gf_pct == 0
     assert cfg.spray_angle_pl_pct == 0
-    assert cfg.foulStrikeBasePct == 27.8
-    assert cfg.foulContactTrendPct == 2.0
+    assert cfg.foulStrikeBasePct == 30.0
+    assert cfg.foulContactTrendPct == 1.5
 
     # Pitcher AI defaults
     assert cfg.pitchRatVariationCount == 1


### PR DESCRIPTION
## Summary
- Raise `foulStrikeBasePct` to 30% and lower `foulContactTrendPct` to 1.5% to encourage more foul balls
- Apply new defaults in simulation and configuration files while clamping foul chance to 50%
- Update docs and tests to reflect revised foul ball tuning

## Testing
- `python -m py_compile logic/simulation.py logic/playbalance_config.py tests/test_playbalance_config.py`
- `pytest tests/test_playbalance_config.py::test_playbalance_config_defaults -q`
- `pytest tests/test_simulation_foul_balls.py::test_foul_strike_distribution -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3113d6264832e9644de0338ca94bc