### PR TITLE
refactor: centralize theme handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,12 @@
 import sys
 from PyQt6.QtWidgets import QApplication
+
 from ui.splash_screen import SplashScreen
+from ui.theme import LIGHT_QSS
 
 def main():
     app = QApplication(sys.argv)
+    app.setStyleSheet(LIGHT_QSS)
     splash = SplashScreen()
     splash.showMaximized()
     sys.exit(app.exec())

--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -39,9 +39,8 @@ from .ui_template import (
     NavButton,
     Card,
     section_title,
-    LIGHT_QSS,
-    DARK_QSS,
 )
+from .theme import _toggle_theme
 from .team_entry_dialog import TeamEntryDialog
 from .exhibition_game_dialog import ExhibitionGameDialog
 from .playbalance_editor import PlayBalanceEditor
@@ -299,7 +298,7 @@ class MainWindow(QMainWindow):
 
         view_menu = self.menuBar().addMenu("&View")
         theme_action = QAction("Toggle Dark Mode", self)
-        theme_action.triggered.connect(self._toggle_theme)
+        theme_action.triggered.connect(lambda: _toggle_theme(self.statusBar()))
         view_menu.addAction(theme_action)
 
     def _go(self, key: str) -> None:
@@ -307,10 +306,6 @@ class MainWindow(QMainWindow):
         self.stack.setCurrentIndex(idx)
         self.statusBar().showMessage(f"Ready • {key.capitalize()}")
 
-    def _toggle_theme(self) -> None:
-        is_dark = "0f1623" in QApplication.instance().styleSheet()
-        QApplication.instance().setStyleSheet(LIGHT_QSS if is_dark else DARK_QSS)
-        self.statusBar().showMessage("Dark theme" if not is_dark else "Light theme")
 
     # ------------------------------------------------------------------
     # Existing behaviours

--- a/ui/league_leaders_window.py
+++ b/ui/league_leaders_window.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from typing import Iterable, List, Tuple
 
 from PyQt6.QtWidgets import (
@@ -41,16 +40,7 @@ class LeagueLeadersWindow(QDialog):
             self.table.setItem(row, 1, QTableWidgetItem(name))
             self.table.setItem(row, 2, QTableWidgetItem(value))
         self.table.setSortingEnabled(True)
-        self._apply_espn_style()
 
-    def _apply_espn_style(self) -> None:
-        """Apply ESPN-like color scheme."""
-        qss_path = os.path.join(
-            os.path.dirname(__file__), "resources", "espn.qss"
-        )
-        if os.path.exists(qss_path) and callable(getattr(self, "setStyleSheet", None)):
-            with open(qss_path, "r", encoding="utf-8") as qss_file:
-                self.setStyleSheet(qss_file.read())
 
     # ------------------------------------------------------------------
     def _gather_leaders(

--- a/ui/owner_dashboard.py
+++ b/ui/owner_dashboard.py
@@ -48,6 +48,7 @@ from utils.team_loader import load_teams, save_team_settings
 from utils.pitcher_role import get_role
 from utils.trade_utils import get_pending_trades
 from utils.path_utils import get_base_dir
+from .theme import _toggle_theme
 
 
 def _hex_to_rgb(value: str) -> tuple[int, int, int]:
@@ -110,6 +111,8 @@ class OwnerDashboard(QWidget):
         exit_action = file_menu.addAction("Exit")
         exit_action.triggered.connect(QApplication.quit)
         color_menu = file_menu.addMenu("Color Scheme")
+        toggle_action = color_menu.addAction("Toggle Dark Mode")
+        toggle_action.triggered.connect(_toggle_theme)
         for name, (primary, secondary) in PREDEFINED_COLOR_SCHEMES.items():
             action = color_menu.addAction(name)
             action.triggered.connect(

--- a/ui/player_profile_dialog.py
+++ b/ui/player_profile_dialog.py
@@ -1,7 +1,6 @@
 """Dialog for displaying a player's profile with avatar, info,
 ratings and stats."""
 
-import os
 from dataclasses import asdict, is_dataclass
 from datetime import datetime
 from typing import Any, Dict, List, Tuple
@@ -73,7 +72,6 @@ class PlayerProfileDialog(QDialog):
         layout.addWidget(self._build_stats_table(stats_history))
 
         self.setLayout(layout)
-        self._apply_espn_style()
         self.adjustSize()
         self.setFixedSize(self.sizeHint())
 
@@ -275,14 +273,6 @@ class PlayerProfileDialog(QDialog):
         group.setLayout(grid)
         return group
 
-    def _apply_espn_style(self) -> None:
-        """Apply ESPN-like color scheme."""
-        qss_path = os.path.join(
-            os.path.dirname(__file__), "resources", "espn.qss"
-        )
-        if os.path.exists(qss_path) and callable(getattr(self, "setStyleSheet", None)):
-            with open(qss_path, "r", encoding="utf-8") as qss_file:
-                self.setStyleSheet(qss_file.read())
 
     def _calculate_age(self, birthdate_str: str):
         try:

--- a/ui/team_stats_window.py
+++ b/ui/team_stats_window.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from typing import Dict, Iterable, List
 
 from PyQt6.QtWidgets import (
@@ -96,7 +95,6 @@ class TeamStatsWindow(QDialog):
             "Pitching",
         )
         self.tabs.addTab(self._build_team_table(team.season_stats), "Team")
-        self._apply_espn_style()
 
     # ------------------------------------------------------------------
     def _build_player_table(
@@ -119,14 +117,6 @@ class TeamStatsWindow(QDialog):
         table.setSortingEnabled(True)
         return table
 
-    def _apply_espn_style(self) -> None:
-        """Apply ESPN-like color scheme."""
-        qss_path = os.path.join(
-            os.path.dirname(__file__), "resources", "espn.qss"
-        )
-        if os.path.exists(qss_path) and callable(getattr(self, "setStyleSheet", None)):
-            with open(qss_path, "r", encoding="utf-8") as qss_file:
-                self.setStyleSheet(qss_file.read())
 
     def _build_team_table(self, stats: Dict[str, float]) -> QTableWidget:
         items = sorted(stats.items())

--- a/ui/theme.py
+++ b/ui/theme.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from typing import Optional
+from PyQt6.QtWidgets import QApplication, QStatusBar
+
+LIGHT_QSS = """
+/* App */
+QWidget {
+    background: #f7f8fb;
+    color: #0f2545;
+    font-family: 'Segoe UI', 'Noto Sans', Arial;
+    font-size: 14px;
+}
+
+/* Sidebar (dugout) */
+#Sidebar {
+    background: #0f2545; /* deep navy */
+    border: none;
+}
+#Sidebar QLabel {
+    color: #f1f5ff;
+    font-weight: 600;
+    padding: 8px 10px;
+    letter-spacing: .5px;
+}
+#NavButton {
+    color: #e7efff;
+    background: transparent;
+    padding: 10px 14px;
+    margin: 4px 8px;
+    border-radius: 10px;
+    text-align: left;
+}
+#NavButton:hover { background: #1b3b6b; }
+#NavButton:checked {
+    background: #1b4d89;
+    border: 1px solid #2b66b8;
+    color: white;
+}
+
+/* Header (scoreboard strip) */
+#Header {
+    background: white;
+    border-bottom: 1px solid #e6e9f2;
+}
+#Title {
+    font-size: 20px;
+    font-weight: 800;
+    letter-spacing: .5px;
+}
+#Scoreboard {
+    background: #0f2545;
+    color: #f6f8ff;
+    border-radius: 10px;
+    padding: 6px 12px;
+    font-weight: 700;
+}
+
+/* Cards and content */
+QFrame#Card {
+    background: white;
+    border: 1px solid #e9edf5;
+    border-radius: 14px;
+}
+QLabel#SectionTitle {
+    font-size: 16px;
+    font-weight: 700;
+    color: #0f2545;
+}
+
+/* Buttons */
+QPushButton#Primary {
+    background: #1b4d89;  /* primary blue */
+    color: white;
+    border: none;
+    padding: 10px 16px;
+    border-radius: 10px;
+    font-weight: 600;
+}
+QPushButton#Primary:hover { background: #205aa0; }
+QPushButton#Primary:pressed { background: #17487a; }
+
+QPushButton#Success {
+    background: #2f9e44;  /* "Play ball" green */
+    color: white;
+    border: none;
+    padding: 12px 18px;
+    border-radius: 14px;
+    font-size: 16px;
+    font-weight: 700;
+}
+QPushButton#Success:hover { background: #27903c; }
+QPushButton#Success:pressed { background: #237f35; }
+
+QStatusBar { background: #ffffff; border-top: 1px solid #e6e9f2; }
+"""
+
+DARK_QSS = """
+QWidget {
+    background: #0f1623;
+    color: #e6ecfa;
+    font-family: 'Segoe UI', 'Noto Sans', Arial;
+    font-size: 14px;
+}
+#Sidebar {
+    background: #0b1222;
+}
+#Sidebar QLabel { color: #dbe6ff; }
+#NavButton {
+    color: #cfe0ff;
+    background: transparent;
+    padding: 10px 14px;
+    margin: 4px 8px;
+    border-radius: 10px;
+}
+#NavButton:hover { background: #132645; }
+#NavButton:checked {
+    background: #19345f;
+    border: 1px solid #2a4c8e;
+    color: white;
+}
+#Header {
+    background: #111a2b;
+    border-bottom: 1px solid #1b2943;
+}
+#Title { color: #eaf1ff; }
+#Scoreboard {
+    background: #0b1222;
+    color: #eaf1ff;
+    border: 1px solid #1b2943;
+    border-radius: 10px;
+    padding: 6px 12px;
+    font-weight: 700;
+}
+QFrame#Card {
+    background: #121b2d;
+    border: 1px solid #1b2943;
+    border-radius: 14px;
+}
+QLabel#SectionTitle {
+    font-size: 16px;
+    font-weight: 700;
+    color: #e6ecfa;
+}
+QPushButton#Primary {
+    background: #1b4d89;
+    color: white;
+    border: none;
+    padding: 10px 16px;
+    border-radius: 10px;
+    font-weight: 600;
+}
+QPushButton#Primary:hover { background: #205aa0; }
+QPushButton#Primary:pressed { background: #17487a; }
+QPushButton#Success {
+    background: #2f9e44;
+    color: white;
+    border: none;
+    padding: 12px 18px;
+    border-radius: 14px;
+    font-size: 16px;
+    font-weight: 700;
+}
+QPushButton#Success:hover { background: #27903c; }
+QPushButton#Success:pressed { background: #237f35; }
+QStatusBar { background: #0f1623; border-top: 1px solid #1b2943; }
+"""
+
+def _toggle_theme(status_bar: Optional[QStatusBar] = None) -> None:
+    """Toggle between light and dark themes."""
+    app = QApplication.instance()
+    if app is None:
+        return
+    is_dark = "0f1623" in app.styleSheet()
+    app.setStyleSheet(LIGHT_QSS if is_dark else DARK_QSS)
+    if status_bar is not None:
+        status_bar.showMessage("Light theme" if is_dark else "Dark theme")
+

--- a/ui/ui_template.py
+++ b/ui/ui_template.py
@@ -7,172 +7,7 @@ from PyQt6.QtWidgets import (
     QSizePolicy, QStatusBar, QSpacerItem
 )
 
-# ------------------------------------------------------------
-# Theme toggles
-# ------------------------------------------------------------
-
-LIGHT_QSS = """
-/* App */
-QWidget {
-    background: #f7f8fb;
-    color: #0f2545;
-    font-family: 'Segoe UI', 'Noto Sans', Arial;
-    font-size: 14px;
-}
-
-/* Sidebar (dugout) */
-#Sidebar {
-    background: #0f2545; /* deep navy */
-    border: none;
-}
-#Sidebar QLabel {
-    color: #f1f5ff;
-    font-weight: 600;
-    padding: 8px 10px;
-    letter-spacing: .5px;
-}
-#NavButton {
-    color: #e7efff;
-    background: transparent;
-    padding: 10px 14px;
-    margin: 4px 8px;
-    border-radius: 10px;
-    text-align: left;
-}
-#NavButton:hover { background: #1b3b6b; }
-#NavButton:checked {
-    background: #1b4d89;
-    border: 1px solid #2b66b8;
-    color: white;
-}
-
-/* Header (scoreboard strip) */
-#Header {
-    background: white;
-    border-bottom: 1px solid #e6e9f2;
-}
-#Title {
-    font-size: 20px;
-    font-weight: 800;
-    letter-spacing: .5px;
-}
-#Scoreboard {
-    background: #0f2545;
-    color: #f6f8ff;
-    border-radius: 10px;
-    padding: 6px 12px;
-    font-weight: 700;
-}
-
-/* Cards and content */
-QFrame#Card {
-    background: white;
-    border: 1px solid #e9edf5;
-    border-radius: 14px;
-}
-QLabel#SectionTitle {
-    font-size: 16px;
-    font-weight: 700;
-    color: #0f2545;
-}
-
-/* Buttons */
-QPushButton#Primary {
-    background: #1b4d89;  /* primary blue */
-    color: white;
-    border: none;
-    padding: 10px 16px;
-    border-radius: 10px;
-    font-weight: 600;
-}
-QPushButton#Primary:hover { background: #205aa0; }
-QPushButton#Primary:pressed { background: #17487a; }
-
-QPushButton#Success {
-    background: #2f9e44;  /* "Play ball" green */
-    color: white;
-    border: none;
-    padding: 12px 18px;
-    border-radius: 14px;
-    font-size: 16px;
-    font-weight: 700;
-}
-QPushButton#Success:hover { background: #27903c; }
-QPushButton#Success:pressed { background: #237f35; }
-
-QStatusBar { background: #ffffff; border-top: 1px solid #e6e9f2; }
-"""
-
-DARK_QSS = """
-QWidget {
-    background: #0f1623;
-    color: #e6ecfa;
-    font-family: 'Segoe UI', 'Noto Sans', Arial;
-    font-size: 14px;
-}
-#Sidebar {
-    background: #0b1222;
-}
-#Sidebar QLabel { color: #dbe6ff; }
-#NavButton {
-    color: #cfe0ff;
-    background: transparent;
-    padding: 10px 14px;
-    margin: 4px 8px;
-    border-radius: 10px;
-}
-#NavButton:hover { background: #132645; }
-#NavButton:checked {
-    background: #19345f;
-    border: 1px solid #2a4c8e;
-    color: white;
-}
-#Header {
-    background: #111a2b;
-    border-bottom: 1px solid #1b2943;
-}
-#Title { color: #eaf1ff; }
-#Scoreboard {
-    background: #0b1222;
-    color: #eaf1ff;
-    border: 1px solid #1b2943;
-    border-radius: 10px;
-    padding: 6px 12px;
-    font-weight: 700;
-}
-QFrame#Card {
-    background: #121b2d;
-    border: 1px solid #1b2943;
-    border-radius: 14px;
-}
-QLabel#SectionTitle {
-    font-size: 16px;
-    font-weight: 700;
-    color: #e6ecfa;
-}
-QPushButton#Primary {
-    background: #1b4d89;
-    color: white;
-    border: none;
-    padding: 10px 16px;
-    border-radius: 10px;
-    font-weight: 600;
-}
-QPushButton#Primary:hover { background: #205aa0; }
-QPushButton#Primary:pressed { background: #17487a; }
-QPushButton#Success {
-    background: #2f9e44;
-    color: white;
-    border: none;
-    padding: 12px 18px;
-    border-radius: 14px;
-    font-size: 16px;
-    font-weight: 700;
-}
-QPushButton#Success:hover { background: #27903c; }
-QPushButton#Success:pressed { background: #237f35; }
-QStatusBar { background: #0f1623; border-top: 1px solid #1b2943; }
-"""
+from .theme import LIGHT_QSS, _toggle_theme
 
 # ------------------------------------------------------------
 # Small building blocks
@@ -402,7 +237,7 @@ class MainWindow(QMainWindow):
         self.btn_teams.clicked.connect(lambda: self._go("teams"))
         self.btn_users.clicked.connect(lambda: self._go("users"))
         self.btn_utils.clicked.connect(lambda: self._go("utils"))
-        self.btn_settings.clicked.connect(self._toggle_theme)
+        self.btn_settings.clicked.connect(lambda: _toggle_theme(self.statusBar()))
 
         # Default selection
         self.btn_dashboard.setChecked(True)
@@ -416,7 +251,7 @@ class MainWindow(QMainWindow):
 
         view_menu = self.menuBar().addMenu("&View")
         theme_action = QAction("Toggle Dark Mode", self)
-        theme_action.triggered.connect(self._toggle_theme)
+        theme_action.triggered.connect(lambda: _toggle_theme(self.statusBar()))
         view_menu.addAction(theme_action)
 
     def _go(self, key):
@@ -424,17 +259,6 @@ class MainWindow(QMainWindow):
         self.stack.setCurrentIndex(idx)
         self.statusBar().showMessage(f"Ready • {key.capitalize()}")
 
-    def _toggle_theme(self):
-        # swap app-wide style between light and dark
-        current = self.parent().styleSheet() if self.parent() else self.styleSheet()
-        # detect by a token present in each sheet
-        is_dark = "0f1623" in QApplication.instance().styleSheet()
-        if is_dark:
-            QApplication.instance().setStyleSheet(LIGHT_QSS)
-            self.statusBar().showMessage("Light theme")
-        else:
-            QApplication.instance().setStyleSheet(DARK_QSS)
-            self.statusBar().showMessage("Dark theme")
 
 # ------------------------------------------------------------
 # Run


### PR DESCRIPTION
## Summary
- centralize LIGHT_QSS/DARK_QSS definitions and theme toggling in `ui/theme.py`
- apply default light theme in `main.py` and wire menu actions to shared `_toggle_theme`
- drop per-window stylesheet helpers in favour of global theme management

## Testing
- `python -m py_compile main.py ui/theme.py ui/ui_template.py ui/admin_dashboard.py ui/owner_dashboard.py ui/league_leaders_window.py ui/team_stats_window.py ui/player_profile_dialog.py`


------
https://chatgpt.com/codex/tasks/task_e_68b36bc84ff0832e91835561d05ce4ec