### PR TITLE
refactor: centralize reusable UI components

### DIFF
--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -35,11 +35,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from .ui_template import (
-    NavButton,
-    Card,
-    section_title,
-)
+from .components import Card, NavButton, section_title
 from .theme import _toggle_theme
 from .team_entry_dialog import TeamEntryDialog
 from .exhibition_game_dialog import ExhibitionGameDialog

--- a/ui/components.py
+++ b/ui/components.py
@@ -1,0 +1,56 @@
+"""Reusable UI components for consistent styling."""
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QToolButton,
+    QFrame,
+    QVBoxLayout,
+    QLabel,
+    QSizePolicy,
+    QSpacerItem,
+)
+
+
+class NavButton(QToolButton):
+    """Navigation button used in sidebars."""
+
+    def __init__(self, text: str, parent=None) -> None:
+        super().__init__(parent)
+        self.setObjectName("NavButton")
+        # Emoji icons keep dependencies light; swap for SVGs if you prefer
+        self.setText(text)  # e.g., "⚾  Dashboard"
+        self.setCheckable(True)
+        self.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+
+
+class Card(QFrame):
+    """Framed container with standard padding and layout."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setObjectName("Card")
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.setFrameShape(QFrame.Shape.StyledPanel)
+        self.setLayout(QVBoxLayout())
+        self.layout().setContentsMargins(18, 18, 18, 18)
+        self.layout().setSpacing(10)
+
+
+def section_title(text: str) -> QLabel:
+    """Create a standardized section header label."""
+
+    label = QLabel(text)
+    label.setObjectName("SectionTitle")
+    return label
+
+
+def spacer(h: int = 1, v: int = 1) -> QSpacerItem:
+    """Return a flexible spacer item for layouts."""
+
+    return QSpacerItem(
+        h,
+        v,
+        QSizePolicy.Policy.Expanding,
+        QSizePolicy.Policy.Expanding,
+    )

--- a/ui/ui_template.py
+++ b/ui/ui_template.py
@@ -2,44 +2,20 @@ import sys
 from PyQt6.QtCore import Qt, QSize
 from PyQt6.QtGui import QAction, QFont
 from PyQt6.QtWidgets import (
-    QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
-    QToolButton, QStackedWidget, QLabel, QFrame, QPushButton,
-    QSizePolicy, QStatusBar, QSpacerItem
+    QApplication,
+    QMainWindow,
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QStackedWidget,
+    QLabel,
+    QFrame,
+    QPushButton,
+    QStatusBar,
 )
 
+from .components import Card, NavButton, section_title
 from .theme import LIGHT_QSS, _toggle_theme
-
-# ------------------------------------------------------------
-# Small building blocks
-# ------------------------------------------------------------
-
-class NavButton(QToolButton):
-    def __init__(self, text, parent=None):
-        super().__init__(parent)
-        self.setObjectName("NavButton")
-        # Emoji icons keep dependencies light; swap for SVGs if you prefer
-        self.setText(text)  # e.g., "⚾  Dashboard"
-        self.setCheckable(True)
-        self.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
-        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-
-class Card(QFrame):
-    def __init__(self, parent=None):
-        super().__init__(parent)
-        self.setObjectName("Card")
-        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-        self.setFrameShape(QFrame.Shape.StyledPanel)
-        self.setLayout(QVBoxLayout())
-        self.layout().setContentsMargins(18, 18, 18, 18)
-        self.layout().setSpacing(10)
-
-def section_title(text):
-    lbl = QLabel(text)
-    lbl.setObjectName("SectionTitle")
-    return lbl
-
-def spacer(h=1, v=1):
-    return QSpacerItem(h, v, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
 
 # ------------------------------------------------------------
 # Pages


### PR DESCRIPTION
## Summary
- move NavButton, Card, section_title and spacer into new `ui.components`
- update `ui_template` and `admin_dashboard` to import shared components

## Testing
- `python -m py_compile ui/components.py ui/ui_template.py ui/admin_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68b36f065798832eb282609821d4dad0