### PR TITLE
Fix add_user invocation in admin dashboard

### DIFF
--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -499,7 +499,8 @@ class MainWindow(QMainWindow):
                 QMessageBox.warning(dialog, "Error", "Username and password required")
                 return
             try:
-                add_user(username, password, team_id, data_dir / "users.txt")
+                role = "owner" if team_id else "admin"
+                add_user(username, password, role, team_id, data_dir / "users.txt")
             except ValueError as e:
                 QMessageBox.warning(dialog, "Error", str(e))
                 return


### PR DESCRIPTION
## Summary
- Correct user creation logic to supply role and file path correctly
- Determine user role from selected team before adding

## Testing
- `python -m py_compile ui/admin_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68b374433714832e897a4cf65e7876db