### PR TITLE
Enable default dark mode and roster movement utilities

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,11 @@ import sys
 from PyQt6.QtWidgets import QApplication
 
 from ui.splash_screen import SplashScreen
-from ui.theme import LIGHT_QSS
+from ui.theme import DARK_QSS
 
 def main():
     app = QApplication(sys.argv)
-    app.setStyleSheet(LIGHT_QSS)
+    app.setStyleSheet(DARK_QSS)
     splash = SplashScreen()
     splash.showMaximized()
     sys.exit(app.exec())

--- a/services/roster_moves.py
+++ b/services/roster_moves.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Utilities for moving players between roster levels."""
+
+from models.roster import Roster
+
+
+def move_player_between_rosters(player_id: str, roster: Roster, source: str, destination: str) -> None:
+    """Move *player_id* from *source* to *destination* roster level.
+
+    Parameters
+    ----------
+    player_id:
+        Identifier of the player to move.
+    roster:
+        Roster object to update.
+    source:
+        One of ``"act"``, ``"aaa"`` or ``"low"`` indicating the current roster.
+    destination:
+        One of ``"act"``, ``"aaa"`` or ``"low"`` indicating the target roster.
+
+    Raises
+    ------
+    ValueError
+        If *source* or *destination* is not a valid roster level or the player
+        is not present on the source roster.
+    """
+
+    valid_levels = {"act", "aaa", "low"}
+    if source not in valid_levels or destination not in valid_levels:
+        raise ValueError("source and destination must be 'act', 'aaa' or 'low'")
+    if source == destination:
+        return
+
+    src_list = getattr(roster, source)
+    if player_id not in src_list:
+        raise ValueError("player not found in source roster")
+
+    dest_list = getattr(roster, destination)
+    if player_id in dest_list:
+        raise ValueError("player already in destination roster")
+
+    src_list.remove(player_id)
+    dest_list.append(player_id)

--- a/tests/test_roster_moves.py
+++ b/tests/test_roster_moves.py
@@ -1,0 +1,17 @@
+from models.roster import Roster
+from services.roster_moves import move_player_between_rosters
+import pytest
+
+
+def test_move_player_between_rosters():
+    roster = Roster(team_id="T", act=["p1"], aaa=["p2"], low=["p3"])
+
+    move_player_between_rosters("p2", roster, "aaa", "act")
+    assert "p2" in roster.act
+    assert "p2" not in roster.aaa
+
+    with pytest.raises(ValueError):
+        move_player_between_rosters("p4", roster, "aaa", "act")
+
+    with pytest.raises(ValueError):
+        move_player_between_rosters("p1", roster, "act", "foo")

--- a/ui/login_window.py
+++ b/ui/login_window.py
@@ -14,7 +14,7 @@ import importlib
 import bcrypt
 
 from utils.path_utils import get_base_dir
-from ui.theme import LIGHT_QSS
+from ui.theme import DARK_QSS
 
 # Determine the path to the users file in a cross-platform way
 USER_FILE = get_base_dir() / "data" / "users.txt"
@@ -113,7 +113,7 @@ class LoginWindow(QWidget):
 
         app = QApplication.instance()
         if app:
-            app.setStyleSheet(LIGHT_QSS)
+            app.setStyleSheet(DARK_QSS)
 
         self.dashboard.show()
 
@@ -142,7 +142,7 @@ class LoginWindow(QWidget):
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)
-    app.setStyleSheet(LIGHT_QSS)
+    app.setStyleSheet(DARK_QSS)
     window = LoginWindow()
     window.show()
     sys.exit(app.exec())

--- a/ui/owner_dashboard.py
+++ b/ui/owner_dashboard.py
@@ -72,9 +72,9 @@ class OwnerDashboard(QMainWindow):
 
         self.btn_roster = NavButton("  Roster")
         self.btn_transactions = NavButton("  Transactions")
-        self.btn_schedule = NavButton("  Schedule")
+        self.btn_league = NavButton("  League")
 
-        for b in (self.btn_roster, self.btn_transactions, self.btn_schedule):
+        for b in (self.btn_roster, self.btn_transactions, self.btn_league):
             side.addWidget(b)
 
         side.addStretch()
@@ -103,7 +103,7 @@ class OwnerDashboard(QMainWindow):
         self.pages = {
             "roster": RosterPage(self),
             "transactions": TransactionsPage(self),
-            "schedule": SchedulePage(self),
+            "league": SchedulePage(self),
         }
         for p in self.pages.values():
             self.stack.addWidget(p)
@@ -128,7 +128,7 @@ class OwnerDashboard(QMainWindow):
         # Navigation signals
         self.btn_roster.clicked.connect(lambda: self._go("roster"))
         self.btn_transactions.clicked.connect(lambda: self._go("transactions"))
-        self.btn_schedule.clicked.connect(lambda: self._go("schedule"))
+        self.btn_league.clicked.connect(lambda: self._go("league"))
         self.btn_roster.setChecked(True)
         self._go("roster")
 

--- a/ui/ui_template.py
+++ b/ui/ui_template.py
@@ -15,7 +15,7 @@ from PyQt6.QtWidgets import (
 )
 
 from .components import Card, NavButton, section_title
-from .theme import LIGHT_QSS, _toggle_theme
+from .theme import DARK_QSS, _toggle_theme
 
 # ------------------------------------------------------------
 # Pages
@@ -242,7 +242,7 @@ class MainWindow(QMainWindow):
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)
-    app.setStyleSheet(LIGHT_QSS)  # start in light; toggle with View > Toggle Dark Mode
+    app.setStyleSheet(DARK_QSS)  # start in dark; toggle with View > Toggle Dark Mode
     w = MainWindow()
     w.show()
     sys.exit(app.exec())


### PR DESCRIPTION
## Summary
- default to dark theme across main entry points and login
- rename owner dashboard Schedule button to League
- add service and tests for moving players between roster levels

## Testing
- `python -m py_compile main.py ui/ui_template.py ui/login_window.py services/roster_moves.py tests/test_roster_moves.py ui/owner_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3789eb0ac832eaccb95fc26055778