### PR TITLE
Enable roster move from owner dashboard

### DIFF
--- a/ui/move_player_dialog.py
+++ b/ui/move_player_dialog.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Dialog allowing owners to move players between roster levels."""
+
+from typing import Dict
+
+from PyQt6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QFormLayout,
+    QMessageBox,
+    QPushButton,
+)
+
+from models.base_player import BasePlayer
+from models.roster import Roster
+from services.roster_moves import move_player_between_rosters
+
+
+class MovePlayerDialog(QDialog):
+    """Simple dialog for moving a player to a different roster level."""
+
+    levels = ("act", "aaa", "low")
+
+    def __init__(self, players: Dict[str, BasePlayer], roster: Roster, parent=None):
+        super().__init__(parent)
+        self.players = players
+        self.roster = roster
+
+        self.setWindowTitle("Move Player")
+
+        self.player_combo = QComboBox()
+        for level in self.levels:
+            for pid in getattr(roster, level):
+                player = players.get(pid)
+                if not player:
+                    continue
+                label = f"{player.first_name} {player.last_name} ({level.upper()})"
+                self.player_combo.addItem(label, (pid, level))
+        self.player_combo.currentIndexChanged.connect(self._update_destinations)
+
+        self.dest_combo = QComboBox()
+        self._update_destinations()
+
+        move_btn = QPushButton("Move")
+        move_btn.clicked.connect(self._move_player)
+
+        layout = QFormLayout(self)
+        layout.addRow("Player", self.player_combo)
+        layout.addRow("Destination", self.dest_combo)
+        layout.addRow(move_btn)
+
+    def _update_destinations(self) -> None:
+        data = self.player_combo.currentData()
+        self.dest_combo.clear()
+        if not data:
+            return
+        _pid, source = data
+        for level in self.levels:
+            if level != source:
+                self.dest_combo.addItem(level.upper(), level)
+
+    def _move_player(self) -> None:
+        data = self.player_combo.currentData()
+        if not data:
+            return
+        pid, source = data
+        dest = self.dest_combo.currentData()
+        if not dest:
+            return
+        try:
+            move_player_between_rosters(pid, self.roster, source, dest)
+            QMessageBox.information(
+                self, "Move Player", "Player moved successfully."
+            )
+            self.accept()
+        except Exception as exc:
+            QMessageBox.critical(self, "Error", str(exc))

--- a/ui/owner_dashboard.py
+++ b/ui/owner_dashboard.py
@@ -26,6 +26,7 @@ from .schedule_page import SchedulePage
 from .lineup_editor import LineupEditor
 from .pitching_editor import PitchingEditor
 from .position_players_dialog import PositionPlayersDialog
+from .move_player_dialog import MovePlayerDialog
 from .transactions_window import TransactionsWindow
 from .trade_dialog import TradeDialog
 from .standings_window import StandingsWindow
@@ -163,6 +164,9 @@ class OwnerDashboard(QMainWindow):
 
     def open_position_players_dialog(self) -> None:
         PositionPlayersDialog(self.players, self.roster).exec()
+
+    def open_move_player_dialog(self) -> None:
+        MovePlayerDialog(self.players, self.roster, self).exec()
 
     def open_transactions_page(self) -> None:
         TransactionsWindow().exec()

--- a/ui/roster_page.py
+++ b/ui/roster_page.py
@@ -25,6 +25,10 @@ class RosterPage(QWidget):
         btn_lineups.clicked.connect(dashboard.open_lineup_editor)
         card.layout().addWidget(btn_lineups)
 
+        btn_move = QPushButton("Move Player", objectName="Primary")
+        btn_move.clicked.connect(dashboard.open_move_player_dialog)
+        card.layout().addWidget(btn_move)
+
         card.layout().addStretch()
         layout.addWidget(card)
         layout.addStretch()


### PR DESCRIPTION
## Summary
- Allow owners to move players between roster levels via a new dialog
- Add Move Player button to owner roster page and hook into dashboard

## Testing
- `python -m py_compile ui/move_player_dialog.py ui/owner_dashboard.py ui/roster_page.py`
- `pytest tests/test_make_player_item.py tests/test_roster_moves.py -q` *(fails: ImportError: cannot import name 'QAction' from 'PyQt6.QtGui')*
- `pytest tests/test_roster_moves.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b37e83fc80832e8e55e57b44422d22