### PR TITLE
Refactor reassign players dialog and fix nav highlighting

### DIFF
--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -214,6 +214,13 @@ class MainWindow(QMainWindow):
             side.addWidget(b)
         side.addStretch()
 
+        self.nav_buttons = {
+            "league": self.btn_league,
+            "teams": self.btn_teams,
+            "users": self.btn_users,
+            "utils": self.btn_utils,
+        }
+
         # header + stacked pages -----------------------------------------
         header = QWidget(objectName="Header")
         h = QHBoxLayout(header)
@@ -300,6 +307,11 @@ class MainWindow(QMainWindow):
         view_menu.addAction(theme_action)
 
     def _go(self, key: str) -> None:
+        for btn in self.nav_buttons.values():
+            btn.setChecked(False)
+        btn = self.nav_buttons.get(key)
+        if btn:
+            btn.setChecked(True)
         idx = list(self.pages.keys()).index(key)
         self.stack.setCurrentIndex(idx)
         self.statusBar().showMessage(f"Ready • {key.capitalize()}")

--- a/ui/owner_dashboard.py
+++ b/ui/owner_dashboard.py
@@ -78,6 +78,12 @@ class OwnerDashboard(QMainWindow):
         for b in (self.btn_roster, self.btn_transactions, self.btn_league):
             side.addWidget(b)
 
+        self.nav_buttons = {
+            "roster": self.btn_roster,
+            "transactions": self.btn_transactions,
+            "league": self.btn_league,
+        }
+
         side.addStretch()
         self.btn_settings = NavButton("  Toggle Theme")
         self.btn_settings.clicked.connect(lambda: _toggle_theme(self.statusBar()))
@@ -151,6 +157,11 @@ class OwnerDashboard(QMainWindow):
         view_menu.addAction(theme_action)
 
     def _go(self, key: str) -> None:
+        for btn in self.nav_buttons.values():
+            btn.setChecked(False)
+        btn = self.nav_buttons.get(key)
+        if btn:
+            btn.setChecked(True)
         idx = list(self.pages.keys()).index(key)
         self.stack.setCurrentIndex(idx)
         self.statusBar().showMessage(f"Ready • {key.capitalize()}")

--- a/ui/ui_template.py
+++ b/ui/ui_template.py
@@ -154,6 +154,14 @@ class MainWindow(QMainWindow):
         for b in (self.btn_dashboard, self.btn_league, self.btn_teams, self.btn_users, self.btn_utils):
             side.addWidget(b)
 
+        self.nav_buttons = {
+            "dashboard": self.btn_dashboard,
+            "league": self.btn_league,
+            "teams": self.btn_teams,
+            "users": self.btn_users,
+            "utils": self.btn_utils,
+        }
+
         side.addStretch()
         side.addWidget(QLabel("  Settings"))
         self.btn_settings = NavButton("  Preferences")
@@ -231,6 +239,11 @@ class MainWindow(QMainWindow):
         view_menu.addAction(theme_action)
 
     def _go(self, key):
+        for btn in self.nav_buttons.values():
+            btn.setChecked(False)
+        btn = self.nav_buttons.get(key)
+        if btn:
+            btn.setChecked(True)
         idx = list(self.pages.keys()).index(key)
         self.stack.setCurrentIndex(idx)
         self.statusBar().showMessage(f"Ready • {key.capitalize()}")


### PR DESCRIPTION
## Summary
- Display players in Reassign Players dialog as ACT/AAA/LOW columns with drag-and-drop reassignment
- Highlight only the active navigation button in dashboards and templates

## Testing
- `python -m py_compile ui/reassign_players_dialog.py ui/ui_template.py ui/admin_dashboard.py ui/owner_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3857da3d0832eb8a10bdd32691e4a