### PR TITLE
Add roster counts and save functionality

### DIFF
--- a/ui/reassign_players_dialog.py
+++ b/ui/reassign_players_dialog.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Dialog allowing owners to reassign players between roster levels."""
 
-from typing import Dict
+from typing import Dict, List
 from datetime import datetime
 
 from PyQt6.QtCore import Qt
@@ -20,6 +20,7 @@ from PyQt6.QtWidgets import (
 
 from models.base_player import BasePlayer
 from models.roster import Roster
+from utils.roster_loader import save_roster
 
 
 class ReassignPlayersDialog(QDialog):
@@ -35,11 +36,15 @@ class ReassignPlayersDialog(QDialog):
         self.setWindowTitle("Reassign Players")
 
         self.lists: Dict[str, QListWidget] = {}
+        self.labels: Dict[str, QLabel] = {}
+        self.max_counts: Dict[str, int] = {"act": 25, "aaa": 15, "low": 10}
 
         columns = QHBoxLayout()
         for level in self.levels:
             vbox = QVBoxLayout()
-            vbox.addWidget(QLabel(level.upper()))
+            label = QLabel()
+            vbox.addWidget(label)
+            self.labels[level] = label
             lw = QListWidget()
             lw.setObjectName(level)
             lw.setSelectionMode(QListWidget.SelectionMode.SingleSelection)
@@ -68,9 +73,13 @@ class ReassignPlayersDialog(QDialog):
         move_btn = QPushButton("Reassign")
         move_btn.clicked.connect(self._apply_moves)
 
+        save_btn = QPushButton("Save Roster", objectName="Primary")
+        save_btn.clicked.connect(self._save_roster)
+
         layout = QVBoxLayout(self)
         layout.addLayout(columns)
         layout.addWidget(move_btn)
+        layout.addWidget(save_btn)
 
         def _calc_height(lw: QListWidget) -> int:
             row = lw.sizeHintForRow(0) if lw.count() else 20
@@ -78,6 +87,7 @@ class ReassignPlayersDialog(QDialog):
 
         height = max(_calc_height(lw) for lw in self.lists.values())
         self.resize(600, height)
+        self._update_counts()
 
     def _calculate_age(self, birthdate_str: str):
         try:
@@ -125,4 +135,50 @@ class ReassignPlayersDialog(QDialog):
 
         self.lists[from_level].update()
         self.lists[to_level].update()
+        self._update_counts()
         self.update()
+
+    def _update_counts(self) -> None:
+        """Refresh roster counts displayed above each column."""
+        for level, label in self.labels.items():
+            count = len(getattr(self.roster, level))
+            max_count = self.max_counts.get(level)
+            label.setText(f"{level.upper()} ({count}/{max_count})")
+
+    def _validate_roster(self) -> List[str]:
+        """Return a list of roster rule violations."""
+        errors: List[str] = []
+        if len(self.roster.act) > self.max_counts["act"]:
+            errors.append("Active roster exceeds 25 players.")
+
+        pos_players = [
+            pid
+            for pid in self.roster.act
+            if (player := self.players.get(pid)) and player.primary_position != "P"
+        ]
+        if len(pos_players) < 11:
+            errors.append("Active roster must have at least 11 position players.")
+
+        if len(self.roster.aaa) > self.max_counts["aaa"]:
+            errors.append("AAA roster exceeds 15 players.")
+
+        if len(self.roster.low) > self.max_counts["low"]:
+            errors.append("Low roster exceeds 10 players.")
+
+        return errors
+
+    def _save_roster(self) -> None:
+        """Persist roster changes to disk after validating rules."""
+        errors = self._validate_roster()
+        if errors:
+            QMessageBox.warning(self, "Roster Violations", "\n".join(errors))
+            return
+
+        try:
+            save_roster(self.roster.team_id, self.roster)
+        except Exception as exc:  # pragma: no cover - UI feedback
+            QMessageBox.critical(self, "Save Failed", str(exc))
+            return
+
+        QMessageBox.information(self, "Roster Saved", "Roster saved successfully.")
+


### PR DESCRIPTION
## Summary
- Show dynamic player counts for each roster level in the Reassign Players dialog
- Add Save Roster button that writes changes to roster files
- Validate roster size and composition before saving and alert on violations

## Testing
- `python -m py_compile ui/reassign_players_dialog.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3989d9f98832e8a68eaf4bf6bc3a8