### PR TITLE
Fix roster count updates on reassign players screen

### DIFF
--- a/ui/reassign_players_dialog.py
+++ b/ui/reassign_players_dialog.py
@@ -181,7 +181,7 @@ class ReassignPlayersDialog(QDialog):
     def _update_counts(self) -> None:
         """Refresh roster counts displayed above each column."""
         for level, label in self.labels.items():
-            count = len(getattr(self.roster, level))
+            count = self.lists[level].count()
             max_count = self.max_counts.get(level)
             label.setText(f"{level.upper()} ({count}/{max_count})")
 


### PR DESCRIPTION
## Summary
- ensure roster counts reflect actual list widget contents in reassign players dialog

## Testing
- `python -m py_compile ui/reassign_players_dialog.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3a16a0d28832e9e64758ee102214f