### PR TITLE
Handle Windows spawn start method in season simulator

### DIFF
--- a/scripts/simulate_season_avg.py
+++ b/scripts/simulate_season_avg.py
@@ -188,7 +188,7 @@ def simulate_season_average(use_tqdm: bool = True) -> None:
     # pickling errors, so fall back to a simple sequential loop when the
     # ``spawn`` method is active.  This keeps the function usable on Windows
     # while still taking advantage of multiprocessing on Unix-like systems.
-    use_pool = mp.get_start_method(allow_none=True) != "spawn"
+    use_pool = mp.get_start_method() != "spawn"
 
     if use_pool:
         with mp.Pool(initializer=_init_pool, initargs=(base_states, cfg)) as pool:


### PR DESCRIPTION
## Summary
- Ensure `simulate_season_avg` avoids multiprocessing when the `spawn` start method is active

## Testing
- `python - <<'PY'
import multiprocessing as mp
mp.set_start_method('spawn', force=True)
import importlib
s = importlib.import_module('scripts.simulate_season_avg')
print('start method', mp.get_start_method())
use_pool = mp.get_start_method() != 'spawn'
print('use_pool', use_pool)
PY`
- `python -m py_compile scripts/simulate_season_avg.py`

------
https://chatgpt.com/codex/tasks/task_e_68b3a8ec6cf0832e8410a607c30249ff