### PR TITLE
Add ground and fly ball tracking to stats

### DIFF
--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -65,6 +65,8 @@ class BatterState:
     pitches: int = 0  # Pitches seen
     lob: int = 0  # Left on base
     lead: int = 0  # Lead level
+    gb: int = 0  # Ground balls put in play
+    fb: int = 0  # Fly balls put in play
 
 
 @dataclass
@@ -113,6 +115,8 @@ class PitcherState:
     consecutive_baserunners: int = 0  # Consecutive batters reaching base
     is_toast: bool = False  # Reliever toast flag
     allowed_hr: bool = False  # True if last batter hit a home run
+    gb: int = 0  # Ground balls induced
+    fb: int = 0  # Fly balls induced
 
     # Backwards compatibility accessors
     @property
@@ -1081,6 +1085,8 @@ class GameSimulation:
                         batter,
                         pitcher,
                         defense,
+                        batter_state,
+                        pitcher_state,
                         pitch_speed=pitch_speed,
                         rand=dec_r,
                         contact_quality=contact_quality,
@@ -1481,6 +1487,8 @@ class GameSimulation:
         batter: Player,
         pitcher: Pitcher,
         defense: TeamState,
+        batter_state: BatterState,
+        pitcher_state: PitcherState,
         *,
         pitch_speed: float,
         rand: float,
@@ -1502,6 +1510,12 @@ class GameSimulation:
         launch_angle = swing_angle + vert_angle + power_adjust
         self.last_batted_ball_type = "ground" if launch_angle < 0 else "fly"
         self.last_batted_ball_angles = (swing_angle, vert_angle)
+        if self.last_batted_ball_type == "ground":
+            self._add_stat(batter_state, "gb")
+            pitcher_state.gb += 1
+        else:
+            self._add_stat(batter_state, "fb")
+            pitcher_state.fb += 1
         roll_dist = self.physics.ball_roll_distance(
             bat_speed,
             self.surface,

--- a/logic/stats.py
+++ b/logic/stats.py
@@ -31,6 +31,7 @@ def compute_batting_rates(stats: 'BatterState') -> Dict[str, float]:
     hbp = stats.hbp
     sf = stats.sf
     tb = derived["tb"]
+    gb_fb_den = stats.gb + stats.fb
 
     avg = h / ab if ab else 0.0
     obp_den = ab + bb + hbp + sf
@@ -45,6 +46,9 @@ def compute_batting_rates(stats: 'BatterState') -> Dict[str, float]:
     bb_k = bb / stats.so if stats.so else 0.0
     sb_den = stats.sb + stats.cs
     sb_pct = stats.sb / sb_den if sb_den else 0.0
+    gb_pct = stats.gb / gb_fb_den if gb_fb_den else 0.0
+    fb_pct = stats.fb / gb_fb_den if gb_fb_den else 0.0
+    gb_fb = stats.gb / stats.fb if stats.fb else 0.0
 
     return {
         "avg": avg,
@@ -57,6 +61,9 @@ def compute_batting_rates(stats: 'BatterState') -> Dict[str, float]:
         "k_pct": k_pct,
         "bb_k": bb_k,
         "sb_pct": sb_pct,
+        "gb_pct": gb_pct,
+        "fb_pct": fb_pct,
+        "gb_fb": gb_fb,
     }
 
 
@@ -111,6 +118,10 @@ def compute_pitching_rates(stats: 'PitcherState') -> Dict[str, float]:
         stats.o_zone_contacts / stats.o_zone_swings if stats.o_zone_swings else 0.0
     )
     ozone_pct = o_zone_pitches / stats.pitches_thrown if stats.pitches_thrown else 0.0
+    gb_fb_den = stats.gb + stats.fb
+    gb_pct = stats.gb / gb_fb_den if gb_fb_den else 0.0
+    fb_pct = stats.fb / gb_fb_den if gb_fb_den else 0.0
+    gb_fb = stats.gb / stats.fb if stats.fb else 0.0
 
     return {
         "h9": h9,
@@ -129,6 +140,9 @@ def compute_pitching_rates(stats: 'PitcherState') -> Dict[str, float]:
         "ozone_pct": ozone_pct,
         "ozone_swing_pct": ozone_swing_pct,
         "ozone_contact_pct": ozone_contact_pct,
+        "gb_pct": gb_pct,
+        "fb_pct": fb_pct,
+        "gb_fb": gb_fb,
     }
 
 

--- a/tests/test_ground_fly_distribution.py
+++ b/tests/test_ground_fly_distribution.py
@@ -1,7 +1,12 @@
 import random
 import pytest
 
-from logic.simulation import GameSimulation, TeamState
+from logic.simulation import (
+    BatterState,
+    GameSimulation,
+    PitcherState,
+    TeamState,
+)
 from logic.playbalance_config import PlayBalanceConfig
 from tests.test_physics import make_player, make_pitcher
 
@@ -14,11 +19,15 @@ def test_ground_fly_distribution():
     defense = TeamState(lineup=[make_player("d")], bench=[], pitchers=[pitcher])
     offense = TeamState(lineup=[batter], bench=[], pitchers=[make_pitcher("op")])
     sim = GameSimulation(defense, offense, cfg, rng)
+    b_state = BatterState(batter)
+    p_state = PitcherState(pitcher)
 
     total = 5000
     ground = fly = 0
     for _ in range(total):
-        sim._swing_result(batter, pitcher, defense, pitch_speed=90, rand=rng.random())
+        sim._swing_result(
+            batter, pitcher, defense, b_state, p_state, pitch_speed=90, rand=rng.random()
+        )
         if sim.last_batted_ball_type == "ground":
             ground += 1
         else:

--- a/tests/test_ground_fly_stats.py
+++ b/tests/test_ground_fly_stats.py
@@ -1,0 +1,63 @@
+import random
+
+import pytest
+
+from logic.simulation import (
+    BatterState,
+    GameSimulation,
+    PitcherState,
+    TeamState,
+)
+from logic.playbalance_config import PlayBalanceConfig
+from logic.stats import compute_batting_rates, compute_pitching_rates
+from tests.test_physics import make_player, make_pitcher
+
+
+def test_swing_result_tracks_ground_fly(monkeypatch):
+    cfg_gb = PlayBalanceConfig.from_dict({"groundBallBaseRate": 100, "flyBallBaseRate": 0})
+    batter = make_player("b")
+    pitcher = make_pitcher("p")
+    defense = TeamState(lineup=[make_player("d")], bench=[], pitchers=[pitcher])
+    offense = TeamState(lineup=[batter], bench=[], pitchers=[make_pitcher("op")])
+    sim = GameSimulation(defense, offense, cfg_gb, random.Random(0))
+    monkeypatch.setattr(sim.fielding_ai, "catch_action", lambda *a, **k: "no_attempt")
+    monkeypatch.setattr(sim.physics, "landing_point", lambda *a, **k: (100.0, 0.0, 1.0))
+    monkeypatch.setattr(sim.physics, "ball_roll_distance", lambda *a, **k: 0.0)
+    monkeypatch.setattr(sim.physics, "ball_bounce", lambda *a, **k: (0.0, 0.0))
+    b_state = BatterState(batter)
+    p_state = PitcherState(pitcher)
+    sim._swing_result(batter, pitcher, defense, b_state, p_state, pitch_speed=90, rand=0.0)
+    assert b_state.gb == 1 and p_state.gb == 1 and b_state.fb == 0 and p_state.fb == 0
+
+    cfg_fb = PlayBalanceConfig.from_dict({"groundBallBaseRate": 0, "flyBallBaseRate": 100})
+    sim_fly = GameSimulation(defense, offense, cfg_fb, random.Random(0))
+    monkeypatch.setattr(sim_fly.fielding_ai, "catch_action", lambda *a, **k: "no_attempt")
+    monkeypatch.setattr(sim_fly.physics, "landing_point", lambda *a, **k: (100.0, 0.0, 1.0))
+    monkeypatch.setattr(sim_fly.physics, "ball_roll_distance", lambda *a, **k: 0.0)
+    monkeypatch.setattr(sim_fly.physics, "ball_bounce", lambda *a, **k: (0.0, 0.0))
+    b_state2 = BatterState(batter)
+    p_state2 = PitcherState(pitcher)
+    sim_fly._swing_result(
+        batter, pitcher, defense, b_state2, p_state2, pitch_speed=90, rand=0.0
+    )
+    assert b_state2.fb == 1 and p_state2.fb == 1 and b_state2.gb == 0 and p_state2.gb == 0
+
+
+def test_ground_fly_rates():
+    batter = make_player("b")
+    bs = BatterState(batter)
+    bs.gb = 30
+    bs.fb = 20
+    rates = compute_batting_rates(bs)
+    assert rates["gb_pct"] == pytest.approx(0.6)
+    assert rates["fb_pct"] == pytest.approx(0.4)
+    assert rates["gb_fb"] == pytest.approx(1.5)
+
+    pitcher = make_pitcher("p")
+    ps = PitcherState(pitcher)
+    ps.gb = 40
+    ps.fb = 10
+    prates = compute_pitching_rates(ps)
+    assert prates["gb_pct"] == pytest.approx(0.8)
+    assert prates["fb_pct"] == pytest.approx(0.2)
+    assert prates["gb_fb"] == pytest.approx(4.0)

--- a/tests/test_stadium_dimensions.py
+++ b/tests/test_stadium_dimensions.py
@@ -1,7 +1,12 @@
 import random
 
 from logic.field_geometry import Stadium
-from logic.simulation import GameSimulation, TeamState
+from logic.simulation import (
+    BatterState,
+    GameSimulation,
+    PitcherState,
+    TeamState,
+)
 from models.player import Player
 from models.pitcher import Pitcher
 from tests.util.pbini_factory import make_cfg
@@ -69,7 +74,11 @@ def test_custom_stadium_affects_hit_value(monkeypatch):
     monkeypatch.setattr(sim.physics, "ball_roll_distance", lambda *a, **k: 0.0)
     monkeypatch.setattr(sim.physics, "ball_bounce", lambda *a, **k: (0.0, 0.0))
 
-    bases, _ = sim._swing_result(batter, pitcher, home, pitch_speed=50, rand=0.0)
+    b_state = BatterState(batter)
+    p_state = PitcherState(pitcher)
+    bases, _ = sim._swing_result(
+        batter, pitcher, home, b_state, p_state, pitch_speed=50, rand=0.0
+    )
     assert bases == 3
 
     small = Stadium(left=300.0, center=300.0, right=300.0)
@@ -83,8 +92,10 @@ def test_custom_stadium_affects_hit_value(monkeypatch):
         sim_small.physics, "ball_bounce", lambda *a, **k: (0.0, 0.0)
     )
 
+    b_state = BatterState(batter)
+    p_state = PitcherState(pitcher)
     bases_small, _ = sim_small._swing_result(
-        batter, pitcher, home, pitch_speed=50, rand=0.0
+        batter, pitcher, home, b_state, p_state, pitch_speed=50, rand=0.0
     )
     assert bases_small == 4
 


### PR DESCRIPTION
## Summary
- Track ground balls and fly balls for batters and pitchers during simulation
- Expose ground-ball and fly-ball rates in batting and pitching statistics
- Add tests for ground/fly tracking and rate calculations

## Testing
- `pytest tests/test_ground_fly_stats.py tests/test_stadium_dimensions.py tests/test_ground_fly_distribution.py tests/test_physics.py::test_swing_result_respects_bat_speed tests/test_physics.py::test_power_hitter_can_hit_home_run tests/test_simulation.py::test_throw_error_results_in_roe -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3b656a940832e99ffd34cd8521c95