### PR TITLE
Apply ground/fly launch angle adjustment

### DIFF
--- a/docs/simulation_engine.md
+++ b/docs/simulation_engine.md
@@ -65,6 +65,10 @@ seed the simulation's batted-ball model. `PlayBalanceConfig` exposes knobs to
 tune them: `foulPitchBasePct` sets the foul-per-pitch rate【F:logic/playbalance_config.py†L142-L147】,
 while `groundBallBaseRate` and `flyBallBaseRate` establish grounder and fly-ball
 shares that influence vertical launch angles【F:logic/playbalance_config.py†L134-L135】.
+`vertAngleGFPct` further adjusts the vertical angle based on a batter's
+ground/fly rating—positive values push fly-ball hitters to loft the ball and
+ground-ball hitters to keep it down. The default of ``0`` preserves the MLB
+average split of roughly 45% grounders and 55% flies.
 
 ## Statistics
 
@@ -85,6 +89,9 @@ Key entries now available include:
 - **`exitVeloPHPct`** – percentage boost to exit velocity for pinch hitters.
 - **`groundBallBaseRate`** – baseline percentage of balls in play that become grounders【F:logic/playbalance_config.py†L134】.
 - **`flyBallBaseRate`** – baseline percentage of balls in play that become fly balls【F:logic/playbalance_config.py†L135】.
+- **`vertAngleGFPct`** – percentage adjustment to vertical launch angle based on a
+  batter's ground/fly rating; the default ``0`` yields MLB-average ground/fly
+  proportions.
 - **`sprayAnglePLPct`** – pull/line tendency applied to spray angle calculations.
 - **`minMisreadContact`** – minimum contact quality applied when a batter
   completely misidentifies a pitch.

--- a/logic/physics.py
+++ b/logic/physics.py
@@ -316,11 +316,14 @@ class Physics:
     # ------------------------------------------------------------------
     # Vertical hit angle
     # ------------------------------------------------------------------
-    def vertical_hit_angle(self, swing_type: str = "normal") -> float:
+    def vertical_hit_angle(self, swing_type: str = "normal", gf: int = 50) -> float:
         """Return vertical launch angle offset for ``swing_type``.
 
-        The original game determines the vertical angle of the ball off the bat
-        by rolling a configurable number of dice.  Each swing type uses its own
+        ``gf`` is the batter's ground/fly rating.  When the configuration
+        entry ``vertAngleGFPct`` is non-zero the angle is nudged by ``gf`` so
+        high values yield more fly balls and low values more grounders.  The
+        original game determines the vertical angle of the ball off the bat by
+        rolling a configurable number of dice.  Each swing type uses its own
         ``hitAngleCount*``, ``hitAngleFaces*`` and ``hitAngleBase*`` values from
         :class:`PlayBalanceConfig`.  The dice results are summed, adjusted by the
         base value and then converted into an angle between ``-90`` and ``+90``
@@ -338,7 +341,12 @@ class Physics:
             roll += self.rng.randint(1, max(1, faces))
 
         roll = max(1, min(59, roll))
-        return (roll - 30) * (180.0 / 58.0)
+        angle = (roll - 30) * (180.0 / 58.0)
+
+        gf_pct = getattr(self.config, "vertAngleGFPct")
+        angle += (gf - 50) * gf_pct / 100.0
+
+        return angle
 
     # ------------------------------------------------------------------
     # Ball physics

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -1437,7 +1437,7 @@ class GameSimulation:
         bat_speed = self.physics.bat_speed(batter.ph, pitch_speed=pitch_speed)
         bat_speed, _ = self.physics.bat_impact(bat_speed, rand=rand)
         swing_angle = self.physics.swing_angle(batter.gf)
-        vert_angle = self.physics.vertical_hit_angle()
+        vert_angle = self.physics.vertical_hit_angle(gf=batter.gf)
         vx, vy, vz = self.physics.launch_vector(
             getattr(batter, "ph", 50),
             getattr(batter, "pl", 50),
@@ -1498,7 +1498,7 @@ class GameSimulation:
         bat_speed, _ = self.physics.bat_impact(bat_speed, rand=rand)
         # Calculate and store angles for potential future physics steps.
         swing_angle = self.physics.swing_angle(batter.gf)
-        vert_base = abs(self.physics.vertical_hit_angle())
+        vert_base = abs(self.physics.vertical_hit_angle(gf=batter.gf))
         power_adjust = (getattr(batter, "ph", 50) - 50) * 0.1
         gb = self.config.ground_ball_base_rate
         fb = self.config.fly_ball_base_rate

--- a/tests/test_ground_fly_distribution.py
+++ b/tests/test_ground_fly_distribution.py
@@ -38,3 +38,34 @@ def test_ground_fly_distribution():
     expected_fly = fb_rate / (gb_rate + fb_rate)
     assert ground / total == pytest.approx(expected_ground, abs=0.02)
     assert fly / total == pytest.approx(expected_fly, abs=0.02)
+
+
+def test_vert_angle_gf_pct_shifts_distribution():
+    cfg0 = PlayBalanceConfig.from_dict({"vertAngleGFPct": 0})
+    cfg10 = PlayBalanceConfig.from_dict({"vertAngleGFPct": 10})
+
+    def run(cfg):
+        rng = random.Random(0)
+        batter = make_player("b")
+        batter.gf = 0
+        pitcher = make_pitcher("p")
+        defense = TeamState(lineup=[make_player("d")], bench=[], pitchers=[pitcher])
+        offense = TeamState(lineup=[batter], bench=[], pitchers=[make_pitcher("op")])
+        sim = GameSimulation(defense, offense, cfg, rng)
+        b_state = BatterState(batter)
+        p_state = PitcherState(pitcher)
+        ground = fly = 0
+        for _ in range(1000):
+            sim._swing_result(
+                batter, pitcher, defense, b_state, p_state, pitch_speed=90, rand=rng.random()
+            )
+            if sim.last_batted_ball_type == "ground":
+                ground += 1
+            else:
+                fly += 1
+        return ground, fly
+
+    ground0, fly0 = run(cfg0)
+    ground10, fly10 = run(cfg10)
+    assert ground10 < ground0
+    assert fly10 > fly0


### PR DESCRIPTION
## Summary
- adjust `Physics.vertical_hit_angle` using batter ground/fly rating via `vertAngleGFPct`
- document new launch angle tuning option and default MLB splits
- add regression test confirming `vertAngleGFPct` changes ground/fly balance

## Testing
- `pytest tests/test_ground_fly_distribution.py::test_vert_angle_gf_pct_shifts_distribution tests/test_physics.py::test_vertical_hit_angle_power_vs_contact tests/test_coordinate_simulation.py::test_routine_fly_caught -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3b997827c832ebc537cc35efb12c7