### PR TITLE
Tone down batted-ball power and launch angles

### DIFF
--- a/data/playbalance_overrides.json
+++ b/data/playbalance_overrides.json
@@ -1,4 +1,9 @@
 {
+  "exitVeloBase": -3,
+  "vertAngleGFPct": -5,
+  "groundBallBaseRate": 50,
+  "flyBallBaseRate": 50,
+  "hitHRProb": 10,
   "idRatingBase": 44,
   "idRatingCHPct": 90,
   "idRatingExpPct": 80,

--- a/docs/simulation_engine.md
+++ b/docs/simulation_engine.md
@@ -65,10 +65,10 @@ seed the simulation's batted-ball model. `PlayBalanceConfig` exposes knobs to
 tune them: `foulPitchBasePct` sets the foul-per-pitch rate【F:logic/playbalance_config.py†L142-L147】,
 while `groundBallBaseRate` and `flyBallBaseRate` establish grounder and fly-ball
 shares that influence vertical launch angles【F:logic/playbalance_config.py†L134-L135】.
-`vertAngleGFPct` further adjusts the vertical angle based on a batter's
-ground/fly rating—positive values push fly-ball hitters to loft the ball and
-ground-ball hitters to keep it down. The default of ``0`` preserves the MLB
-average split of roughly 45% grounders and 55% flies.
+A slight negative `vertAngleGFPct` flattens trajectories, nudging extreme
+ground- or fly-ball hitters toward the middle. The defaults now bias outcomes
+toward an even **50/50** split rather than the previous MLB-average of roughly
+45% grounders and 55% flies.
 
 ## Statistics
 
@@ -90,8 +90,8 @@ Key entries now available include:
 - **`groundBallBaseRate`** – baseline percentage of balls in play that become grounders【F:logic/playbalance_config.py†L134】.
 - **`flyBallBaseRate`** – baseline percentage of balls in play that become fly balls【F:logic/playbalance_config.py†L135】.
 - **`vertAngleGFPct`** – percentage adjustment to vertical launch angle based on a
-  batter's ground/fly rating; the default ``0`` yields MLB-average ground/fly
-  proportions.
+  batter's ground/fly rating; the default ``-5`` gently flattens launch angles
+  toward an even ground/fly distribution.
 - **`sprayAnglePLPct`** – pull/line tendency applied to spray angle calculations.
 - **`minMisreadContact`** – minimum contact quality applied when a batter
   completely misidentifies a pitch.

--- a/logic/physics.py
+++ b/logic/physics.py
@@ -445,10 +445,11 @@ class Physics:
         velocities.
         """
 
-        speed_mph = 50 + ph * 0.5
+        # Scale down raw power so balls carry a bit less distance
+        speed_mph = 50 + ph * 0.45
         speed_fps = speed_mph * 5280 / 3600
 
-        power_adjust = (ph - 50) * 0.1
+        power_adjust = (ph - 50) * 0.08
         vert_angle = swing_angle + vertical_hit_angle + power_adjust
         horiz_angle = -45 + pl * 0.9
 

--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -127,17 +127,17 @@ _DEFAULTS: Dict[str, Any] = {
     "throwSpeedOFDistPct": 3,
     "throwSpeedOFMax": 92,
     # Exit velocity and launch characteristics
-    "exitVeloBase": 0,
+    "exitVeloBase": -3,
     "exitVeloPHPct": 0,
-    "vertAngleGFPct": 0,
+    "vertAngleGFPct": -5,
     "sprayAnglePLPct": 0,
-    "groundBallBaseRate": 45,
-    "flyBallBaseRate": 55,
+    "groundBallBaseRate": 50,
+    "flyBallBaseRate": 50,
     # Hit type distribution reflecting MLB averages
     "hit1BProb": 64,
     "hit2BProb": 20,
     "hit3BProb": 2,
-    "hitHRProb": 14,
+    "hitHRProb": 10,
     # Foul ball tuning -----------------------------------------------
     # Percentages for foul balls; strike-based rate is derived from all pitches.
     "foulPitchBasePct": _FOUL_PITCH_BASE_PCT,


### PR DESCRIPTION
## Summary
- Reduce baseline exit velocity and boost ground-ball tendency
- Lower home-run probability and flatten launch angles
- Scale back launch_vector power so hits carry less

## Testing
- `python -m py_compile logic/playbalance_config.py logic/physics.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3e44ae714832e8343cf181ad91f75