### PR TITLE
Adjust triple and strikeout tuning

### DIFF
--- a/logic/field_geometry.py
+++ b/logic/field_geometry.py
@@ -40,7 +40,7 @@ class Stadium:
     center: float = 400.0
     right: float = 330.0
     double: float = 200.0 / 380.0
-    triple: float = 300.0 / 380.0
+    triple: float = 360.0 / 380.0
 
     def wall_distance(self, angle: float) -> float:
         """Return the distance to the wall at ``angle`` in radians.

--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -217,7 +217,7 @@ _DEFAULTS: Dict[str, Any] = {
     "disciplineRating30CountAdjust": 60,
     "disciplineRating31CountAdjust": 5,
     "disciplineRating32CountAdjust": 15,
-    "minMisreadContact": 0.2,
+    "minMisreadContact": 0.4,
     # Check-swing tuning ---------------------------------------------------
     "checkChanceBasePower": 150,
     "checkChanceBaseNormal": 250,

--- a/tests/test_playbalance_config.py
+++ b/tests/test_playbalance_config.py
@@ -23,7 +23,7 @@ def test_playbalance_config_defaults():
     assert cfg.foulPitchBasePct == 18.3
     assert cfg.foulStrikeBasePct == pytest.approx(27.8, abs=0.01)
     assert cfg.foulContactTrendPct == 1.5
-    assert cfg.minMisreadContact == 0.2
+    assert cfg.minMisreadContact == 0.4
 
     # Pitcher AI defaults
     assert cfg.pitchRatVariationCount == 1


### PR DESCRIPTION
## Summary
- Raise triple distance requirement so balls must travel farther before being scored as a triple
- Increase minimum contact on misread pitches to cut down on strikeouts
- Update tests for new default contact value

## Testing
- `python -m py_compile logic/field_geometry.py logic/playbalance_config.py tests/test_playbalance_config.py`
- `pytest tests/test_playbalance_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4b69e91f8832ebe6647b21ad0457e