### PR TITLE
Scale misread contact floor by hitter rating

### DIFF
--- a/docs/simulation_engine.md
+++ b/docs/simulation_engine.md
@@ -94,5 +94,7 @@ Key entries now available include:
   toward an even ground/fly distribution.
 - **`sprayAnglePLPct`** – pull/line tendency applied to spray angle calculations.
 - **`minMisreadContact`** – minimum contact quality applied when a batter
-  completely misidentifies a pitch.
+  completely misidentifies a pitch.  The value acts as a floor scaled by the
+  batter's contact rating so weak hitters still produce occasional foul tips
+  without generating excessive hits.
 

--- a/logic/batter_ai.py
+++ b/logic/batter_ai.py
@@ -351,10 +351,10 @@ class BatterAI:
             success = int(type_id) + int(loc_id) + int(time_id)
             self.last_misread = success == 0
             if self.last_misread:
-                contact = min(
-                    getattr(batter, "ch", 0) / 1000.0,
-                    float(self.config.get("minMisreadContact", 0.15)),
-                )
+                ch = getattr(batter, "ch", 0)
+                base_floor = float(self.config.get("minMisreadContact", 0.15))
+                scaled_floor = base_floor * ch / 100.0
+                contact = max(ch / 1000.0, scaled_floor)
             else:
                 ch_factor = getattr(batter, "ch", 0) / 100.0
                 weights = [

--- a/tests/test_batter_ai.py
+++ b/tests/test_batter_ai.py
@@ -53,6 +53,46 @@ def test_misidentification_reduces_contact():
     assert contact == 0.0
 
 
+def test_misread_contact_has_scaled_floor():
+    cfg = make_cfg(
+        idRatingBase=0,
+        idRatingCHPct=0,
+        idRatingExpPct=0,
+        idRatingPitchRatPct=0,
+        minMisreadContact=0.2,
+    )
+    ai = BatterAI(cfg)
+    pitcher = make_pitcher("p1")
+
+    batter_low = make_player("low", ch=20)
+    batter_high = make_player("high", ch=80)
+
+    swing_low, contact_low = ai.decide_swing(
+        batter_low,
+        pitcher,
+        pitch_type="fb",
+        balls=0,
+        strikes=0,
+        dist=0,
+        random_value=0.0,
+    )
+
+    swing_high, contact_high = ai.decide_swing(
+        batter_high,
+        pitcher,
+        pitch_type="fb",
+        balls=0,
+        strikes=0,
+        dist=0,
+        random_value=0.0,
+    )
+
+    assert swing_low is True and swing_high is True
+    assert contact_low == pytest.approx(0.04)
+    assert contact_high == pytest.approx(0.16)
+    assert contact_high > contact_low
+
+
 def test_primary_look_adjust_increases_swings():
     cfg = load_config()
     cfg.values.update(


### PR DESCRIPTION
## Summary
- treat `minMisreadContact` as a floor and scale it by batter contact rating
- document and test baseline foul contact behaviour

## Testing
- `pytest tests/test_batter_ai.py::test_misread_contact_has_scaled_floor -q`
- `pytest tests/test_batter_ai.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4db13bbd0832ea893d9211fb115b6