### PR TITLE
Make swing decision probabilities configurable

### DIFF
--- a/logic/batter_ai.py
+++ b/logic/batter_ai.py
@@ -326,13 +326,13 @@ class BatterAI:
         if type_id or loc_id:
             swing = is_strike
         else:
-            swing_probs = {
-                "sure strike": 0.75,
-                "close strike": 0.5,
-                "close ball": 0.35,
-                "sure ball": 0.1,
-            }
-            swing_prob = swing_probs[p_class]
+            cfg = self.config
+            swing_prob = {
+                "sure strike": cfg.get("swingProbSureStrike", 0.75),
+                "close strike": cfg.get("swingProbCloseStrike", 0.5),
+                "close ball": cfg.get("swingProbCloseBall", 0.35),
+                "sure ball": cfg.get("swingProbSureBall", 0.1),
+            }[p_class]
             if p_class in {"close ball", "sure ball"}:
                 swing_prob = max(
                     0.0, swing_prob - getattr(batter, "ch", 0) / 400.0

--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -171,6 +171,11 @@ _DEFAULTS: Dict[str, Any] = {
     "sureStrikeDist": 4,
     "closeStrikeDist": 5,
     "closeBallDist": 4,
+    # Baseline swing probabilities reflecting MLB averages
+    "swingProbSureStrike": 0.75,
+    "swingProbCloseStrike": 0.5,
+    "swingProbCloseBall": 0.35,
+    "swingProbSureBall": 0.1,
     "lookPrimaryType00CountAdjust": 0,
     "lookPrimaryType01CountAdjust": 0,
     "lookPrimaryType02CountAdjust": 0,

--- a/tests/util/pbini_factory.py
+++ b/tests/util/pbini_factory.py
@@ -14,7 +14,16 @@ def make_cfg(**entries: int) -> PlayBalanceConfig:
     fall back to :class:`PlayBalanceConfig` defaults when accessed.
     """
 
-    base_entries = {"hit1BProb": 100, "hit2BProb": 0, "hit3BProb": 0, "hitHRProb": 0}
+    base_entries = {
+        "hit1BProb": 100,
+        "hit2BProb": 0,
+        "hit3BProb": 0,
+        "hitHRProb": 0,
+        "swingProbSureStrike": 0.75,
+        "swingProbCloseStrike": 0.5,
+        "swingProbCloseBall": 0.35,
+        "swingProbSureBall": 0.1,
+    }
     base_entries.update(entries)
     return PlayBalanceConfig.from_dict({"PlayBalance": base_entries})
 
@@ -30,8 +39,19 @@ def load_config(path: Path | None = None) -> PlayBalanceConfig:
     path = Path("logic/PBINI.txt") if path is None else Path(path)
     pbini = load_pbini(path)
     cfg = PlayBalanceConfig.from_dict(pbini)
-    # Default to singles only for deterministic tests unless overridden later
-    cfg.values.update({"hit1BProb": 100, "hit2BProb": 0, "hit3BProb": 0, "hitHRProb": 0})
+    # Default to singles only and deterministic swing probabilities for tests
+    cfg.values.update(
+        {
+            "hit1BProb": 100,
+            "hit2BProb": 0,
+            "hit3BProb": 0,
+            "hitHRProb": 0,
+            "swingProbSureStrike": 0.75,
+            "swingProbCloseStrike": 0.5,
+            "swingProbCloseBall": 0.35,
+            "swingProbSureBall": 0.1,
+        }
+    )
     # The real configuration contains pitch objective weights which would
     # introduce additional randomness via :class:`PitcherAI`.  Tests expect
     # deterministic behaviour so clear all such weights.


### PR DESCRIPTION
## Summary
- Read swing decision probabilities from `PlayBalanceConfig`
- Add MLB-calibrated `swingProb*` defaults to configuration and test helpers
- Allow tests to set deterministic swing probabilities

## Testing
- `pytest tests/test_batter_ai.py::test_swing_decision_respects_idrating -q`
- `pytest tests/test_batter_ai.py::test_contact_quality_variability -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4dd564274832e816c123895ebacc7