### PR TITLE
feat: tune movement influence scaling

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -145,8 +145,8 @@ _DEFAULTS: Dict[str, Any] = {
     "hitProbBase": 0.02,
     "contactFactorBase": 0.8,
     "contactFactorDiv": 280.0,
-    "movementFactorMin": 0.15,
-    "movementFactorDiv": 90.0,
+    "movementFactorMin": 0.3,
+    "movementImpactScale": 1.0,
     # Foul ball tuning -----------------------------------------------
     # Percentages for foul balls; strike-based rate is derived from all pitches.
     "foulPitchBasePct": _FOUL_PITCH_BASE_PCT,
@@ -682,9 +682,9 @@ class PlayBalanceConfig:
         return float(self.movementFactorMin)
 
     @property
-    def movement_factor_div(self) -> float:
-        """Divisor for scaling pitcher movement in the hit calculation."""
-        return float(self.movementFactorDiv)
+    def movement_impact_scale(self) -> float:
+        """Scale applied to pitcher movement's effect in hit probability."""
+        return float(self.movementImpactScale)
 
     # ------------------------------------------------------------------
     # Mapping style helpers

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -1543,7 +1543,8 @@ class GameSimulation:
         )
         movement_factor = max(
             self.config.movement_factor_min,
-            (100 - pitcher.movement) / self.config.movement_factor_div,
+            ((100 - pitcher.movement) / 120)
+            * self.config.movement_impact_scale,
         )
         contact_factor = (
             self.config.contact_factor_base


### PR DESCRIPTION
## Summary
- soften pitcher movement impact with gentler formula
- expose `movementImpactScale` in `PlayBalanceConfig`

## Testing
- `python scripts/simulate_season_avg.py` *(fails: Team DRO does not have enough position players)*
- `pytest tests/test_playbalance_config.py::test_playbalance_config_defaults -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4de3aed84832e82a1848e0a28889a