### PR TITLE
Tune pitch control towards MLB strike rate

### DIFF
--- a/data/playbalance_overrides.json
+++ b/data/playbalance_overrides.json
@@ -53,5 +53,7 @@
   "timingGoodBase": -56,
   "timingVeryGoodCount": 9,
   "timingVeryGoodFaces": 13,
-  "timingVeryGoodBase": -63
+  "timingVeryGoodBase": -63,
+  "controlScale": 225,
+  "controlBoxIncreaseEffCOPct": 15
 }


### PR DESCRIPTION
## Summary
- Raise play balance `controlScale` to 225 and set `controlBoxIncreaseEffCOPct` to 15 for broader pitch miss distance
- Aim for strike rate closer to MLB average

## Testing
- `python - <<'PY' ...` *(simulate 100 games to gather pitch/strike totals)*


------
https://chatgpt.com/codex/tasks/task_e_68b4e709327c832e9ece1d1f2752c801