### PR TITLE
Tune swing probability and contact factors

### DIFF
--- a/data/playbalance_overrides.json
+++ b/data/playbalance_overrides.json
@@ -8,7 +8,7 @@
   "idRatingCHPct": 100,
   "idRatingExpPct": 90,
   "idRatingPitchRatPct": 100,
-  "minMisreadContact": 0.5,
+  "minMisreadContact": 0.3,
   "foulStrikeBasePct": 31,
   "foulContactTrendPct": 2.0,
   "catchBaseChance": 92,

--- a/logic/batter_ai.py
+++ b/logic/batter_ai.py
@@ -337,6 +337,8 @@ class BatterAI:
                 swing_prob = max(
                     0.0, swing_prob - getattr(batter, "ch", 0) / 400.0
                 )
+            swing_prob *= cfg.get("swingProbScale", 1.0)
+            swing_prob = max(0.0, min(1.0, swing_prob))
             swing = rand_type < swing_prob
 
         if swing and p_class in {"close ball", "sure ball"}:
@@ -384,6 +386,10 @@ class BatterAI:
                     contact = 0.1
                 else:
                     contact = 0.0
+
+        if swing:
+            contact *= self.config.get("contactQualityScale", 1.0)
+            contact = max(0.0, min(1.0, contact))
 
         self.last_decision = (swing, contact)
         return self.last_decision

--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -143,7 +143,7 @@ _DEFAULTS: Dict[str, Any] = {
     "hitHRProb": 10,
     # Hit probability tuning ----------------------------------------
     "hitProbBase": 0.02,
-    "contactFactorBase": 0.8,
+    "contactFactorBase": 0.9,
     "contactFactorDiv": 280.0,
     "movementFactorMin": 0.3,
     "movementImpactScale": 1.0,
@@ -172,10 +172,12 @@ _DEFAULTS: Dict[str, Any] = {
     "closeStrikeDist": 5,
     "closeBallDist": 4,
     # Baseline swing probabilities reflecting MLB averages
-    "swingProbSureStrike": 0.75,
-    "swingProbCloseStrike": 0.5,
-    "swingProbCloseBall": 0.35,
-    "swingProbSureBall": 0.1,
+    "swingProbSureStrike": 0.85,
+    "swingProbCloseStrike": 0.6,
+    "swingProbCloseBall": 0.25,
+    "swingProbSureBall": 0.05,
+    # Global swing probability scaling factor
+    "swingProbScale": 1.0,
     "lookPrimaryType00CountAdjust": 0,
     "lookPrimaryType01CountAdjust": 0,
     "lookPrimaryType02CountAdjust": 0,
@@ -201,7 +203,7 @@ _DEFAULTS: Dict[str, Any] = {
     "lookBestType31CountAdjust": 15,
     "lookBestType32CountAdjust": 0,
     # Pitch identification and discipline ---------------------------------
-    "idRatingBase": 44,
+    "idRatingBase": 50,
     "idRatingCHPct": 90,
     "idRatingExpPct": 80,
     "idRatingPitchRatPct": 100,
@@ -228,7 +230,9 @@ _DEFAULTS: Dict[str, Any] = {
     "disciplineRating30CountAdjust": 60,
     "disciplineRating31CountAdjust": 5,
     "disciplineRating32CountAdjust": 15,
-    "minMisreadContact": 0.4,
+    "minMisreadContact": 0.3,
+    # Final contact multiplier applied to swing decisions
+    "contactQualityScale": 1.0,
     # Check-swing tuning ---------------------------------------------------
     "checkChanceBasePower": 150,
     "checkChanceBaseNormal": 250,


### PR DESCRIPTION
## Summary
- Increase baseline swing probabilities and contact factors in play balance config
- Add global scaling options and apply them in batter AI
- Lower misread contact override for gentler strikeout rates

## Testing
- ⚠️ `python scripts/simulate_season_avg.py` *(fails: Team ABU does not have enough position players)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ec21851c832ea7fd4e22787e2207