### PR TITLE
Boost contact tuning to curb strikeouts

### DIFF
--- a/docs/simulation_engine.md
+++ b/docs/simulation_engine.md
@@ -97,4 +97,6 @@ Key entries now available include:
   completely misidentifies a pitch.  The value acts as a floor scaled by the
   batter's contact rating so weak hitters still produce occasional foul tips
   without generating excessive hits.
+- **`contactQualityScale`** – multiplier applied to raw contact quality.  Raising
+  this value increases fouls and balls in play, reducing strikeout rates.
 

--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -230,9 +230,9 @@ _DEFAULTS: Dict[str, Any] = {
     "disciplineRating30CountAdjust": 60,
     "disciplineRating31CountAdjust": 5,
     "disciplineRating32CountAdjust": 15,
-    "minMisreadContact": 0.3,
+    "minMisreadContact": 0.4,
     # Final contact multiplier applied to swing decisions
-    "contactQualityScale": 1.0,
+    "contactQualityScale": 1.5,
     # Check-swing tuning ---------------------------------------------------
     "checkChanceBasePower": 150,
     "checkChanceBaseNormal": 250,


### PR DESCRIPTION
## Summary
- increase `minMisreadContact` floor to 0.4 so misidentified swings still make more contact
- scale `contactQuality` by 1.5 to encourage balls in play and reduce strikeouts
- document `contactQualityScale` in simulation engine docs

## Testing
- `python -m py_compile logic/playbalance_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4f398fc3c832e8eb7f8af3db509b6