### PR TITLE
Reduce excessive strikeouts with higher contact scaling

### DIFF
--- a/docs/simulation_engine.md
+++ b/docs/simulation_engine.md
@@ -97,6 +97,7 @@ Key entries now available include:
   completely misidentifies a pitch.  The value acts as a floor scaled by the
   batter's contact rating so weak hitters still produce occasional foul tips
   without generating excessive hits.
-- **`contactQualityScale`** – multiplier applied to raw contact quality.  Raising
-  this value increases fouls and balls in play, reducing strikeout rates.
+ - **`contactQualityScale`** – multiplier applied to raw contact quality.  The
+   default of **3.5** boosts contact to curb strikeouts; raising it further
+   increases fouls and balls in play while lowering whiff rates.
 

--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -232,7 +232,8 @@ _DEFAULTS: Dict[str, Any] = {
     "disciplineRating32CountAdjust": 15,
     "minMisreadContact": 0.4,
     # Final contact multiplier applied to swing decisions
-    "contactQualityScale": 1.5,
+    # Increased to encourage contact and curb extreme strikeout rates
+    "contactQualityScale": 3.5,
     # Check-swing tuning ---------------------------------------------------
     "checkChanceBasePower": 150,
     "checkChanceBaseNormal": 250,


### PR DESCRIPTION
## Summary
- Increase contactQualityScale default to 3.5 to push more contact and reduce strikeouts
- Document new contactQualityScale default and its role in lowering whiff rates

## Testing
- `python -m py_compile logic/playbalance_config.py`
- `python - <<'PY'
from logic.playbalance_config import PlayBalanceConfig
cfg = PlayBalanceConfig()
print(cfg.contactQualityScale)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b4f665ec44832eb9e996db33c09484