### PR TITLE
Expose control scale to adjust pitcher accuracy

### DIFF
--- a/data/playbalance_overrides.json
+++ b/data/playbalance_overrides.json
@@ -54,6 +54,6 @@
   "timingVeryGoodCount": 9,
   "timingVeryGoodFaces": 13,
   "timingVeryGoodBase": -63,
-  "controlScale": 225,
+  "controlScale": 170,
   "controlBoxIncreaseEffCOPct": 15
 }

--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -71,6 +71,7 @@ _DEFAULTS: Dict[str, Any] = {
     "siControlBoxWidth": 1,
     "siControlBoxHeight": 1,
     "controlBoxIncreaseEffCOPct": 15,
+    "controlScale": 170,
     "speedReductionBase": 3,
     "speedReductionRange": 3,
     "speedReductionEffMOPct": 5,
@@ -167,6 +168,9 @@ _DEFAULTS: Dict[str, Any] = {
     "pitchObj00CountBestCenterWeight": 0,
     "pitchObj00CountFastCenterWeight": 0,
     "pitchObj00CountPlusWeight": 60,
+    "pitchObj10CountOutsideWeight": 30,
+    "pitchObj11CountOutsideWeight": 30,
+    "pitchObj20CountOutsideWeight": 30,
     # Batter AI -------------------------------------------------------
     "sureStrikeDist": 4,
     "closeStrikeDist": 5,

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -1001,7 +1001,7 @@ class GameSimulation:
             pitch_speed = self.physics.pitch_velocity(
                 pitch_type, pitcher.arm, rand=loc_r
             )
-            control_scale = self.config.get("controlScale", 150)
+            control_scale = self.config.controlScale
             jitter = self.rng.uniform(-5, 5)
             control_chance = (pitcher.control + jitter) / control_scale
             control_chance = max(0.0, min(1.0, control_chance))


### PR DESCRIPTION
## Summary
- Allow configuring pitcher control via new `controlScale` default
- Bias AI pitch objectives toward the outside zone in early counts
- Use configured control scale during simulations

## Testing
- `python -m py_compile logic/playbalance_config.py logic/simulation.py`
- `python scripts/sim_halfseason_avg.py --disable-tqdm` *(fails: Team DRO does not have enough position players)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fdd12ae0832eb60094ecdeaa0ae9