### PR TITLE
Adjust contact and base hit probability

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -143,8 +143,8 @@ _DEFAULTS: Dict[str, Any] = {
     "hit3BProb": 2,
     "hitHRProb": 10,
     # Hit probability tuning ----------------------------------------
-    "hitProbBase": 0.02,
-    "contactFactorBase": 0.9,
+    "hitProbBase": 0.01,
+    "contactFactorBase": 0.85,
     "contactFactorDiv": 280.0,
     "movementFactorMin": 0.3,
     "movementImpactScale": 1.0,


### PR DESCRIPTION
## Summary
- Reduce base hit probability to 0.01
- Lower contact factor baseline to trim hits from contact

## Testing
- `python scripts/simulate_season_avg.py --disable-tqdm` *(fails: Team DRO does not have enough position players)*
- `python - <<'PY' ...` *(custom 20-game simulation; hits per game ~1.1, BIP outs ~54.65)*

------
https://chatgpt.com/codex/tasks/task_e_68b504be47f8832eaebe1dadd319110a