### PR TITLE
Enable outs on balls in play during season simulations

### DIFF
--- a/scripts/sim_halfseason_avg.py
+++ b/scripts/sim_halfseason_avg.py
@@ -149,7 +149,7 @@ def simulate_halfseason_average(use_tqdm: bool = True) -> None:
     base_states = {tid: build_default_game_state(tid) for tid in teams}
 
     cfg = PlayBalanceConfig.from_file(get_base_dir() / "logic" / "PBINI.txt")
-    cfg.ballInPlayOuts = 0
+    cfg.ballInPlayOuts = 1
 
     csv_path = (
         get_base_dir()

--- a/scripts/simulate_season_avg.py
+++ b/scripts/simulate_season_avg.py
@@ -149,7 +149,7 @@ def simulate_season_average(use_tqdm: bool = True) -> None:
     base_states = {tid: build_default_game_state(tid) for tid in teams}
 
     cfg = PlayBalanceConfig.from_file(get_base_dir() / "logic" / "PBINI.txt")
-    cfg.ballInPlayOuts = 0
+    cfg.ballInPlayOuts = 1
 
     csv_path = (
         get_base_dir()


### PR DESCRIPTION
## Summary
- Allow balls put in play to be recorded as outs in both full-season and half-season simulation scripts by setting `ballInPlayOuts` to `1`.

## Testing
- ⚠️ `pytest tests/test_simulation_averages.py::test_simulated_averages_close_to_mlb -q` (fails: Team DRO does not have enough position players)


------
https://chatgpt.com/codex/tasks/task_e_68b507be05bc832e926ba60affa20db3