### PR TITLE
Tune foul probability and expose ball-in-play rate

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -149,12 +149,14 @@ _DEFAULTS: Dict[str, Any] = {
     "movementFactorMin": 0.3,
     "movementImpactScale": 1.0,
     # Foul ball tuning -----------------------------------------------
-    # Percentages for foul balls; strike-based rate is derived from all pitches.
+    # Percentages for foul balls and balls put in play; strike-based rate is
+    # derived from all pitches.
     "foulPitchBasePct": _FOUL_PITCH_BASE_PCT,
     "foulStrikeBasePct": round(
         _FOUL_PITCH_BASE_PCT / _LEAGUE_STRIKE_PCT * 100, 1
     ),
     "foulContactTrendPct": 1.5,
+    "ballInPlayPitchPct": 70,
     "ballInPlayOuts": 1,
     # Pitcher AI ------------------------------------------------------
     "pitchRatVariationCount": 1,

--- a/tests/test_bip_distribution.py
+++ b/tests/test_bip_distribution.py
@@ -1,0 +1,41 @@
+import random
+from types import SimpleNamespace
+
+import pytest
+
+from logic.simulation import GameSimulation
+from logic.playbalance_config import PlayBalanceConfig
+from utils.path_utils import get_base_dir
+from tests.test_physics import make_player, make_pitcher
+
+PB_CFG = PlayBalanceConfig.from_file(get_base_dir() / "logic" / "PBINI.txt")
+
+
+def test_bip_distribution():
+    """Ensure balls in play and fouls follow configured pitch rates."""
+    rng = random.Random(0)
+    batter = make_player("B", ch=50)
+    pitcher = make_pitcher("P")
+    sim_stub = SimpleNamespace(config=PB_CFG)
+
+    foul_pitch_pct = PB_CFG.foulPitchBasePct / 100.0
+    bip_pitch_pct = PB_CFG.ballInPlayPitchPct / 100.0
+    contact_rate = foul_pitch_pct + bip_pitch_pct
+
+    total_pitches = 100_000
+    fouls = 0
+    balls_in_play = 0
+
+    for _ in range(total_pitches):
+        if rng.random() < contact_rate:
+            prob = GameSimulation._foul_probability(sim_stub, batter, pitcher)
+            if rng.random() < prob:
+                fouls += 1
+            else:
+                balls_in_play += 1
+
+    bip_pct = balls_in_play / total_pitches
+    foul_pct = fouls / total_pitches
+
+    assert bip_pct == pytest.approx(bip_pitch_pct, abs=0.02)
+    assert foul_pct == pytest.approx(foul_pitch_pct, abs=0.02)


### PR DESCRIPTION
## Summary
- convert foul probability to use per-pitch foul and ball-in-play rates
- add `ballInPlayPitchPct` to play balance defaults
- test that balls in play and fouls follow configured distribution

## Testing
- `pytest tests/test_bip_distribution.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b50b4e4a00832e89a5aa44bda67bdd