### PR TITLE
Track line drives and related stats

### DIFF
--- a/logic/stats.py
+++ b/logic/stats.py
@@ -31,7 +31,7 @@ def compute_batting_rates(stats: 'BatterState') -> Dict[str, float]:
     hbp = stats.hbp
     sf = stats.sf
     tb = derived["tb"]
-    gb_fb_den = stats.gb + stats.fb
+    bip_den = stats.gb + stats.ld + stats.fb
 
     avg = h / ab if ab else 0.0
     obp_den = ab + bb + hbp + sf
@@ -46,9 +46,11 @@ def compute_batting_rates(stats: 'BatterState') -> Dict[str, float]:
     bb_k = bb / stats.so if stats.so else 0.0
     sb_den = stats.sb + stats.cs
     sb_pct = stats.sb / sb_den if sb_den else 0.0
-    gb_pct = stats.gb / gb_fb_den if gb_fb_den else 0.0
-    fb_pct = stats.fb / gb_fb_den if gb_fb_den else 0.0
+    gb_pct = stats.gb / bip_den if bip_den else 0.0
+    ld_pct = stats.ld / bip_den if bip_den else 0.0
+    fb_pct = stats.fb / bip_den if bip_den else 0.0
     gb_fb = stats.gb / stats.fb if stats.fb else 0.0
+    ld_fb_ratio = stats.ld / stats.fb if stats.fb else 0.0
 
     return {
         "avg": avg,
@@ -62,8 +64,10 @@ def compute_batting_rates(stats: 'BatterState') -> Dict[str, float]:
         "bb_k": bb_k,
         "sb_pct": sb_pct,
         "gb_pct": gb_pct,
+        "ld_pct": ld_pct,
         "fb_pct": fb_pct,
         "gb_fb": gb_fb,
+        "ld_fb_ratio": ld_fb_ratio,
     }
 
 
@@ -118,10 +122,12 @@ def compute_pitching_rates(stats: 'PitcherState') -> Dict[str, float]:
         stats.o_zone_contacts / stats.o_zone_swings if stats.o_zone_swings else 0.0
     )
     ozone_pct = o_zone_pitches / stats.pitches_thrown if stats.pitches_thrown else 0.0
-    gb_fb_den = stats.gb + stats.fb
-    gb_pct = stats.gb / gb_fb_den if gb_fb_den else 0.0
-    fb_pct = stats.fb / gb_fb_den if gb_fb_den else 0.0
+    bip_den = stats.gb + stats.ld + stats.fb
+    gb_pct = stats.gb / bip_den if bip_den else 0.0
+    ld_pct = stats.ld / bip_den if bip_den else 0.0
+    fb_pct = stats.fb / bip_den if bip_den else 0.0
     gb_fb = stats.gb / stats.fb if stats.fb else 0.0
+    ld_fb_ratio = stats.ld / stats.fb if stats.fb else 0.0
 
     return {
         "h9": h9,
@@ -141,8 +147,10 @@ def compute_pitching_rates(stats: 'PitcherState') -> Dict[str, float]:
         "ozone_swing_pct": ozone_swing_pct,
         "ozone_contact_pct": ozone_contact_pct,
         "gb_pct": gb_pct,
+        "ld_pct": ld_pct,
         "fb_pct": fb_pct,
         "gb_fb": gb_fb,
+        "ld_fb_ratio": ld_fb_ratio,
     }
 
 

--- a/tests/test_ground_fly_distribution.py
+++ b/tests/test_ground_fly_distribution.py
@@ -11,7 +11,7 @@ from logic.playbalance_config import PlayBalanceConfig
 from tests.test_physics import make_player, make_pitcher
 
 
-def test_ground_fly_distribution():
+def test_ground_air_distribution():
     cfg = PlayBalanceConfig.from_dict({})
     rng = random.Random(0)
     batter = make_player("b")
@@ -23,21 +23,24 @@ def test_ground_fly_distribution():
     p_state = PitcherState(pitcher)
 
     total = 5000
-    ground = fly = 0
+    ground = line = fly = 0
     for _ in range(total):
         sim._swing_result(
             batter, pitcher, defense, b_state, p_state, pitch_speed=90, rand=rng.random()
         )
         if sim.last_batted_ball_type == "ground":
             ground += 1
+        elif sim.last_batted_ball_type == "line":
+            line += 1
         else:
             fly += 1
     gb_rate = cfg.ground_ball_base_rate
     fb_rate = cfg.fly_ball_base_rate
     expected_ground = gb_rate / (gb_rate + fb_rate)
-    expected_fly = fb_rate / (gb_rate + fb_rate)
+    expected_air = fb_rate / (gb_rate + fb_rate)
+    air = line + fly
     assert ground / total == pytest.approx(expected_ground, abs=0.02)
-    assert fly / total == pytest.approx(expected_fly, abs=0.02)
+    assert air / total == pytest.approx(expected_air, abs=0.02)
 
 
 def test_vert_angle_gf_pct_shifts_distribution():
@@ -54,7 +57,7 @@ def test_vert_angle_gf_pct_shifts_distribution():
         sim = GameSimulation(defense, offense, cfg, rng)
         b_state = BatterState(batter)
         p_state = PitcherState(pitcher)
-        ground = fly = 0
+        ground = air = 0
         for _ in range(1000):
             sim._swing_result(
                 batter, pitcher, defense, b_state, p_state, pitch_speed=90, rand=rng.random()
@@ -62,10 +65,10 @@ def test_vert_angle_gf_pct_shifts_distribution():
             if sim.last_batted_ball_type == "ground":
                 ground += 1
             else:
-                fly += 1
-        return ground, fly
+                air += 1
+        return ground, air
 
-    ground0, fly0 = run(cfg0)
-    ground10, fly10 = run(cfg10)
+    ground0, air0 = run(cfg0)
+    ground10, air10 = run(cfg10)
     assert ground10 < ground0
-    assert fly10 > fly0
+    assert air10 > air0

--- a/tests/test_ground_fly_stats.py
+++ b/tests/test_ground_fly_stats.py
@@ -13,7 +13,7 @@ from logic.stats import compute_batting_rates, compute_pitching_rates
 from tests.test_physics import make_player, make_pitcher
 
 
-def test_swing_result_tracks_ground_fly(monkeypatch):
+def test_swing_result_tracks_ground_line_fly(monkeypatch):
     cfg_gb = PlayBalanceConfig.from_dict({"groundBallBaseRate": 100, "flyBallBaseRate": 0})
     batter = make_player("b")
     pitcher = make_pitcher("p")
@@ -27,37 +27,73 @@ def test_swing_result_tracks_ground_fly(monkeypatch):
     b_state = BatterState(batter)
     p_state = PitcherState(pitcher)
     sim._swing_result(batter, pitcher, defense, b_state, p_state, pitch_speed=90, rand=0.0)
-    assert b_state.gb == 1 and p_state.gb == 1 and b_state.fb == 0 and p_state.fb == 0
+    assert (
+        b_state.gb == 1
+        and p_state.gb == 1
+        and b_state.ld == 0
+        and b_state.fb == 0
+    )
 
     cfg_fb = PlayBalanceConfig.from_dict({"groundBallBaseRate": 0, "flyBallBaseRate": 100})
+
+    sim_line = GameSimulation(defense, offense, cfg_fb, random.Random(0))
+    monkeypatch.setattr(sim_line.fielding_ai, "catch_action", lambda *a, **k: "no_attempt")
+    monkeypatch.setattr(sim_line.physics, "landing_point", lambda *a, **k: (100.0, 0.0, 1.0))
+    monkeypatch.setattr(sim_line.physics, "ball_roll_distance", lambda *a, **k: 0.0)
+    monkeypatch.setattr(sim_line.physics, "ball_bounce", lambda *a, **k: (0.0, 0.0))
+    monkeypatch.setattr(sim_line.physics, "vertical_hit_angle", lambda *a, **k: 10.0)
+    b_state_line = BatterState(batter)
+    p_state_line = PitcherState(pitcher)
+    sim_line._swing_result(
+        batter, pitcher, defense, b_state_line, p_state_line, pitch_speed=90, rand=0.0
+    )
+    assert (
+        b_state_line.ld == 1
+        and p_state_line.ld == 1
+        and b_state_line.gb == 0
+        and b_state_line.fb == 0
+    )
+
     sim_fly = GameSimulation(defense, offense, cfg_fb, random.Random(0))
     monkeypatch.setattr(sim_fly.fielding_ai, "catch_action", lambda *a, **k: "no_attempt")
     monkeypatch.setattr(sim_fly.physics, "landing_point", lambda *a, **k: (100.0, 0.0, 1.0))
     monkeypatch.setattr(sim_fly.physics, "ball_roll_distance", lambda *a, **k: 0.0)
     monkeypatch.setattr(sim_fly.physics, "ball_bounce", lambda *a, **k: (0.0, 0.0))
-    b_state2 = BatterState(batter)
-    p_state2 = PitcherState(pitcher)
+    monkeypatch.setattr(sim_fly.physics, "vertical_hit_angle", lambda *a, **k: 20.0)
+    b_state_fly = BatterState(batter)
+    p_state_fly = PitcherState(pitcher)
     sim_fly._swing_result(
-        batter, pitcher, defense, b_state2, p_state2, pitch_speed=90, rand=0.0
+        batter, pitcher, defense, b_state_fly, p_state_fly, pitch_speed=90, rand=0.0
     )
-    assert b_state2.fb == 1 and p_state2.fb == 1 and b_state2.gb == 0 and p_state2.gb == 0
+    assert (
+        b_state_fly.fb == 1
+        and p_state_fly.fb == 1
+        and b_state_fly.gb == 0
+        and b_state_fly.ld == 0
+    )
 
 
-def test_ground_fly_rates():
+def test_batted_ball_rates():
     batter = make_player("b")
     bs = BatterState(batter)
     bs.gb = 30
+    bs.ld = 10
     bs.fb = 20
     rates = compute_batting_rates(bs)
-    assert rates["gb_pct"] == pytest.approx(0.6)
-    assert rates["fb_pct"] == pytest.approx(0.4)
+    assert rates["gb_pct"] == pytest.approx(0.5)
+    assert rates["ld_pct"] == pytest.approx(1 / 6)
+    assert rates["fb_pct"] == pytest.approx(1 / 3)
     assert rates["gb_fb"] == pytest.approx(1.5)
+    assert rates["ld_fb_ratio"] == pytest.approx(0.5)
 
     pitcher = make_pitcher("p")
     ps = PitcherState(pitcher)
     ps.gb = 40
+    ps.ld = 10
     ps.fb = 10
     prates = compute_pitching_rates(ps)
-    assert prates["gb_pct"] == pytest.approx(0.8)
-    assert prates["fb_pct"] == pytest.approx(0.2)
+    assert prates["gb_pct"] == pytest.approx(2 / 3)
+    assert prates["ld_pct"] == pytest.approx(1 / 6)
+    assert prates["fb_pct"] == pytest.approx(1 / 6)
     assert prates["gb_fb"] == pytest.approx(4.0)
+    assert prates["ld_fb_ratio"] == pytest.approx(1.0)

--- a/tests/test_line_drive_distribution.py
+++ b/tests/test_line_drive_distribution.py
@@ -1,0 +1,28 @@
+import random
+import pytest
+
+from logic.simulation import BatterState, GameSimulation, PitcherState, TeamState
+from logic.playbalance_config import PlayBalanceConfig
+from tests.test_physics import make_player, make_pitcher
+
+
+def test_line_drive_distribution():
+    cfg = PlayBalanceConfig.from_dict({})
+    rng = random.Random(1)
+    batter = make_player("b")
+    pitcher = make_pitcher("p")
+    defense = TeamState(lineup=[make_player("d")], bench=[], pitchers=[pitcher])
+    offense = TeamState(lineup=[batter], bench=[], pitchers=[make_pitcher("op")])
+    sim = GameSimulation(defense, offense, cfg, rng)
+    b_state = BatterState(batter)
+    p_state = PitcherState(pitcher)
+
+    total = 5000
+    line = 0
+    for _ in range(total):
+        sim._swing_result(
+            batter, pitcher, defense, b_state, p_state, pitch_speed=90, rand=rng.random()
+        )
+        if sim.last_batted_ball_type == "line":
+            line += 1
+    assert line / total == pytest.approx(0.21, abs=0.02)


### PR DESCRIPTION
## Summary
- Split fly balls into line drives and flies, tracking `ld` counts in game state
- Calculate `ld_pct` and `ld_fb_ratio` for hitters and pitchers
- Validate line-drive frequency with a new distribution test

## Testing
- `pytest tests/test_ground_fly_distribution.py tests/test_ground_fly_stats.py tests/test_line_drive_distribution.py`


------
https://chatgpt.com/codex/tasks/task_e_68b50cc57c30832e879deeb5fd95c152