### PR TITLE
Add line drive rate and swing distribution regression test

### DIFF
--- a/data/playbalance_overrides.json
+++ b/data/playbalance_overrides.json
@@ -1,8 +1,9 @@
 {
   "exitVeloBase": 0,
   "vertAngleGFPct": 0,
-  "groundBallBaseRate": 45,
-  "flyBallBaseRate": 55,
+  "groundBallBaseRate": 44,
+  "flyBallBaseRate": 35,
+  "lineDriveBaseRate": 21,
   "hitHRProb": 10,
   "idRatingBase": 50,
   "idRatingCHPct": 100,

--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -135,8 +135,10 @@ _DEFAULTS: Dict[str, Any] = {
     "exitVeloContactPct": 100,
     "vertAngleGFPct": 0,
     "sprayAnglePLPct": 0,
-    "groundBallBaseRate": 45,
-    "flyBallBaseRate": 55,
+    # Baseline batted ball type distribution (ground/line/fly)
+    "groundBallBaseRate": 44,
+    "flyBallBaseRate": 35,
+    "lineDriveBaseRate": 21,
     # Hit type distribution reflecting MLB averages
     "hit1BProb": 64,
     "hit2BProb": 20,
@@ -671,6 +673,11 @@ class PlayBalanceConfig:
     def fly_ball_base_rate(self) -> int:
         """Baseline percentage of batted balls that are fly balls."""
         return int(self.flyBallBaseRate)
+
+    @property
+    def line_drive_base_rate(self) -> int:
+        """Baseline percentage of batted balls that are line drives."""
+        return int(self.lineDriveBaseRate)
 
     @property
     def hit_prob_base(self) -> float:

--- a/tests/test_bip_type_distribution.py
+++ b/tests/test_bip_type_distribution.py
@@ -1,0 +1,39 @@
+import random
+import pytest
+
+from logic.simulation import (
+    BatterState,
+    GameSimulation,
+    PitcherState,
+    TeamState,
+)
+from logic.playbalance_config import PlayBalanceConfig
+from tests.test_physics import make_player, make_pitcher
+
+
+def test_bip_type_distribution():
+    cfg = PlayBalanceConfig.from_dict({})
+    rng = random.Random(0)
+    batter = make_player("b")
+    pitcher = make_pitcher("p")
+    defense = TeamState(lineup=[make_player("d")], bench=[], pitchers=[pitcher])
+    offense = TeamState(lineup=[batter], bench=[], pitchers=[make_pitcher("op")])
+    sim = GameSimulation(defense, offense, cfg, rng)
+    b_state = BatterState(batter)
+    p_state = PitcherState(pitcher)
+
+    total = 5000
+    counts = {"ground": 0, "line": 0, "fly": 0}
+    for _ in range(total):
+        sim._swing_result(
+            batter, pitcher, defense, b_state, p_state, pitch_speed=90, rand=rng.random()
+        )
+        counts[sim.last_batted_ball_type] += 1
+
+    gb = cfg.ground_ball_base_rate
+    ld = cfg.line_drive_base_rate
+    fb = cfg.fly_ball_base_rate
+    total_rate = gb + ld + fb
+    assert counts["ground"] / total == pytest.approx(gb / total_rate, abs=0.02)
+    assert counts["line"] / total == pytest.approx(ld / total_rate, abs=0.02)
+    assert counts["fly"] / total == pytest.approx(fb / total_rate, abs=0.02)

--- a/tests/test_ground_fly_distribution.py
+++ b/tests/test_ground_fly_distribution.py
@@ -35,9 +35,11 @@ def test_ground_air_distribution():
         else:
             fly += 1
     gb_rate = cfg.ground_ball_base_rate
+    ld_rate = cfg.line_drive_base_rate
     fb_rate = cfg.fly_ball_base_rate
-    expected_ground = gb_rate / (gb_rate + fb_rate)
-    expected_air = fb_rate / (gb_rate + fb_rate)
+    total_rate = gb_rate + ld_rate + fb_rate
+    expected_ground = gb_rate / total_rate
+    expected_air = (ld_rate + fb_rate) / total_rate
     air = line + fly
     assert ground / total == pytest.approx(expected_ground, abs=0.02)
     assert air / total == pytest.approx(expected_air, abs=0.02)


### PR DESCRIPTION
## Summary
- add line drive base rate to play balance configuration and default to 44/35/21 distribution
- use new ground/line/fly rate split when determining swing outcomes
- verify batted ball type proportions with a regression test

## Testing
- `pytest tests/test_bip_type_distribution.py tests/test_ground_fly_distribution.py::test_ground_air_distribution tests/test_line_drive_distribution.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b50e98c2f8832e92134646e46334db