### PR TITLE
Increase base hit probability for more realistic hit rates

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -145,7 +145,7 @@ _DEFAULTS: Dict[str, Any] = {
     "hit3BProb": 2,
     "hitHRProb": 10,
     # Hit probability tuning ----------------------------------------
-    "hitProbBase": 0.01,
+    "hitProbBase": 0.03,
     "contactFactorBase": 0.85,
     "contactFactorDiv": 280.0,
     "movementFactorMin": 0.3,


### PR DESCRIPTION
## Summary
- raise `hitProbBase` from 0.01 to 0.03 to better approximate MLB hit frequencies

## Testing
- `python - <<'PY' ...` (simulate 5 games to inspect hit totals)


------
https://chatgpt.com/codex/tasks/task_e_68b513e922c8832e93c41ee8b7070104