### PR TITLE
Increase swing probability scale

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -185,7 +185,7 @@ _DEFAULTS: Dict[str, Any] = {
     "swingProbCloseBall": 0.25,
     "swingProbSureBall": 0.05,
     # Global swing probability scaling factor
-    "swingProbScale": 1.0,
+    "swingProbScale": 1.18,
     "lookPrimaryType00CountAdjust": 0,
     "lookPrimaryType01CountAdjust": 0,
     "lookPrimaryType02CountAdjust": 0,


### PR DESCRIPTION
## Summary
- Increase `swingProbScale` to 1.18 to encourage more swings at borderline pitches

## Testing
- `python - <<'PY'
from collections import Counter
import random
import csv, copy
from utils.path_utils import get_base_dir
from logic.playbalance_config import PlayBalanceConfig
from logic.simulation import GameSimulation, generate_boxscore, TeamState
import logic.simulation as sim
from models.player import Player
from models.pitcher import Pitcher

sim.save_stats = lambda players, teams: None

def make_player(pid, ch=50):
    return Player(player_id=pid, first_name='F'+pid, last_name='L'+pid,
                   birthdate='2000-01-01', height=72, weight=180, bats='R',
                   primary_position='1B', other_positions=[], gf=50, ch=ch,
                   ph=50, sp=50, pl=0, vl=0, sc=0, fa=0, arm=0)

def make_pitcher(pid):
    return Pitcher(player_id=pid, first_name='PF'+pid, last_name='PL'+pid,
                   birthdate='2000-01-01', height=72, weight=180, bats='R',
                   primary_position='P', other_positions=[], gf=50,
                   endurance=100, control=50, movement=50, hold_runner=50,
                   fb=50, cu=0, cb=0, sl=0, si=0, scb=0, kn=0,
                   arm=50, fa=50, role='SP')

lineup_home = [make_player(f'H{i}', ch=50) for i in range(9)]
lineup_away = [make_player(f'A{i}', ch=50) for i in range(9)]
home_base = TeamState(lineup=lineup_home, bench=[], pitchers=[make_pitcher('HP')])
away_base = TeamState(lineup=lineup_away, bench=[], pitchers=[make_pitcher('AP')])

csv_path = get_base_dir()/"data"/"MLB_avg"/"mlb_avg_boxscore_2020_2024_both_teams.csv"
with csv_path.open(newline='') as f: row = next(csv.DictReader(f))
hits=float(row['Hits'])
singles=hits - float(row['Doubles']) - float(row['Triples']) - float(row['HomeRuns'])


def run(scale):
    cfg = PlayBalanceConfig.from_file(get_base_dir()/"logic"/"PBINI.txt")
    cfg.ballInPlayOuts = 1
    cfg.swingProbScale = scale
    cfg.hit1BProb = int(round(singles / hits * 100))
    cfg.hit2BProb = int(round(float(row['Doubles']) / hits * 100))
    cfg.hit3BProb = int(round(float(row['Triples']) / hits * 100))
    cfg.hitHRProb = max(0,100-cfg.hit1BProb-cfg.hit2BProb-cfg.hit3BProb)
    results=Counter()
    for i in range(50):
        home = copy.deepcopy(home_base)
        away = copy.deepcopy(away_base)
        rng = random.Random(i)
        sim_game = GameSimulation(home, away, cfg, rng)
        sim_game.simulate_game()
        box = generate_boxscore(home, away)
        for side in ('home','away'):
            batting = box[side]['batting']
            results['Walks'] += sum(p['bb'] for p in batting)
            results['BIP'] += sum(p['pa'] - p['bb'] - p['hbp'] - p['so'] - p.get('ci',0) for p in batting)
    return results['Walks']/50, results['BIP']/50

bw, bbip = run(1.0)
mw, mbip = run(1.18)
print('Baseline walks', bw, 'BIP', bbip)
print('Modified walks', mw, 'BIP', mbip)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b514a5b61c832e9b7c7ab9268c93da