### PR TITLE
Retune contact quality for more swing-and-miss variance

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -238,10 +238,11 @@ _DEFAULTS: Dict[str, Any] = {
     "disciplineRating30CountAdjust": 60,
     "disciplineRating31CountAdjust": 5,
     "disciplineRating32CountAdjust": 15,
-    "minMisreadContact": 0.4,
+    # Baseline contact chance when the batter misreads the pitch
+    "minMisreadContact": 0.5,
     # Final contact multiplier applied to swing decisions
-    # Further increased to align strikeout rates with MLB norms
-    "contactQualityScale": 4.7,
+    # Lowered to reintroduce swing-and-miss outcomes while keeping run scoring in line
+    "contactQualityScale": 2.3,
     # Check-swing tuning ---------------------------------------------------
     "checkChanceBasePower": 150,
     "checkChanceBaseNormal": 250,


### PR DESCRIPTION
## Summary
- Reduce `contactQualityScale` to 2.3 to allow more swing-and-miss outcomes
- Increase `minMisreadContact` baseline to 0.5 to keep run scoring balanced

## Testing
- `python -m py_compile logic/playbalance_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68b51d37fa90832ea793580b0bfe218f