### PR TITLE
Reduce batter identification to restore strikeouts

### DIFF
--- a/logic/PBINI.txt
+++ b/logic/PBINI.txt
@@ -1364,10 +1364,10 @@ lookBestType32CountAdjust=0     ; Adjustment to best pitch on 3-2 counts
 ; pitch is based on the formula:
 ;       Base + (( CH + EXP + (100 - PitchRating) / 2 )
 ;
-idRatingBase=44             ; Base identification chance
-idRatingCHPct=90            ; Percent multiplier on CH component of formula
-idRatingExpPct=80           ; Percent multiplier on EXP component of formula
-idRatingPitchRatPct=100     ; Percent multiplier on Pitch component of formula
+idRatingBase=10             ; Base identification chance
+idRatingCHPct=40            ; Percent multiplier on CH component of formula
+idRatingExpPct=30           ; Percent multiplier on EXP component of formula
+idRatingPitchRatPct=0       ; Percent multiplier on Pitch component of formula
 idRatingTypeWeight=100      ; Percent multiplier on chance to ID pitch type
 idRatingLocWeight=100       ; Percent multiplier on chance to ID pitch location
 idRatingTimingWeight=100    ; Percent multiplier on chance to ID pitch timing
@@ -1535,7 +1535,7 @@ failedCheckContactChance = 0   ; If a player checks his swing and the bat
 ;                                  happens to be in the way of the ball, this
 ;                                  is the percent of time that contact will
 ;                                  actually be made
-minMisreadContact=0.2          ; Minimum contact quality when a batter
+minMisreadContact=0.15         ; Minimum contact quality when a batter
 ;                                  completely misidentifies a pitch
 ;
 ; FOUL BALL RATES

--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -211,10 +211,10 @@ _DEFAULTS: Dict[str, Any] = {
     "lookBestType31CountAdjust": 15,
     "lookBestType32CountAdjust": 0,
     # Pitch identification and discipline ---------------------------------
-    "idRatingBase": 50,
-    "idRatingCHPct": 90,
-    "idRatingExpPct": 80,
-    "idRatingPitchRatPct": 100,
+    "idRatingBase": 10,
+    "idRatingCHPct": 40,
+    "idRatingExpPct": 30,
+    "idRatingPitchRatPct": 0,
     "disciplineRatingBase": 0,
     "disciplineRatingCHPct": 150,
     "disciplineRatingExpPct": 100,
@@ -239,7 +239,7 @@ _DEFAULTS: Dict[str, Any] = {
     "disciplineRating31CountAdjust": 5,
     "disciplineRating32CountAdjust": 15,
     # Baseline contact chance when the batter misreads the pitch
-    "minMisreadContact": 0.5,
+    "minMisreadContact": 0.15,
     # Final contact multiplier applied to swing decisions
     # Lowered to reintroduce swing-and-miss outcomes while keeping run scoring in line
     "contactQualityScale": 2.3,


### PR DESCRIPTION
## Summary
- Lower batter pitch identification weights and misread contact floor to allow swing-and-miss outcomes
- Update PBINI defaults to match new tuning

## Testing
- `pytest tests/test_simulation.py::test_swing_and_miss_records_strikeout -q`

------
https://chatgpt.com/codex/tasks/task_e_68b525f2f950832e812299f9b22f80de