### PR TITLE
Allow configuring ball-in-play outs in simulation scripts

### DIFF
--- a/scripts/sim_halfseason_avg.py
+++ b/scripts/sim_halfseason_avg.py
@@ -137,11 +137,16 @@ def _simulate_game(home_id: str, away_id: str, seed: int) -> Counter[str]:
     return totals
 
 
-def simulate_halfseason_average(use_tqdm: bool = True) -> None:
+def simulate_halfseason_average(
+    use_tqdm: bool = True, ball_in_play_outs: int = 0
+) -> None:
     """Run a half-season simulation and print average box score values.
 
     Args:
         use_tqdm: Whether to display a progress bar using ``tqdm``.
+        ball_in_play_outs: Value for ``PlayBalanceConfig.ballInPlayOuts``.
+            ``0`` allows normal hit/out resolution while ``1`` makes every
+            ball put in play an out.
     """
 
     teams = [t.team_id for t in load_teams()]
@@ -149,7 +154,7 @@ def simulate_halfseason_average(use_tqdm: bool = True) -> None:
     base_states = {tid: build_default_game_state(tid) for tid in teams}
 
     cfg = PlayBalanceConfig.from_file(get_base_dir() / "logic" / "PBINI.txt")
-    cfg.ballInPlayOuts = 1
+    cfg.ballInPlayOuts = ball_in_play_outs
 
     csv_path = (
         get_base_dir()
@@ -225,8 +230,19 @@ if __name__ == "__main__":
         action="store_true",
         help="Disable tqdm progress bar.",
     )
+    parser.add_argument(
+        "--ball-in-play-outs",
+        type=int,
+        default=0,
+        help=(
+            "Set PlayBalanceConfig.ballInPlayOuts (0 normal, 1 every ball in "
+            "play is an out)."
+        ),
+    )
     args = parser.parse_args()
 
     env_disable = os.getenv("DISABLE_TQDM", "").lower() in {"1", "true", "yes"}
     use_tqdm = not (args.disable_tqdm or env_disable)
-    simulate_halfseason_average(use_tqdm=use_tqdm)
+    simulate_halfseason_average(
+        use_tqdm=use_tqdm, ball_in_play_outs=args.ball_in_play_outs
+    )

--- a/scripts/simulate_season_avg.py
+++ b/scripts/simulate_season_avg.py
@@ -137,11 +137,16 @@ def _simulate_game(home_id: str, away_id: str, seed: int) -> Counter[str]:
     return totals
 
 
-def simulate_season_average(use_tqdm: bool = True) -> None:
+def simulate_season_average(
+    use_tqdm: bool = True, ball_in_play_outs: int = 0
+) -> None:
     """Run a season simulation and print average box score values.
 
     Args:
         use_tqdm: Whether to display a progress bar using ``tqdm``.
+        ball_in_play_outs: Value for ``PlayBalanceConfig.ballInPlayOuts``.
+            ``0`` allows normal hit/out resolution while ``1`` makes every
+            ball put in play an out.
     """
 
     teams = [t.team_id for t in load_teams()]
@@ -149,7 +154,7 @@ def simulate_season_average(use_tqdm: bool = True) -> None:
     base_states = {tid: build_default_game_state(tid) for tid in teams}
 
     cfg = PlayBalanceConfig.from_file(get_base_dir() / "logic" / "PBINI.txt")
-    cfg.ballInPlayOuts = 1
+    cfg.ballInPlayOuts = ball_in_play_outs
 
     csv_path = (
         get_base_dir()
@@ -225,8 +230,19 @@ if __name__ == "__main__":
         action="store_true",
         help="Disable tqdm progress bar.",
     )
+    parser.add_argument(
+        "--ball-in-play-outs",
+        type=int,
+        default=0,
+        help=(
+            "Set PlayBalanceConfig.ballInPlayOuts (0 normal, 1 every ball in "
+            "play is an out)."
+        ),
+    )
     args = parser.parse_args()
 
     env_disable = os.getenv("DISABLE_TQDM", "").lower() in {"1", "true", "yes"}
     use_tqdm = not (args.disable_tqdm or env_disable)
-    simulate_season_average(use_tqdm=use_tqdm)
+    simulate_season_average(
+        use_tqdm=use_tqdm, ball_in_play_outs=args.ball_in_play_outs
+    )


### PR DESCRIPTION
## Summary
- add `--ball-in-play-outs` flag to half- and full-season simulation helpers
- default `ballInPlayOuts` to 0 so batted balls aren't forced outs

## Testing
- `python -m py_compile scripts/sim_halfseason_avg.py scripts/simulate_season_avg.py`
- `python scripts/sim_halfseason_avg.py --help`
- `python scripts/simulate_season_avg.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68b535d88ff4832ebed1dd0c8ef32a7e