### PR TITLE
Increase base hit probability

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -145,7 +145,9 @@ _DEFAULTS: Dict[str, Any] = {
     "hit3BProb": 2,
     "hitHRProb": 10,
     # Hit probability tuning ----------------------------------------
-    "hitProbBase": 0.03,
+    # Baseline additive hit probability; ~0.24 approximates a .240 average
+    # after other modifiers.
+    "hitProbBase": 0.24,
     "contactFactorBase": 1.0,
     "contactFactorDiv": 280.0,
     "movementFactorMin": 0.3,

--- a/tests/test_playbalance_config.py
+++ b/tests/test_playbalance_config.py
@@ -20,7 +20,7 @@ def test_playbalance_config_defaults():
     assert cfg.spray_angle_pl_pct == 0
     assert cfg.ground_ball_base_rate == 45
     assert cfg.fly_ball_base_rate == 55
-    assert cfg.hit_prob_base == pytest.approx(0.02)
+    assert cfg.hit_prob_base == pytest.approx(0.24)
     assert cfg.foulPitchBasePct == 18.3
     assert cfg.foulStrikeBasePct == 31
     assert cfg.foulContactTrendPct == 2.0


### PR DESCRIPTION
## Summary
- raise `hitProbBase` default to 0.24 for a .240 baseline average
- update default-config test to expect the new hit probability

## Testing
- `pytest tests/test_playbalance_config.py::test_playbalance_config_defaults -q` *(fails: assert 44 == 45)*
- `python - <<'PY'
from logic.playbalance_config import PlayBalanceConfig
print(PlayBalanceConfig.from_dict({}).hit_prob_base)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b5381c5fdc832e86c991525031e039