### PR TITLE
Tighten contact quality and add strikeout rate test

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -184,10 +184,10 @@ _DEFAULTS: Dict[str, Any] = {
     # Baseline swing probabilities reflecting MLB averages
     "swingProbSureStrike": 0.85,
     "swingProbCloseStrike": 0.6,
-    "swingProbCloseBall": 0.25,
+    "swingProbCloseBall": 0.3,
     "swingProbSureBall": 0.05,
     # Global swing probability scaling factor
-    "swingProbScale": 1.18,
+    "swingProbScale": 1.2,
     "lookPrimaryType00CountAdjust": 0,
     "lookPrimaryType01CountAdjust": 0,
     "lookPrimaryType02CountAdjust": 0,
@@ -244,7 +244,7 @@ _DEFAULTS: Dict[str, Any] = {
     "minMisreadContact": 0.15,
     # Final contact multiplier applied to swing decisions
     # Lowered to reintroduce swing-and-miss outcomes while keeping run scoring in line
-    "contactQualityScale": 2.3,
+    "contactQualityScale": 1.0,
     # Check-swing tuning ---------------------------------------------------
     "checkChanceBasePower": 150,
     "checkChanceBaseNormal": 250,

--- a/tests/test_simulation_strikeouts.py
+++ b/tests/test_simulation_strikeouts.py
@@ -1,0 +1,46 @@
+import random
+import pytest
+
+import logic.simulation as sim
+from logic.playbalance_config import PlayBalanceConfig
+from logic.simulation import GameSimulation, generate_boxscore
+from scripts.simulate_season_avg import clone_team_state
+from utils.lineup_loader import build_default_game_state
+from utils.path_utils import get_base_dir
+from utils.team_loader import load_teams
+
+
+def _simulate(monkeypatch, games: int = 20) -> float:
+    teams = [t.team_id for t in load_teams()]
+    base_states = {}
+    for tid in teams:
+        try:
+            base_states[tid] = build_default_game_state(tid)
+            if len(base_states) == 2:
+                break
+        except ValueError:
+            continue
+    if len(base_states) < 2:
+        pytest.skip("Insufficient roster data for simulation")
+    ids = list(base_states.keys())
+
+    cfg = PlayBalanceConfig.from_file(get_base_dir() / "logic" / "PBINI.txt")
+    rng = random.Random(0)
+    total_strikeouts = 0
+
+    with monkeypatch.context() as m:
+        m.setattr(sim, "save_stats", lambda players, teams: None)
+        for _ in range(games):
+            home = clone_team_state(base_states[ids[0]])
+            away = clone_team_state(base_states[ids[1]])
+            game = GameSimulation(home, away, cfg, rng)
+            game.simulate_game()
+            box = generate_boxscore(home, away)
+            for side in ("home", "away"):
+                total_strikeouts += sum(p["so"] for p in box[side]["batting"])
+    return total_strikeouts / games
+
+
+def test_strikeouts_within_mlb_range(monkeypatch):
+    avg_k = _simulate(monkeypatch)
+    assert 15 <= avg_k <= 19


### PR DESCRIPTION
## Summary
- Drop `contactQualityScale` to 1.0 and raise swing aggressiveness to keep walks reasonable
- Add simulation test ensuring combined strikeouts stay near MLB norms

## Testing
- `pytest tests/test_simulation_strikeouts.py::test_strikeouts_within_mlb_range -q` *(skipped: Insufficient roster data for simulation)*

------
https://chatgpt.com/codex/tasks/task_e_68b538f9319c832e8b1a9be5f1f240f0