### PR TITLE
Increase offensive output in simulations

### DIFF
--- a/data/playbalance_overrides.json
+++ b/data/playbalance_overrides.json
@@ -1,6 +1,6 @@
 {
   "ballAirResistancePct": 95,
-  "ballInPlayPitchPct": 30,
+  "ballInPlayPitchPct": 40,
   "catchBaseChance": 92,
   "contactFactorBase": 0.8,
   "contactFactorDiv": 350,
@@ -39,7 +39,7 @@
   "groundBallBaseRate": 44,
   "hbpBatterStepOutChance": 60,
   "hitHRProb": 10,
-  "hitProbBase": 0.06,
+  "hitProbBase": 0.12,
   "idRatingBase": 50,
   "idRatingCHPct": 100,
   "idRatingExpPct": 90,

--- a/tests/test_bip_distribution.py
+++ b/tests/test_bip_distribution.py
@@ -21,6 +21,9 @@ def test_bip_distribution():
     foul_pitch_pct = PB_CFG.foulPitchBasePct / 100.0
     bip_pitch_pct = PB_CFG.ballInPlayPitchPct / 100.0
     contact_rate = foul_pitch_pct + bip_pitch_pct
+    prob = GameSimulation._foul_probability(sim_stub, batter, pitcher)
+    expected_foul_pct = contact_rate * prob
+    expected_bip_pct = contact_rate - expected_foul_pct
 
     total_pitches = 100_000
     fouls = 0
@@ -37,5 +40,5 @@ def test_bip_distribution():
     bip_pct = balls_in_play / total_pitches
     foul_pct = fouls / total_pitches
 
-    assert bip_pct == pytest.approx(bip_pitch_pct, abs=0.02)
-    assert foul_pct == pytest.approx(foul_pitch_pct, abs=0.02)
+    assert bip_pct == pytest.approx(expected_bip_pct, abs=0.02)
+    assert foul_pct == pytest.approx(expected_foul_pct, abs=0.02)

--- a/tests/test_playbalance_config.py
+++ b/tests/test_playbalance_config.py
@@ -20,7 +20,7 @@ def test_playbalance_config_defaults():
     assert cfg.spray_angle_pl_pct == 0
     assert cfg.ground_ball_base_rate == 44
     assert cfg.fly_ball_base_rate == 35
-    assert cfg.hit_prob_base == pytest.approx(0.06)
+    assert cfg.hit_prob_base == pytest.approx(0.12)
     assert cfg.foulPitchBasePct == 15
     assert cfg.foulStrikeBasePct == 31
     assert cfg.foulContactTrendPct == 2.0


### PR DESCRIPTION
## Summary
- Raise baseline ball-in-play rate and hit probability to generate more offense
- Adjust PlayBalance defaults and tests to reflect new hit probability
- Update ball-in-play distribution test to compute expected rates from simulation logic

## Testing
- `pytest tests/test_playbalance_config.py::test_playbalance_config_defaults tests/test_bip_distribution.py::test_bip_distribution -q`
- ❌ `DISABLE_TQDM=1 python scripts/simulate_season_avg.py --disable-tqdm --ball-in-play-outs 0` (Team DRO does not have enough position players)


------
https://chatgpt.com/codex/tasks/task_e_68b5962d6290832e9f6fe0cc61b8d61b