### PR TITLE
Calibrate pitch contact rates and track strikeout details

### DIFF
--- a/data/playbalance_overrides.json
+++ b/data/playbalance_overrides.json
@@ -1,6 +1,6 @@
 {
   "ballAirResistancePct": 95,
-  "ballInPlayPitchPct": 40,
+  "ballInPlayPitchPct": 18,
   "catchBaseChance": 92,
   "contactFactorBase": 0.8,
   "contactFactorDiv": 350,
@@ -34,8 +34,8 @@
   "exitVeloPowerPct": 85,
   "flyBallBaseRate": 35,
   "foulContactTrendPct": 2.0,
-  "foulPitchBasePct": 15,
-  "foulStrikeBasePct": 31,
+  "foulPitchBasePct": 18,
+  "foulStrikeBasePct": 27,
   "groundBallBaseRate": 44,
   "hbpBatterStepOutChance": 60,
   "hitHRProb": 10,

--- a/docs/simulation_engine.md
+++ b/docs/simulation_engine.md
@@ -58,11 +58,14 @@ impact【F:logic/physics.py†L8-L75】【F:logic/physics.py†L92-L130】.
 
 ## Foul Balls
 
-MLB pitch tracking shows roughly **18.3%** of all pitches are fouled off. When
-batters put the ball in play, about **42.3%** become grounders and roughly
+MLB pitch tracking shows roughly **18%** of all pitches are fouled off and a
+similar **18%** are put into play. When batters put the ball in play, about
+**42.3%** become grounders and roughly
 **30–35%** are fly balls, with the remainder line drives or bunts. These averages
 seed the simulation's batted-ball model. `PlayBalanceConfig` exposes knobs to
-tune them: `foulPitchBasePct` sets the foul-per-pitch rate【F:logic/playbalance_config.py†L142-L147】,
+tune them: `foulPitchBasePct` sets the foul-per-pitch rate and
+`ballInPlayPitchPct` the share of pitches turned into balls in play
+【F:logic/playbalance_config.py†L142-L148】【F:logic/playbalance_config.py†L154】,
 while `groundBallBaseRate` and `flyBallBaseRate` establish grounder and fly-ball
 shares that influence vertical launch angles【F:logic/playbalance_config.py†L134-L135】.
 A slight negative `vertAngleGFPct` flattens trajectories, nudging extreme

--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -13,7 +13,8 @@ DATA_DIR = get_base_dir() / "data"
 _OVERRIDE_PATH = DATA_DIR / "playbalance_overrides.json"
 
 # MLB averages used to derive strike-based foul rates from all pitches.
-_FOUL_PITCH_BASE_PCT = 15  # Percent of all pitches that are fouls
+# Roughly 18 percent of MLB pitches are fouled off.
+_FOUL_PITCH_BASE_PCT = 18  # Percent of all pitches that are fouls
 _LEAGUE_STRIKE_PCT = 65.9    # Percent of all pitches that are strikes
 
 # Default values for PlayBalance configuration entries used throughout the
@@ -160,7 +161,8 @@ _DEFAULTS: Dict[str, Any] = {
         _FOUL_PITCH_BASE_PCT / _LEAGUE_STRIKE_PCT * 100, 1
     ),
     "foulContactTrendPct": 1.5,
-    "ballInPlayPitchPct": 30,
+    # Target roughly 18% of all pitches being put into play
+    "ballInPlayPitchPct": 18,
     "ballInPlayOuts": 1,
     # Hit by pitch avoidance ----------------------------------------
     "hbpBatterStepOutChance": 60,

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -52,6 +52,8 @@ class BatterState:
     ibb: int = 0  # Intentional walks
     hbp: int = 0  # Hit by pitch
     so: int = 0  # Strikeouts
+    so_looking: int = 0  # Called third strikes
+    so_swinging: int = 0  # Swinging strikeouts
     sh: int = 0  # Sacrifice hits
     sf: int = 0  # Sacrifice flies
     roe: int = 0  # Reached on error
@@ -90,6 +92,8 @@ class PitcherState:
     ibb: int = 0  # Intentional walks issued
     hbp: int = 0  # Hit batters
     so: int = 0  # Strikeouts
+    so_looking: int = 0  # Called third strikes
+    so_swinging: int = 0  # Swinging strikeouts
     wp: int = 0  # Wild pitches
     bk: int = 0  # Balks
     pk: int = 0  # Pickoffs
@@ -1345,6 +1349,12 @@ class GameSimulation:
             if strikes >= 3:
                 self._add_stat(batter_state, "ab")
                 self._add_stat(batter_state, "so")
+                if swing:
+                    self._add_stat(batter_state, "so_swinging")
+                    pitcher_state.so_swinging += 1
+                else:
+                    self._add_stat(batter_state, "so_looking")
+                    pitcher_state.so_looking += 1
                 pitcher_state.so += 1
                 outs += 1
                 pitcher_state.toast += self.config.get("pitchScoringOut", 0)

--- a/logic/stats.py
+++ b/logic/stats.py
@@ -44,6 +44,7 @@ def compute_batting_rates(stats: 'BatterState') -> Dict[str, float]:
     bb_pct = bb / pa if pa else 0.0
     k_pct = stats.so / pa if pa else 0.0
     bb_k = bb / stats.so if stats.so else 0.0
+    so_looking_pct = stats.so_looking / stats.so if stats.so else 0.0
     sb_den = stats.sb + stats.cs
     sb_pct = stats.sb / sb_den if sb_den else 0.0
     gb_pct = stats.gb / bip_den if bip_den else 0.0
@@ -62,6 +63,7 @@ def compute_batting_rates(stats: 'BatterState') -> Dict[str, float]:
         "bb_pct": bb_pct,
         "k_pct": k_pct,
         "bb_k": bb_k,
+        "so_looking_pct": so_looking_pct,
         "sb_pct": sb_pct,
         "gb_pct": gb_pct,
         "ld_pct": ld_pct,
@@ -128,6 +130,12 @@ def compute_pitching_rates(stats: 'PitcherState') -> Dict[str, float]:
     fb_pct = stats.fb / bip_den if bip_den else 0.0
     gb_fb = stats.gb / stats.fb if stats.fb else 0.0
     ld_fb_ratio = stats.ld / stats.fb if stats.fb else 0.0
+    swings = stats.zone_swings + stats.o_zone_swings
+    contacts = stats.zone_contacts + stats.o_zone_contacts
+    swstr_pct = (
+        (swings - contacts) / stats.pitches_thrown if stats.pitches_thrown else 0.0
+    )
+    so_looking_pct = stats.so_looking / stats.so if stats.so else 0.0
 
     return {
         "h9": h9,
@@ -146,6 +154,8 @@ def compute_pitching_rates(stats: 'PitcherState') -> Dict[str, float]:
         "ozone_pct": ozone_pct,
         "ozone_swing_pct": ozone_swing_pct,
         "ozone_contact_pct": ozone_contact_pct,
+        "swstr_pct": swstr_pct,
+        "so_looking_pct": so_looking_pct,
         "gb_pct": gb_pct,
         "ld_pct": ld_pct,
         "fb_pct": fb_pct,

--- a/scripts/simulate_season_avg.py
+++ b/scripts/simulate_season_avg.py
@@ -132,6 +132,10 @@ def _simulate_game(home_id: str, away_id: str, seed: int) -> Counter[str]:
         totals["StolenBases"] += sum(p["sb"] for p in batting)
         totals["CaughtStealing"] += sum(p["cs"] for p in batting)
         totals["HitByPitch"] += sum(p["hbp"] for p in batting)
+        totals["PlateAppearances"] += sum(p["pa"] for p in batting)
+        totals["AtBats"] += sum(p["ab"] for p in batting)
+        totals["SacFlies"] += sum(p.get("sf", 0) for p in batting)
+        totals["GIDP"] += sum(p.get("gidp", 0) for p in batting)
         totals["TotalPitchesThrown"] += sum(p["pitches"] for p in pitching)
         totals["Strikes"] += sum(p["strikes"] for p in pitching)
     return totals
@@ -219,6 +223,23 @@ def simulate_season_average(
         print(
             f"{key}: MLB {mlb_val:.2f}, Sim {sim_val:.2f}, Diff {diff:+.2f}"
         )
+
+    total_pitches = totals["TotalPitchesThrown"]
+    total_pa = totals.get("PlateAppearances", 0)
+    p_pa = total_pitches / total_pa if total_pa else 0.0
+    babip_den = (
+        totals.get("AtBats", 0)
+        - totals["Strikeouts"]
+        - totals["HomeRuns"]
+        + totals.get("SacFlies", 0)
+    )
+    babip = (
+        (totals["Hits"] - totals["HomeRuns"]) / babip_den if babip_den else 0.0
+    )
+    dp_rate = totals.get("GIDP", 0) / babip_den if babip_den else 0.0
+    print(f"Pitches/PA: {p_pa:.2f}")
+    print(f"BABIP: {babip:.3f}")
+    print(f"DoublePlayRate: {dp_rate:.3f}")
 
 
 if __name__ == "__main__":

--- a/tests/test_babip_average.py
+++ b/tests/test_babip_average.py
@@ -1,0 +1,19 @@
+import pytest
+
+from logic.simulation import BatterState
+from logic.stats import compute_batting_rates
+
+
+class DummyPlayer:
+    pass
+
+
+def test_babip_average():
+    bs = BatterState(DummyPlayer())
+    bs.ab = 500
+    bs.h = 132
+    bs.hr = 20
+    bs.so = 100
+    bs.sf = 5
+    rates = compute_batting_rates(bs)
+    assert rates["babip"] == pytest.approx(0.291, abs=0.001)

--- a/tests/test_bip_distribution.py
+++ b/tests/test_bip_distribution.py
@@ -20,6 +20,9 @@ def test_bip_distribution():
 
     foul_pitch_pct = PB_CFG.foulPitchBasePct / 100.0
     bip_pitch_pct = PB_CFG.ballInPlayPitchPct / 100.0
+    # Verify configured baselines roughly match MLB averages (~18% each)
+    assert foul_pitch_pct == pytest.approx(0.18, abs=0.01)
+    assert bip_pitch_pct == pytest.approx(0.18, abs=0.01)
     contact_rate = foul_pitch_pct + bip_pitch_pct
     prob = GameSimulation._foul_probability(sim_stub, batter, pitcher)
     expected_foul_pct = contact_rate * prob

--- a/tests/test_called_third_strike_rate.py
+++ b/tests/test_called_third_strike_rate.py
@@ -1,0 +1,22 @@
+import pytest
+
+from logic.simulation import BatterState, PitcherState
+from logic.stats import compute_batting_rates, compute_pitching_rates
+
+
+class DummyPlayer:
+    pass
+
+
+def test_called_third_strike_rate():
+    batter = BatterState(DummyPlayer())
+    batter.so = 100
+    batter.so_looking = 23
+    rates = compute_batting_rates(batter)
+    assert rates["so_looking_pct"] == pytest.approx(0.23, abs=0.01)
+
+    pitcher = PitcherState(DummyPlayer())
+    pitcher.so = 100
+    pitcher.so_looking = 23
+    rates_p = compute_pitching_rates(pitcher)
+    assert rates_p["so_looking_pct"] == pytest.approx(0.23, abs=0.01)

--- a/tests/test_pitches_per_pa.py
+++ b/tests/test_pitches_per_pa.py
@@ -1,0 +1,16 @@
+import pytest
+
+from logic.simulation import BatterState
+from logic.stats import compute_batting_derived
+
+
+class DummyPlayer:
+    pass
+
+
+def test_pitches_per_pa():
+    bs = BatterState(DummyPlayer())
+    bs.pa = 100
+    bs.pitches = 386
+    derived = compute_batting_derived(bs)
+    assert derived["p_pa"] == pytest.approx(3.86, abs=0.01)

--- a/tests/test_simulation_double_play_rate.py
+++ b/tests/test_simulation_double_play_rate.py
@@ -1,0 +1,51 @@
+import contextlib
+import io
+from datetime import timedelta
+
+import scripts.simulate_season_avg as ssa
+import logic.simulation as sim
+from tests.test_physics import make_player, make_pitcher
+from logic.simulation import TeamState
+
+
+def _run_sim(monkeypatch):
+    monkeypatch.setattr(sim, "save_stats", lambda players, teams: None)
+
+    def short_schedule(teams, start_date):
+        return [
+            {"date": (start_date + timedelta(days=i)).isoformat(), "home": teams[0], "away": teams[1]}
+            for i in range(10)
+        ]
+
+    class DummyTeam:
+        def __init__(self, tid):
+            self.team_id = tid
+
+    def short_load():
+        return [DummyTeam("T1"), DummyTeam("T2")]
+
+    def fake_build(team_id):
+        lineup = [make_player(f"{team_id}{i}") for i in range(9)]
+        pitchers = [make_pitcher(f"{team_id}p")]
+        return TeamState(lineup=lineup, bench=[], pitchers=pitchers)
+
+    monkeypatch.setattr(ssa, "generate_mlb_schedule", short_schedule)
+    monkeypatch.setattr(ssa, "load_teams", short_load)
+    monkeypatch.setattr(ssa, "build_default_game_state", fake_build)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ssa.simulate_season_average(use_tqdm=False)
+    return buf.getvalue().splitlines()
+
+
+def _parse(lines, prefix):
+    for line in lines:
+        if line.startswith(prefix):
+            return float(line.split(":", 1)[1].strip())
+    raise AssertionError(f"{prefix} not found")
+
+
+def test_simulation_double_play_rate(monkeypatch):
+    lines = _run_sim(monkeypatch)
+    dp_rate = _parse(lines, "DoublePlayRate")
+    assert dp_rate < 0.03

--- a/tests/test_swing_and_miss_rate.py
+++ b/tests/test_swing_and_miss_rate.py
@@ -1,0 +1,19 @@
+import pytest
+
+from logic.simulation import PitcherState
+from logic.stats import compute_pitching_rates
+
+
+class DummyPitcher:
+    pass
+
+
+def test_swing_and_miss_rate():
+    ps = PitcherState(DummyPitcher())
+    ps.pitches_thrown = 100
+    ps.zone_swings = 25
+    ps.zone_contacts = 18
+    ps.o_zone_swings = 15
+    ps.o_zone_contacts = 11
+    rates = compute_pitching_rates(ps)
+    assert rates["swstr_pct"] == pytest.approx(0.11, abs=0.01)


### PR DESCRIPTION
## Summary
- Align foul and ball-in-play pitch baselines to ~18%
- Track swinging vs. looking strikeouts and expose SwStr%
- Expand season simulation reporting and add unit tests for new metrics

## Testing
- `pytest tests/test_bip_distribution.py tests/test_swing_and_miss_rate.py tests/test_called_third_strike_rate.py tests/test_pitches_per_pa.py tests/test_babip_average.py tests/test_simulation_double_play_rate.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5afa017bc832e89e32dbf7e543a2e