### PR TITLE
Tighten simulation average comparisons

### DIFF
--- a/data/MLB_avg/mlb_avg_boxscore_2020_2024_both_teams.csv
+++ b/data/MLB_avg/mlb_avg_boxscore_2020_2024_both_teams.csv
@@ -1,2 +1,2 @@
-,Runs,Hits,Doubles,Triples,HomeRuns,Walks,Strikeouts,StolenBases,CaughtStealing,HitByPitch,TotalPitchesThrown,Strikes
-MLB_2020_2024_both_teams_per_game_avg,8.94,16.41,3.26,0.28,2.33,6.35,17.11,1.2,0.35,0.86,292.29,187.15
+,Runs,Hits,Doubles,Triples,HomeRuns,AtBats,Walks,Strikeouts,StolenBases,CaughtStealing,HitByPitch,TotalPitchesThrown,Strikes
+MLB_2020_2024_both_teams_per_game_avg,8.94,16.41,3.26,0.28,2.33,68.51,6.35,17.11,1.2,0.35,0.86,292.29,187.15


### PR DESCRIPTION
## Summary
- Add MLB at-bats benchmark and check it in tests
- Reduce tolerance on simulation vs. MLB averages to 10%
- Use at-bat benchmark for derived rate statistics

## Testing
- `python -m py_compile tests/test_simulation_averages.py`
- `pytest tests/test_simulation_averages.py -q` *(fails: Team DRO does not have enough position players)*

------
https://chatgpt.com/codex/tasks/task_e_68b77cbe22cc832e910833413dc266aa