### PR TITLE
Increase contact skill influence on balls in play

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -253,10 +253,10 @@ _DEFAULTS: Dict[str, Any] = {
     "minMisreadContact": 0.15,
     # Final contact multiplier applied to swing decisions
     # Lowered to reintroduce swing-and-miss outcomes while keeping run scoring in line
-    "contactQualityScale": 1.0,
+    "contactQualityScale": 1.2,
     # Scaling factors for batter skills impacting contact quality
-    "contactAbilityScale": 0.0,
-    "contactDisciplineScale": 0.0,
+    "contactAbilityScale": 0.3,
+    "contactDisciplineScale": 0.2,
     # Check-swing tuning ---------------------------------------------------
     "checkChanceBasePower": 150,
     "checkChanceBaseNormal": 250,


### PR DESCRIPTION
## Summary
- raise `contactQualityScale` above 1.0
- give `contactAbilityScale` and `contactDisciplineScale` positive values so batter skills generate more contact

## Testing
- `python scripts/sim_halfseason_avg.py --disable-tqdm` *(fails: Team DRO does not have enough position players)*
- `python - <<'PY'
# 50-game simulation baseline
...` *(see logs below)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a4d5d784832e8066a500433ecac6