### PR TITLE
Ensure certificate window stays on top

### DIFF
--- a/ui/splash_screen.py
+++ b/ui/splash_screen.py
@@ -44,4 +44,9 @@ class SplashScreen(QWidget):
         self.login_button.setEnabled(False)
 
         self.login_window = LoginWindow(self)
+        # Ensure the login window (certificate selector) isn't hidden behind
+        # other applications by forcing it to the foreground.
+        self.login_window.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint)
         self.login_window.show()
+        self.login_window.raise_()
+        self.login_window.activateWindow()


### PR DESCRIPTION
## Summary
- Prevent certificate/login selection dialog from getting hidden by forcing it to stay above other apps.

## Testing
- `pytest` *(fails: ImportError: cannot import name 'QAction')*
- `pip install PyQt6` *(fails: Could not find a version that satisfies the requirement PyQt6)*

------
https://chatgpt.com/codex/tasks/task_e_68b84958f108832ea6a51ded7602cd07