### PR TITLE
Use arm strength for throw velocity and travel time

### DIFF
--- a/logic/PBINI.txt
+++ b/logic/PBINI.txt
@@ -1608,9 +1608,11 @@ maxThrowDistASPct=100   ; Percent multiplier to AS to add to base distance
 ;
 throwSpeedIFBase=52     ; Infielder base speed
 throwSpeedIFDistPct=3   ; Infielder percent multiplier to distance
+throwSpeedIFASPct=0     ; Infielder percent multiplier to AS
 throwSpeedIFMax=92      ; Infielder maximum throwing speed
 throwSpeedOFBase=52     ; Outfielder base speed
 throwSpeedOFDistPct=3   ; Outfielder percent multiplier to distance
+throwSpeedOFASPct=0     ; Outfielder percent multiplier to AS
 throwSpeedOFMax=92      ; Outfielder maximum throwing speed
 ;
 ; CHANCE OF THROWING ERRORS

--- a/logic/physics.py
+++ b/logic/physics.py
@@ -64,14 +64,17 @@ class Physics:
         pct = getattr(self.config, "maxThrowDistASPct")
         return base + pct * as_rating / 100.0
 
-    def throw_velocity(self, distance: float, *, outfield: bool) -> float:
-        """Return throw velocity for ``distance`` and fielder type."""
+    def throw_velocity(self, distance: float, as_rating: int, *, outfield: bool) -> float:
+        """Return throw velocity for ``distance``, ``as_rating`` and fielder type."""
 
         prefix = "OF" if outfield else "IF"
         base = getattr(self.config, f"throwSpeed{prefix}Base")
-        pct = getattr(self.config, f"throwSpeed{prefix}DistPct")
+        dist_pct = getattr(self.config, f"throwSpeed{prefix}DistPct")
+        as_pct = getattr(self.config, f"throwSpeed{prefix}ASPct")
         max_speed = getattr(self.config, f"throwSpeed{prefix}Max")
-        speed = base + pct * distance / 100.0
+        speed = base
+        speed += dist_pct * distance / 100.0
+        speed += as_pct * as_rating / 100.0
         return min(speed, max_speed)
 
     def throw_time(self, as_rating: int, distance: float, position: str) -> float:
@@ -81,7 +84,7 @@ class Physics:
         if distance > max_dist:
             return float("inf")
         outfield = position.upper() in {"LF", "CF", "RF"}
-        speed = self.throw_velocity(distance, outfield=outfield)
+        speed = self.throw_velocity(distance, as_rating, outfield=outfield)
         fps = speed * 5280 / 3600
         if fps <= 0:
             return float("inf")

--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -125,9 +125,11 @@ _DEFAULTS: Dict[str, Any] = {
     "maxThrowDistASPct": 100,
     "throwSpeedIFBase": 52,
     "throwSpeedIFDistPct": 3,
+    "throwSpeedIFASPct": 0,
     "throwSpeedIFMax": 92,
     "throwSpeedOFBase": 52,
     "throwSpeedOFDistPct": 3,
+    "throwSpeedOFASPct": 0,
     "throwSpeedOFMax": 92,
     # Exit velocity and launch characteristics
     "exitVeloBase": 20,

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -1694,6 +1694,7 @@ class GameSimulation:
         runs_scored = 0
         outs = 0
         aggression = float(self.config.get("baserunningAggression", 0.5))
+        arm = getattr(defense.lineup[0], "arm", 0) if defense.lineup else 0
 
         if error:
             self._add_stat(batter_state, "roe")
@@ -1704,7 +1705,7 @@ class GameSimulation:
             force_fielder_time: Optional[float] = None
             if b[2]:
                 runner_time = 90 / self.physics.player_speed(b[2].player.sp)
-                fielder_time = self.physics.reaction_delay("LF", 0) + self.physics.throw_time(0, 90, "LF")
+                fielder_time = self.physics.reaction_delay("LF", 0) + self.physics.throw_time(arm, 90, "LF")
                 if self.fielding_ai.should_tag_runner(fielder_time, runner_time):
                     outs += 1
                 else:
@@ -1731,7 +1732,7 @@ class GameSimulation:
                     runner_time = 180 / spd
                     fielder_time = (
                         self.physics.reaction_delay("LF", 0)
-                        + self.physics.throw_time(0, 180, "LF")
+                        + self.physics.throw_time(arm, 180, "LF")
                     )
                     if self.fielding_ai.should_tag_runner(fielder_time, runner_time):
                         outs += 1
@@ -1762,7 +1763,7 @@ class GameSimulation:
                     runner_time = 180 / spd
                     fielder_time = (
                         self.physics.reaction_delay("LF", 0)
-                        + self.physics.throw_time(0, 180, "LF")
+                        + self.physics.throw_time(arm, 180, "LF")
                     )
                     if self.fielding_ai.should_tag_runner(fielder_time, runner_time):
                         outs += 1
@@ -1777,7 +1778,7 @@ class GameSimulation:
                     runner_time = 90 / spd
                     fielder_time = (
                         self.physics.reaction_delay("SS", 0)
-                        + self.physics.throw_time(0, 90, "SS")
+                        + self.physics.throw_time(arm, 90, "SS")
                     )
                     if self.fielding_ai.should_tag_runner(fielder_time, runner_time):
                         outs += 1
@@ -1792,7 +1793,7 @@ class GameSimulation:
                 batter_time = 90 / self.physics.player_speed(batter_state.player.sp)
                 relay_time = (
                     self.physics.reaction_delay("2B", 0)
-                    + self.physics.throw_time(0, 90, "2B")
+                    + self.physics.throw_time(arm, 90, "2B")
                 )
                 dp_prob = self.config.get("doublePlayProb", 0)
                 if force_runner_time and force_fielder_time:

--- a/tests/test_throw_simulation.py
+++ b/tests/test_throw_simulation.py
@@ -14,23 +14,44 @@ def test_throw_velocity_and_time_differ_by_position():
         maxThrowDistASPct=50,
         throwSpeedIFBase=10,
         throwSpeedIFDistPct=10,
+        throwSpeedIFASPct=10,
         throwSpeedIFMax=15,
         throwSpeedOFBase=10,
         throwSpeedOFDistPct=10,
+        throwSpeedOFASPct=10,
         throwSpeedOFMax=25,
     )
     physics = Physics(cfg)
     assert physics.max_throw_distance(50) == pytest.approx(125)
 
     dist = 100
-    v_if = physics.throw_velocity(dist, outfield=False)
-    v_of = physics.throw_velocity(dist, outfield=True)
+    v_if = physics.throw_velocity(dist, 50, outfield=False)
+    v_of = physics.throw_velocity(dist, 50, outfield=True)
     assert v_if == pytest.approx(15)
-    assert v_of == pytest.approx(20)
+    assert v_of == pytest.approx(25)
 
     t_if = physics.throw_time(50, dist, position="SS")
     t_of = physics.throw_time(50, dist, position="LF")
     assert t_of < t_if
+
+
+def test_throw_speed_scales_with_arm_strength():
+    cfg = make_cfg(
+        maxThrowDistBase=100,
+        maxThrowDistASPct=0,
+        throwSpeedIFBase=10,
+        throwSpeedIFDistPct=0,
+        throwSpeedIFASPct=10,
+        throwSpeedIFMax=20,
+    )
+    physics = Physics(cfg)
+    dist = 60
+    v_weak = physics.throw_velocity(dist, 10, outfield=False)
+    v_strong = physics.throw_velocity(dist, 90, outfield=False)
+    assert v_strong > v_weak
+    t_weak = physics.throw_time(10, dist, position="SS")
+    t_strong = physics.throw_time(90, dist, position="SS")
+    assert t_strong < t_weak
 
 
 def test_throw_time_infinite_beyond_max_range():


### PR DESCRIPTION
## Summary
- factor arm strength into throw velocity calculations
- allow configuration of arm-strength impact on throws
- pass fielder arm values when advancing runners

## Testing
- `pytest` *(fails: ImportError: cannot import name 'QAction' from 'PyQt6.QtGui')*


------
https://chatgpt.com/codex/tasks/task_e_68b87e7b3ff8832e90cc225605a09fa9