### PR TITLE
Count 2-strike and 3-ball situations

### DIFF
--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -258,6 +258,8 @@ class GameSimulation:
         self.last_batted_ball_angles: tuple[float, float] | None = None
         self.last_batted_ball_type: str | None = None
         self.last_pitch_speed: float | None = None
+        self.two_strike_counts = 0
+        self.three_ball_counts = 0
 
     # ------------------------------------------------------------------
     # Fatigue helpers
@@ -862,6 +864,8 @@ class GameSimulation:
         outs = 0
         balls = 0
         strikes = 0
+        seen_two_strike = False
+        seen_three_ball = False
 
         if ibb:
             self._add_stat(batter_state, "bb")
@@ -882,6 +886,13 @@ class GameSimulation:
         run_diff = offense.runs - defense.runs
 
         while True:
+            if not seen_two_strike and strikes >= 2:
+                seen_two_strike = True
+                self.two_strike_counts += 1
+            if not seen_three_ball and balls >= 3:
+                seen_three_ball = True
+                self.three_ball_counts += 1
+
             self._update_fatigue(pitcher_state)
             pitcher = self._fatigued_pitcher(pitcher_state.player)
             self._set_runner_leads(offense)
@@ -1330,6 +1341,13 @@ class GameSimulation:
                         pitcher_state.balls_thrown += 1
 
             self._maybe_passed_ball(offense, defense, catcher_fs)
+
+            if not seen_two_strike and strikes >= 2:
+                seen_two_strike = True
+                self.two_strike_counts += 1
+            if not seen_three_ball and balls >= 3:
+                seen_three_ball = True
+                self.three_ball_counts += 1
 
             if balls >= 4:
                 self._add_stat(batter_state, "bb")

--- a/scripts/sim_halfseason_avg.py
+++ b/scripts/sim_halfseason_avg.py
@@ -162,6 +162,8 @@ def _simulate_game(home_id: str, away_id: str, seed: int) -> Counter[str]:
         totals["HitByPitch"] += sum(p["hbp"] for p in batting)
         totals["TotalPitchesThrown"] += sum(p["pitches"] for p in pitching)
         totals["Strikes"] += sum(p["strikes"] for p in pitching)
+    totals["TwoStrikeCounts"] += sim.two_strike_counts
+    totals["ThreeBallCounts"] += sim.three_ball_counts
     return totals
 
 
@@ -247,6 +249,8 @@ def simulate_halfseason_average(
         print(
             f"{key}: MLB {mlb_val:.2f}, Sim {sim_val:.2f}, Diff {diff:+.2f}"
         )
+    print(f"Total two-strike counts: {totals['TwoStrikeCounts']}")
+    print(f"Total three-ball counts: {totals['ThreeBallCounts']}")
 
 
 if __name__ == "__main__":

--- a/scripts/simulate_season_avg.py
+++ b/scripts/simulate_season_avg.py
@@ -182,6 +182,8 @@ def _simulate_game(home_id: str, away_id: str, seed: int) -> Counter[str]:
         totals["GIDP"] += sum(p.get("gidp", 0) for p in batting)
         totals["TotalPitchesThrown"] += sum(p["pitches"] for p in pitching)
         totals["Strikes"] += sum(p["strikes"] for p in pitching)
+    totals["TwoStrikeCounts"] += sim.two_strike_counts
+    totals["ThreeBallCounts"] += sim.three_ball_counts
     return totals
 
 
@@ -284,6 +286,8 @@ def simulate_season_average(
     print(f"Pitches/PA: {p_pa:.2f}")
     print(f"BABIP: {babip:.3f}")
     print(f"DoublePlayRate: {dp_rate:.3f}")
+    print(f"Total two-strike counts: {totals['TwoStrikeCounts']}")
+    print(f"Total three-ball counts: {totals['ThreeBallCounts']}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- track two-strike and three-ball counts during game simulation
- tally and report these counts in full and half-season average scripts

## Testing
- `pytest` *(fails: ImportError: cannot import name 'QStatusBar' from 'PyQt6.QtWidgets')*

------
https://chatgpt.com/codex/tasks/task_e_68b8454d8dd8832ea1a8cbd3e137c593