### PR TITLE
Balance fielding with MLB putout probabilities

### DIFF
--- a/utils/putout_probabilities.py
+++ b/utils/putout_probabilities.py
@@ -1,0 +1,20 @@
+"""Utility functions for computing MLB putout probabilities by position."""
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Dict
+
+
+def load_putout_probabilities(path: Path) -> Dict[str, float]:
+    """Return per-position putout probabilities derived from ``path``.
+
+    The CSV file must contain ``POS`` and ``avg_PO_per_game`` columns. The
+    values are normalised so the returned probabilities sum to ``1``.
+    """
+
+    with path.open(newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        avgs = {row["POS"].upper(): float(row["avg_PO_per_game"]) for row in reader}
+    total = sum(avgs.values()) or 1.0
+    return {pos: val / total for pos, val in avgs.items()}


### PR DESCRIPTION
## Summary
- derive MLB per-position putout probabilities from `Average_Putouts_per_Game_by_Position__Last_5_Years_.csv`
- track putouts by defensive position and adapt catch chances toward MLB distribution

## Testing
- `pytest` *(fails: ImportError: cannot import name 'QAction' from 'PyQt6.QtGui')*


------
https://chatgpt.com/codex/tasks/task_e_68b8b0ea4434832e8ddcfc68dc86fe33