### PR TITLE
Add configurable hit probability cap and defensive out checks

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -156,6 +156,12 @@ _DEFAULTS: Dict[str, Any] = {
     "contactFactorDiv": 350,
     "movementFactorMin": 0.2,
     "movementImpactScale": 0.8,
+    # Cap on final hit probability to prevent excessive offense
+    "hitProbCap": 0.95,
+    # Baseline probabilities for converting batted balls into outs
+    "groundOutProb": 0.0,
+    "lineOutProb": 0.0,
+    "flyOutProb": 0.0,
     # Foul ball tuning -----------------------------------------------
     # Percentages for foul balls and balls put in play; strike-based rate is
     # derived from all pitches.

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -1697,6 +1697,14 @@ class GameSimulation:
         else:
             self._add_stat(batter_state, "fb")
             pitcher_state.fb += 1
+        # Simple defensive outcome to curb inflated offense
+        out_prob = {
+            "ground": self.config.get("groundOutProb", 0.0),
+            "line": self.config.get("lineOutProb", 0.0),
+            "fly": self.config.get("flyOutProb", 0.0),
+        }[self.last_batted_ball_type]
+        if self.rng.random() < out_prob:
+            return 0, False
         roll_dist = self.physics.ball_roll_distance(
             bat_speed,
             self.surface,
@@ -1723,7 +1731,7 @@ class GameSimulation:
         hit_prob = max(
             0.0,
             min(
-                0.95,
+                self.config.get("hitProbCap", 0.95),
                 (
                     (bat_speed / 100.0)
                     * contact_quality

--- a/tests/test_ground_ball_out_probability.py
+++ b/tests/test_ground_ball_out_probability.py
@@ -1,0 +1,90 @@
+import random
+
+from logic.simulation import GameSimulation, TeamState
+from models.player import Player
+from models.pitcher import Pitcher
+from tests.util.pbini_factory import make_cfg
+
+
+class ZeroRandom(random.Random):
+    """Deterministic random source returning 0 for all calls."""
+
+    def random(self):  # type: ignore[override]
+        return 0.0
+
+    def randint(self, a, b):  # type: ignore[override]
+        return a
+
+
+def make_player(pid: str) -> Player:
+    return Player(
+        player_id=pid,
+        first_name="F" + pid,
+        last_name="L" + pid,
+        birthdate="2000-01-01",
+        height=72,
+        weight=180,
+        bats="R",
+        primary_position="1B",
+        other_positions=[],
+        gf=50,
+        ch=50,
+        ph=50,
+        sp=50,
+        pl=0,
+        vl=0,
+        sc=0,
+        fa=0,
+        arm=0,
+    )
+
+
+def make_pitcher(pid: str) -> Pitcher:
+    return Pitcher(
+        player_id=pid,
+        first_name="PF" + pid,
+        last_name="PL" + pid,
+        birthdate="2000-01-01",
+        height=72,
+        weight=180,
+        bats="R",
+        primary_position="P",
+        other_positions=[],
+        gf=50,
+        endurance=100,
+        control=50,
+        movement=50,
+        hold_runner=50,
+        fb=50,
+        cu=0,
+        cb=0,
+        sl=0,
+        si=0,
+        scb=0,
+        kn=0,
+        arm=50,
+        fa=50,
+        role="SP",
+    )
+
+
+def test_ground_ball_out_probability():
+    cfg = make_cfg(
+        groundOutProb=1.0,
+        hitProbCap=1.0,
+        groundBallBaseRate=100,
+        flyBallBaseRate=0,
+        lineDriveBaseRate=0,
+    )
+    home = TeamState(lineup=[make_player("h1")], bench=[], pitchers=[make_pitcher("hp")])
+    away = TeamState(lineup=[make_player("a1")], bench=[], pitchers=[make_pitcher("ap")])
+    rng = ZeroRandom()
+    sim = GameSimulation(home, away, cfg, rng)
+    outs = sim.play_at_bat(away, home)
+    assert outs == 1
+    pitcher_state = home.current_pitcher_state
+    assert pitcher_state and pitcher_state.pitches_thrown == 1
+    batter_state = away.lineup_stats[away.lineup[0].player_id]
+    assert batter_state.pitches == 1
+    assert all(b is None for b in away.bases)
+


### PR DESCRIPTION
## Summary
- add PlayBalanceConfig options to cap hit probability and set batted ball out rates
- apply configurable out probabilities and hit prob cap in swing logic
- test ground-ball out probability and pitch count tracking

## Testing
- `pytest` *(fails: ImportError: cannot import name 'QAction' from 'PyQt6.QtGui')*

------
https://chatgpt.com/codex/tasks/task_e_68ba0e8d17c0832e8fa2424ba25fb6c3