### PR TITLE
Fix PlayBalanceConfig get to use defaults

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -748,7 +748,7 @@ class PlayBalanceConfig:
     def get(self, key: str, default: Any = 0) -> Any:
         """Return ``key`` from the configuration or ``default`` if missing."""
 
-        return self.values.get(key, default)
+        return self.values.get(key, _DEFAULTS.get(key, default))
 
     def __getattr__(self, item: str) -> Any:  # pragma: no cover - simple delegation
         values = self.__dict__.get("values", {})

--- a/tests/test_playbalance_config.py
+++ b/tests/test_playbalance_config.py
@@ -83,3 +83,9 @@ def test_reset_overrides(tmp_path, monkeypatch):
     assert not playbalance_config._OVERRIDE_PATH.exists()
 
 
+def test_get_uses_default(monkeypatch):
+    monkeypatch.setitem(playbalance_config._DEFAULTS, "sampleKey", 99)
+    cfg = PlayBalanceConfig.from_dict({})
+    assert cfg.get("sampleKey") == 99
+
+


### PR DESCRIPTION
## Summary
- ensure PlayBalanceConfig.get falls back to module defaults/overrides
- add regression test for default lookup

## Testing
- `pytest` *(fails: ImportError: cannot import name 'QStatusBar' from 'PyQt6.QtWidgets'; ImportError: cannot import name 'ImageDraw' from 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68ba2c006db4832e8e9b3144787fcdc7