### PR TITLE
Improve simulation randomness and BABIP calculation

### DIFF
--- a/tests/test_simulated_hit_probability.py
+++ b/tests/test_simulated_hit_probability.py
@@ -80,7 +80,7 @@ def test_simulated_hit_rate_within_mlb(monkeypatch):
 
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
-        ssa.simulate_season_average(use_tqdm=False)
+        ssa.simulate_season_average(use_tqdm=False, seed=42)
     output = buf.getvalue().splitlines()
 
     stat_lines = [

--- a/tests/test_simulation_double_play_rate.py
+++ b/tests/test_simulation_double_play_rate.py
@@ -1,6 +1,7 @@
 import contextlib
 import io
 from datetime import timedelta
+from pathlib import Path
 
 import scripts.simulate_season_avg as ssa
 import logic.simulation as sim
@@ -55,9 +56,17 @@ def _run_sim(monkeypatch):
     monkeypatch.setattr(ssa, "load_teams", short_load)
     monkeypatch.setattr(ssa, "build_default_game_state", fake_build)
     monkeypatch.setattr(ssa, "_simulate_game", fake_sim_game)
+    sched_path = (
+        Path(__file__).resolve().parents[1]
+        / "data"
+        / "schedules"
+        / "2025_schedule.pkl"
+    )
+    if sched_path.exists():
+        sched_path.unlink()
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
-        ssa.simulate_season_average(use_tqdm=False)
+        ssa.simulate_season_average(use_tqdm=False, seed=42)
     return buf.getvalue().splitlines()
 
 


### PR DESCRIPTION
## Summary
- make `simulate_season_average` use random seeds and support a `--seed` CLI flag
- compute ball-in-play pitch percentage from plate appearances for a realistic BABIP
- adjust tests to seed simulations and clear cached schedules

## Testing
- `pytest tests/test_simulation_double_play_rate.py tests/test_simulated_hit_probability.py`
- `pytest` *(fails: ImportError: cannot import name 'QAction' from 'PyQt6.QtGui')*
- `pip install PyQt6` *(fails: Could not find a version that satisfies the requirement PyQt6 (proxy 403))*

------
https://chatgpt.com/codex/tasks/task_e_68ba30b17d2c832ebbb554ffbd10c33d