### PR TITLE
Use league benchmarks for BABIP and pitch-in-play

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts package."""

--- a/tests/test_league_benchmarks.py
+++ b/tests/test_league_benchmarks.py
@@ -1,0 +1,17 @@
+import pytest
+
+from logic.playbalance_config import PlayBalanceConfig
+from scripts.simulate_season_avg import apply_league_benchmarks
+
+
+def test_apply_league_benchmarks():
+    cfg = PlayBalanceConfig.from_dict({"hitHRProb": 5})
+    benchmarks = {
+        "babip": 0.291,
+        "pitches_put_in_play_pct": 0.175,
+        "pitches_per_pa": 3.86,
+    }
+    apply_league_benchmarks(cfg, benchmarks)
+    assert cfg.hitProbBase == pytest.approx(0.291 / 0.95, abs=0.0001)
+    assert cfg.ballInPlayPitchPct == 18
+    assert cfg.swingProbScale == pytest.approx(1.04, abs=0.001)


### PR DESCRIPTION
## Summary
- derive PlayBalanceConfig probabilities from `mlb_league_benchmarks_2025_filled.csv`
- expose `apply_league_benchmarks` helper and tests
- allow importing scripts as a package

## Testing
- `pytest` *(fails: ImportError: cannot import name 'QStatusBar' from 'PyQt6.QtWidgets')*

------
https://chatgpt.com/codex/tasks/task_e_68ba33725528832e89335021b54db18d