### PR TITLE
Calibrate pitch counts and double play rates

### DIFF
--- a/utils/league_benchmarks.py
+++ b/utils/league_benchmarks.py
@@ -1,0 +1,18 @@
+"""Utilities for loading MLB league benchmark metrics."""
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Dict
+
+
+def load_league_benchmarks(path: Path) -> Dict[str, float]:
+    """Return a mapping of league benchmark metrics from ``path``.
+
+    The CSV at ``path`` must contain ``metric_key`` and ``value`` columns.
+    Values are returned as floats keyed by the metric name.
+    """
+
+    with path.open(newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        return {row["metric_key"]: float(row["value"]) for row in reader}


### PR DESCRIPTION
## Summary
- load MLB benchmark CSV to tune ball-in-play rate, target pitches per PA, and derived double-play probability
- simulate additional called pitches based on league strike rate to increase pitch counts and strikeout/walk opportunities
- add utility for reading league benchmark metrics

## Testing
- `pytest` *(fails: ImportError: cannot import name 'QStatusBar' from 'PyQt6.QtWidgets'; ImportError: cannot import name 'ImageDraw' from 'PIL'; ImportError: cannot import name 'QAction' from 'PyQt6.QtGui')*


------
https://chatgpt.com/codex/tasks/task_e_68ba350e86f8832e835087704aeef7a7