### PR TITLE
Adjust play balance defaults for higher BABIP

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -773,8 +773,6 @@ class PlayBalanceConfig:
             self.values[key] = value
 
 
-PlayBalanceConfig.load_overrides()
-
 if _benchmarks:
     _DEFAULTS["ballInPlayPitchPct"] = int(
         round(_benchmarks.get("pitches_put_in_play_pct", 0.175) * 100)
@@ -784,6 +782,10 @@ if _benchmarks:
     gb_pct = _benchmarks.get("bip_gb_pct", 0.44)
     if gb_pct:
         _DEFAULTS["doublePlayProb"] = round(dp_pct / gb_pct, 3)
+
+# Apply overrides after incorporating league benchmark defaults so that any
+# manual tuning in ``playbalance_overrides.json`` takes precedence.
+PlayBalanceConfig.load_overrides()
 
 
 __all__ = ["PlayBalanceConfig"]

--- a/scripts/simulate_season_avg.py
+++ b/scripts/simulate_season_avg.py
@@ -192,7 +192,10 @@ def apply_league_benchmarks(
     """
 
     hr_rate = cfg.hitHRProb / 100
-    cfg.hitProbBase = benchmarks["babip"] / (1 - hr_rate)
+    # The raw league BABIP underestimates hits in our simplified physics model.
+    # Apply a modest boost to the baseline hit probability to better match
+    # observed MLB averages.
+    cfg.hitProbBase = benchmarks["babip"] / (1 - hr_rate) * 1.25
     cfg.ballInPlayPitchPct = int(
         round(benchmarks["pitches_put_in_play_pct"] * 100)
     )

--- a/tests/test_league_benchmarks.py
+++ b/tests/test_league_benchmarks.py
@@ -12,6 +12,6 @@ def test_apply_league_benchmarks():
         "pitches_per_pa": 3.86,
     }
     apply_league_benchmarks(cfg, benchmarks)
-    assert cfg.hitProbBase == pytest.approx(0.291 / 0.95, abs=0.0001)
+    assert cfg.hitProbBase == pytest.approx(0.291 / 0.95 * 1.25, abs=0.0001)
     assert cfg.ballInPlayPitchPct == 18
     assert cfg.swingProbScale == pytest.approx(1.04, abs=0.001)


### PR DESCRIPTION
## Summary
- Apply play balance overrides after league benchmark defaults so manual tuning (like double play probability) isn't overwritten
- Boost baseline hit probability by 25% to better match MLB BABIP
- Update benchmark test expectations

## Testing
- `pytest` *(fails: ImportError: cannot import name 'QAction' from 'PyQt6.QtGui')*
- `pip install PyQt6` *(fails: Could not find a version that satisfies the requirement PyQt6)*

------
https://chatgpt.com/codex/tasks/task_e_68ba39bcfc08832e8f60cb080d40cdd7