### PR TITLE
Implement template-based avatar generation

### DIFF
--- a/tests/test_avatar_generator.py
+++ b/tests/test_avatar_generator.py
@@ -5,9 +5,16 @@ pil_stub = types.ModuleType("PIL")
 pil_stub.Image = object
 sys.modules.setdefault("PIL", pil_stub)
 
-from utils.avatar_generator import _infer_ethnicity
+from utils.avatar_generator import _infer_ethnicity, _select_template
 
 
 def test_infer_ethnicity_known_pairs():
     assert _infer_ethnicity("Frederick Sullivan") == "Anglo"
     assert _infer_ethnicity("Jim Thompson") == "Anglo"
+
+
+def test_select_template_path_resolution():
+    path = _select_template("Asian", "goatee")
+    assert "Template/Asian/goatee.png" in str(path)
+    clean = _select_template("Hispanic", "clean_shaven")
+    assert clean.name == "clean.png"


### PR DESCRIPTION
## Summary
- select avatar templates based on player ethnicity and facial hair
- recolor template images to team and player hair colors and save avatars
- cover template selection logic with tests

## Testing
- `pytest` *(fails: ImportError: cannot import name 'QAction' from 'PyQt6.QtGui')*


------
https://chatgpt.com/codex/tasks/task_e_68ba41db3f24832e8d17d95a39f3c79f