### PR TITLE
Fix OpenCV merge error in avatar generator

### DIFF
--- a/tests/test_avatar_recolor_alpha.py
+++ b/tests/test_avatar_recolor_alpha.py
@@ -1,0 +1,14 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from utils.avatar_generator import _recolor_by_hex
+
+
+def test_recolor_preserves_alpha():
+    img = np.zeros((2, 2, 4), dtype=np.uint8)
+    img[:, :, :3] = 0
+    img[:, :, 3] = 255
+    recolored = _recolor_by_hex(img, "#000000", "#ffffff")
+    assert recolored.shape == (2, 2, 4)
+    assert np.all(recolored[:, :, 3] == 255)

--- a/utils/avatar_generator.py
+++ b/utils/avatar_generator.py
@@ -137,7 +137,11 @@ def _recolor_by_hex(img, src_hex: str, dst_hex: str, feather: float = 3.0,
     hsv_new = cv2.merge([h_new, s_new, v])
     bgr_new = cv2.cvtColor(hsv_new, cv2.COLOR_HSV2BGR)
     if has_alpha:
-        bgr_new = cv2.merge([bgr_new, alpha])
+        # ``cv2.merge`` expects individual single-channel arrays, but ``bgr_new``
+        # is already a 3-channel image. Passing it directly with ``alpha``
+        # triggers an OpenCV assertion error. ``np.dstack`` safely appends the
+        # alpha channel while preserving existing channels and size.
+        bgr_new = np.dstack((bgr_new, alpha))
     return bgr_new
 
 


### PR DESCRIPTION
## Summary
- Fix OpenCV cv::merge assertion by stacking alpha channel with numpy
- Add regression test ensuring avatar recoloring preserves alpha

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'QStatusBar' from 'PyQt6.QtWidgets')*


------
https://chatgpt.com/codex/tasks/task_e_68ba489afa38832e86ef06645f4c02c1