### PR TITLE
Improve avatar diversity and color customization

### DIFF
--- a/tests/test_avatar_generator.py
+++ b/tests/test_avatar_generator.py
@@ -18,3 +18,8 @@ def test_select_template_path_resolution():
     assert "Template/Asian/goatee.png" in str(path)
     clean = _select_template("Hispanic", "clean_shaven")
     assert clean.name == "clean.png"
+
+
+def test_select_template_normalizes_ethnicity():
+    path = _select_template("latino", "clean_shaven")
+    assert "Template/Hispanic/clean.png" in str(path)


### PR DESCRIPTION
## Summary
- Normalize player ethnicities to select correct avatar templates
- Recolor hats, jerseys, and hair using team and player attributes
- Test template selection with ethnicity normalization

## Testing
- `pytest` *(fails: ImportError: cannot import name 'QStatusBar' from 'PyQt6.QtWidgets')*


------
https://chatgpt.com/codex/tasks/task_e_68ba5173fe38832e82f40cf986cc04c2