### PR TITLE
Expand avatar template ethnicity mapping

### DIFF
--- a/utils/avatar_generator.py
+++ b/utils/avatar_generator.py
@@ -28,11 +28,15 @@ _ETHNICITY_DIR = {
     "anglo": "Anglo",
     "caucasian": "Anglo",
     "african": "African",
+    "african american": "African",
     "black": "African",
     "asian": "Asian",
+    "asian american": "Asian",
     "pacific islander": "Asian",
     "hispanic": "Hispanic",
+    "hispanic american": "Hispanic",
     "latino": "Hispanic",
+    "latina": "Hispanic",
 }
 
 # Base colors present in the avatar templates that need to be replaced.
@@ -54,7 +58,7 @@ def _select_template(ethnicity: str, facial_hair: str) -> Path:
     """
 
     base = Path("images/avatars/Template")
-    key = ethnicity.strip().lower()
+    key = ethnicity.strip().lower().replace("-", " ")
     ethnic_dir = base / _ETHNICITY_DIR.get(key, "Anglo")
     hair_map = {"clean_shaven": "clean"}
     fname = hair_map.get(facial_hair, facial_hair) + ".png"


### PR DESCRIPTION
## Summary
- broaden recognized ethnicity strings for avatar templates
- normalize hyphenated ethnicity inputs when selecting template

## Testing
- `pytest` *(fails: ImportError: cannot import name 'QAction' from 'PyQt6.QtGui')*


------
https://chatgpt.com/codex/tasks/task_e_68ba53234b78832eb4253e1e2060d42c