### PR TITLE
Clear existing team logos before generation

### DIFF
--- a/utils/logo_generator.py
+++ b/utils/logo_generator.py
@@ -2,14 +2,14 @@
 
 Logos are created using OpenAI's image generation API and written to
 ``logo/teams`` relative to the project root. Each logo is named after the
-team's ID (lower-cased). If the OpenAI client is unavailable a fallback to the
-legacy :mod:`images.auto_logo` generator can be enabled.
+team's ID (lower-cased). Existing logos in the output directory are removed
+before new ones are generated. If the OpenAI client is unavailable a fallback
+to the legacy :mod:`images.auto_logo` generator can be enabled.
 """
 
 from __future__ import annotations
 
 import base64
-import os
 from io import BytesIO
 from pathlib import Path
 from typing import Callable, List, Optional
@@ -100,6 +100,9 @@ def generate_team_logos(
     else:
         out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
+    # Remove any existing logos so stale files do not persist
+    for existing in out_dir.glob("*.png"):
+        existing.unlink(missing_ok=True)
 
     if client is None:
         if allow_auto_logo:


### PR DESCRIPTION
## Summary
- remove stale logo files before generating new team logos
- test that logo generation clears out existing logo files

## Testing
- `pytest` *(fails: ImportError: cannot import name 'QAction' from 'PyQt6.QtGui')*
- `pip install PyQt6` *(fails: Could not find a version that satisfies the requirement PyQt6)*
- `pip install Pillow` *(fails: Could not find a version that satisfies the requirement Pillow)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4c7221d4832e850d85eedd3a02e0