### PR TITLE
Allow utils scripts to run standalone

### DIFF
--- a/utils/avatar_generator.py
+++ b/utils/avatar_generator.py
@@ -11,8 +11,12 @@ from typing import Dict, Tuple
 
 from PIL import Image
 
-from utils.openai_client import client
-from utils.team_loader import load_teams
+try:  # Allow running as a standalone script
+    from utils.openai_client import client
+    from utils.team_loader import load_teams
+except ModuleNotFoundError:  # pragma: no cover - for direct script execution
+    from openai_client import client
+    from team_loader import load_teams
 
 
 # Hair color to hex mapping used for template recoloring

--- a/utils/logo_generator.py
+++ b/utils/logo_generator.py
@@ -16,9 +16,14 @@ from typing import Callable, List, Optional
 
 from PIL import Image
 
-from utils.openai_client import client
-from utils.team_loader import load_teams
-from utils.path_utils import get_base_dir
+try:  # Allow running as a standalone script
+    from utils.openai_client import client
+    from utils.team_loader import load_teams
+    from utils.path_utils import get_base_dir
+except ModuleNotFoundError:  # pragma: no cover - for direct script execution
+    from openai_client import client
+    from team_loader import load_teams
+    from path_utils import get_base_dir
 
 
 def _auto_logo_fallback(


### PR DESCRIPTION
## Summary
- fix ModuleNotFoundError when running avatar and logo generators directly

## Testing
- `pytest` *(fails: ImportError: cannot import name 'QMainWindow' from 'PyQt6.QtWidgets')*

------
https://chatgpt.com/codex/tasks/task_e_68bb5bf27770832eb01a518b73c52e24