### PR TITLE
Fix team loader imports for direct script execution

### DIFF
--- a/utils/team_loader.py
+++ b/utils/team_loader.py
@@ -2,9 +2,18 @@ import csv
 import os
 import re
 from pathlib import Path
-from models.team import Team
-from utils.path_utils import get_base_dir
-from utils.stats_persistence import load_stats
+
+try:  # Allow running as a standalone script
+    from models.team import Team
+    from utils.path_utils import get_base_dir
+    from utils.stats_persistence import load_stats
+except ModuleNotFoundError:  # pragma: no cover - for direct script execution
+    import sys
+
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    from models.team import Team
+    from utils.path_utils import get_base_dir
+    from utils.stats_persistence import load_stats
 
 
 def _resolve_path(file_path: str | Path) -> Path:


### PR DESCRIPTION
## Summary
- allow team loader to import project modules when run as a standalone script

## Testing
- `pytest` *(fails: ImportError: cannot import name 'QStatusBar' from 'PyQt6.QtWidgets'; ImportError: cannot import name 'ImageDraw' from 'PIL')*


------
https://chatgpt.com/codex/tasks/task_e_68bb5d949d18832e80e19a76c449499c