### PR TITLE
Align season simulation with MLB benchmark tuning

### DIFF
--- a/scripts/simulate_season.py
+++ b/scripts/simulate_season.py
@@ -13,6 +13,7 @@ from copy import deepcopy
 from datetime import date
 from pathlib import Path
 import argparse
+import csv
 import os
 import random
 import sys
@@ -39,6 +40,7 @@ from logic.playbalance_config import PlayBalanceConfig
 from utils.lineup_loader import build_default_game_state
 from utils.path_utils import get_base_dir
 from utils.team_loader import load_teams
+from scripts.simulate_season_avg import apply_league_benchmarks
 
 
 STAT_ORDER = [
@@ -94,11 +96,20 @@ def clone_team_state(base: TeamState) -> TeamState:
     return team
 
 
-def simulate_season_average(use_tqdm: bool = True) -> None:
+def simulate_season_average(
+    use_tqdm: bool = True,
+    ball_in_play_outs: int = 0,
+    seed: int | None = None,
+) -> None:
     """Run a season simulation and print average box score values.
 
     Args:
         use_tqdm: Whether to display a progress bar using ``tqdm``.
+        ball_in_play_outs: Value for ``PlayBalanceConfig.ballInPlayOuts``.
+            ``0`` allows normal hit/out resolution while ``1`` makes every
+            ball put in play an out.
+        seed: Optional seed for deterministic simulations. If ``None`` (the
+            default) a different random seed will be used on each run.
     """
 
     teams = [t.team_id for t in load_teams()]
@@ -106,8 +117,47 @@ def simulate_season_average(use_tqdm: bool = True) -> None:
     base_states = {tid: build_default_game_state(tid) for tid in teams}
 
     cfg = PlayBalanceConfig.from_file(get_base_dir() / "logic" / "PBINI.txt")
-    cfg.ballInPlayOuts = 1
-    rng = random.Random(42)
+    cfg.ballInPlayOuts = ball_in_play_outs
+
+    csv_path = (
+        get_base_dir()
+        / "data"
+        / "MLB_avg"
+        / "mlb_avg_boxscore_2020_2024_both_teams.csv"
+    )
+    with csv_path.open(newline="") as f:
+        row = next(csv.DictReader(f))
+    hits = float(row["Hits"])
+    singles = (
+        hits
+        - float(row["Doubles"])
+        - float(row["Triples"])
+        - float(row["HomeRuns"])
+    )
+    cfg.hit1BProb = int(round(singles / hits * 100))
+    cfg.hit2BProb = int(round(float(row["Doubles"]) / hits * 100))
+    cfg.hit3BProb = int(round(float(row["Triples"]) / hits * 100))
+    cfg.hitHRProb = max(
+        0,
+        100 - cfg.hit1BProb - cfg.hit2BProb - cfg.hit3BProb,
+    )
+
+    bench_path = (
+        get_base_dir()
+        / "data"
+        / "MLB_avg"
+        / "mlb_league_benchmarks_2025_filled.csv"
+    )
+    with bench_path.open(newline="") as bf:
+        benchmarks = {
+            r["metric_key"]: float(r["value"])
+            for r in csv.DictReader(bf)
+        }
+
+    apply_league_benchmarks(cfg, benchmarks)
+    mlb_averages = {stat: float(val) for stat, val in row.items() if stat}
+
+    rng = random.Random(seed)
 
     totals: Counter[str] = Counter()
     total_games = 0
@@ -134,8 +184,15 @@ def simulate_season_average(use_tqdm: bool = True) -> None:
             totals["StolenBases"] += sum(p["sb"] for p in batting)
             totals["CaughtStealing"] += sum(p["cs"] for p in batting)
             totals["HitByPitch"] += sum(p["hbp"] for p in batting)
+            totals["PlateAppearances"] += sum(p["pa"] for p in batting)
+            totals["AtBats"] += sum(p["ab"] for p in batting)
+            totals["SacFlies"] += sum(p.get("sf", 0) for p in batting)
+            totals["GIDP"] += sum(p.get("gidp", 0) for p in batting)
             totals["TotalPitchesThrown"] += sum(p["pitches"] for p in pitching)
             totals["Strikes"] += sum(p["strikes"] for p in pitching)
+
+        totals["TwoStrikeCounts"] += sim.two_strike_counts
+        totals["ThreeBallCounts"] += sim.three_ball_counts
 
         total_games += 1
         return box["home"]["score"], box["away"]["score"]
@@ -149,9 +206,35 @@ def simulate_season_average(use_tqdm: bool = True) -> None:
 
     averages = {k: totals[k] / total_games for k in STAT_ORDER}
 
+    diffs = {k: averages[k] - mlb_averages.get(k, 0.0) for k in STAT_ORDER}
+
     print("Average box score per game (both teams):")
     for key in STAT_ORDER:
-        print(f"{key}: {averages[key]:.2f}")
+        mlb_val = mlb_averages[key]
+        sim_val = averages[key]
+        diff = diffs[key]
+        print(
+            f"{key}: MLB {mlb_val:.2f}, Sim {sim_val:.2f}, Diff {diff:+.2f}"
+        )
+
+    total_pitches = totals["TotalPitchesThrown"]
+    total_pa = totals.get("PlateAppearances", 0)
+    p_pa = total_pitches / total_pa if total_pa else 0.0
+    babip_den = (
+        totals.get("AtBats", 0)
+        - totals["Strikeouts"]
+        - totals["HomeRuns"]
+        + totals.get("SacFlies", 0)
+    )
+    babip = (
+        (totals["Hits"] - totals["HomeRuns"]) / babip_den if babip_den else 0.0
+    )
+    dp_rate = totals.get("GIDP", 0) / babip_den if babip_den else 0.0
+    print(f"Pitches/PA: {p_pa:.2f}")
+    print(f"BABIP: {babip:.3f}")
+    print(f"DoublePlayRate: {dp_rate:.3f}")
+    print(f"Total two-strike counts: {totals['TwoStrikeCounts']}")
+    print(f"Total three-ball counts: {totals['ThreeBallCounts']}")
 
 
 if __name__ == "__main__":
@@ -163,8 +246,27 @@ if __name__ == "__main__":
         action="store_true",
         help="Disable tqdm progress bar.",
     )
+    parser.add_argument(
+        "--ball-in-play-outs",
+        type=int,
+        default=0,
+        help=(
+            "Set PlayBalanceConfig.ballInPlayOuts (0 normal, 1 every ball in "
+            "play is an out)."
+        ),
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Seed for deterministic runs (default: random)",
+    )
     args = parser.parse_args()
 
     env_disable = os.getenv("DISABLE_TQDM", "").lower() in {"1", "true", "yes"}
     use_tqdm = not (args.disable_tqdm or env_disable)
-    simulate_season_average(use_tqdm=use_tqdm)
+    simulate_season_average(
+        use_tqdm=use_tqdm,
+        ball_in_play_outs=args.ball_in_play_outs,
+        seed=args.seed,
+    )


### PR DESCRIPTION
## Summary
- load MLB average boxscore and league benchmark data in season simulation
- apply league tuning to PlayBalanceConfig and track additional metrics
- add CLI options for ball-in-play outs and deterministic seeds

## Testing
- `pytest` *(fails: cannot import name 'QMainWindow' from 'PyQt6.QtWidgets')*
- `pip install PyQt6` *(fails: Could not find a version that satisfies the requirement PyQt6)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd99bcff4832e92706cf8d787b66b