### PR TITLE
Ensure exclusive stats persistence with file locking

### DIFF
--- a/utils/stats_persistence.py
+++ b/utils/stats_persistence.py
@@ -1,8 +1,17 @@
+"""Utilities for persisting season statistics.
+
+Reads and writes to ``season_stats.json`` are guarded by an inter-process
+file lock (via :mod:`fcntl`) to prevent concurrent writers from corrupting
+the data.
+"""
+
 from __future__ import annotations
 
 import json
 from pathlib import Path
 from typing import Any, Dict, Iterable
+
+import fcntl
 
 from utils.path_utils import get_base_dir
 
@@ -34,35 +43,41 @@ def save_stats(
     teams: Iterable[Any],
     path: str | Path = "data/season_stats.json",
 ) -> None:
+    """Persist season statistics with an inter-process file lock."""
+
     file_path = _resolve_path(path)
-    stats = load_stats(file_path)
-    player_stats = stats.get("players", {})
-    for player in players:
-        season = getattr(player, "season_stats", None)
-        if season:
-            player_stats[player.player_id] = season
-    team_stats = stats.get("teams", {})
-    for team in teams:
-        season = getattr(team, "season_stats", None)
-        if season:
-            team_stats[team.team_id] = season
-    history = stats.get("history", [])
-    history.append(
-        {
-            "players": {
-                p.player_id: getattr(p, "season_stats", {}) for p in players
-            },
-            "teams": {t.team_id: getattr(t, "season_stats", {}) for t in teams},
-        }
-    )
+    lock_path = file_path.with_suffix(file_path.suffix + ".lock")
     file_path.parent.mkdir(parents=True, exist_ok=True)
-    with file_path.open("w", encoding="utf-8") as f:
-        json.dump(
+
+    with lock_path.open("w") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        stats = load_stats(file_path)
+        player_stats = stats.get("players", {})
+        for player in players:
+            season = getattr(player, "season_stats", None)
+            if season:
+                player_stats[player.player_id] = season
+        team_stats = stats.get("teams", {})
+        for team in teams:
+            season = getattr(team, "season_stats", None)
+            if season:
+                team_stats[team.team_id] = season
+        history = stats.get("history", [])
+        history.append(
             {
-                "players": player_stats,
-                "teams": team_stats,
-                "history": history,
-            },
-            f,
-            indent=2,
+                "players": {
+                    p.player_id: getattr(p, "season_stats", {}) for p in players
+                },
+                "teams": {t.team_id: getattr(t, "season_stats", {}) for t in teams},
+            }
         )
+        with file_path.open("w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "players": player_stats,
+                    "teams": team_stats,
+                    "history": history,
+                },
+                f,
+                indent=2,
+            )


### PR DESCRIPTION
## Summary
- protect season stats read-modify-write with an `fcntl`-based file lock
- document the locking behavior in `stats_persistence`

## Testing
- `pytest` *(fails: ImportError: cannot import name 'QMainWindow' from 'PyQt6.QtWidgets')*

------
https://chatgpt.com/codex/tasks/task_e_68bcdd72c754832ebffec887a81cb068