### PR TITLE
Diversify generated player ethnicities

### DIFF
--- a/logic/player_generator.py
+++ b/logic/player_generator.py
@@ -15,17 +15,21 @@ from utils.path_utils import get_base_dir
 # Constants
 BASE_DIR = get_base_dir()
 NAME_PATH = BASE_DIR / "data" / "names.csv"
+PLAYER_PATH = BASE_DIR / "data" / "players.csv"
 
 
 def _load_name_pool() -> Dict[str, List[Tuple[str, str]]]:
     pool: Dict[str, List[Tuple[str, str]]] = {}
-    if NAME_PATH.exists():
-        with NAME_PATH.open(newline="") as f:
+    source = PLAYER_PATH if PLAYER_PATH.exists() else NAME_PATH
+    if source.exists():
+        with source.open(newline="") as f:
             reader = csv.DictReader(f)
             for row in reader:
-                pool.setdefault(row["ethnicity"], []).append(
-                    (row["first_name"], row["last_name"])
-                )
+                ethnicity = row.get("ethnicity", "").strip()
+                first = row.get("first_name")
+                last = row.get("last_name")
+                if ethnicity and first and last:
+                    pool.setdefault(ethnicity, []).append((first, last))
     return pool
 
 

--- a/tests/test_player_generator.py
+++ b/tests/test_player_generator.py
@@ -246,6 +246,15 @@ def test_generate_player_includes_appearance(is_pitcher):
     assert player["facial_hair"] in pg.FACIAL_HAIR_WEIGHTS[player["ethnicity"]]
 
 
+def test_generate_player_varied_ethnicities():
+    pg.reset_name_cache()
+    random.seed(0)
+    ethnicities = {
+        generate_player(is_pitcher=False)["ethnicity"] for _ in range(50)
+    }
+    assert {"Anglo", "African", "Asian", "Hispanic"} <= ethnicities
+
+
 def test_generate_pitches_counts_and_bounds(monkeypatch):
     def fake_randint(a, b):
         if (a, b) == (2, 5):


### PR DESCRIPTION
## Summary
- build name pool from `data/players.csv` so generated names include multiple ethnicities
- verify generator can produce Anglo, African, Asian and Hispanic players

## Testing
- `pytest` *(fails: ImportError: cannot import name 'QMainWindow' from 'PyQt6.QtWidgets')*

------
https://chatgpt.com/codex/tasks/task_e_68bcdeb00e8c832eadf8e985d1f4ef00