### PR TITLE
Add team page to owner dashboard with stats buttons

### DIFF
--- a/tests/test_login_window.py
+++ b/tests/test_login_window.py
@@ -106,6 +106,11 @@ class OwnerDashboard:
 owner_mod.OwnerDashboard = OwnerDashboard
 sys.modules['ui.owner_dashboard'] = owner_mod
 
+theme_mod = types.ModuleType('ui.theme')
+theme_mod.DARK_QSS = ""
+theme_mod._toggle_theme = lambda status_bar=None: None
+sys.modules['ui.theme'] = theme_mod
+
 import bcrypt
 from ui import login_window
 

--- a/tests/test_logo_determinism.py
+++ b/tests/test_logo_determinism.py
@@ -2,6 +2,10 @@ import hashlib
 import pytest
 
 pytest.importorskip("PIL")
+pytest.importorskip("PIL.Image")
+pytest.importorskip("PIL.ImageDraw")
+pytest.importorskip("PIL.ImageFont")
+pytest.importorskip("PIL.ImageFilter")
 
 from images.auto_logo import TeamSpec, generate_logo
 

--- a/tests/test_make_player_item.py
+++ b/tests/test_make_player_item.py
@@ -27,10 +27,12 @@ qtwidgets = types.ModuleType("PyQt6.QtWidgets")
 widget_names = [
     'QWidget','QLabel','QVBoxLayout','QTabWidget','QListWidget','QTextEdit','QPushButton',
     'QHBoxLayout','QComboBox','QMessageBox','QGroupBox','QMenuBar','QDialog','QFormLayout',
-    'QSpinBox','QGridLayout','QScrollArea','QLineEdit','QTableWidget','QTableWidgetItem'
+    'QSpinBox','QGridLayout','QScrollArea','QLineEdit','QTableWidget','QTableWidgetItem',
+    'QMainWindow','QStackedWidget','QFrame','QStatusBar','QToolButton','QSizePolicy','QSpacerItem','QApplication'
 ]
 for name in widget_names:
     setattr(qtwidgets, name, Dummy)
+qtwidgets.__getattr__ = lambda name: Dummy
 
 class QListWidgetItem:
     def __init__(self, text):

--- a/tests/test_schedule_windows.py
+++ b/tests/test_schedule_windows.py
@@ -112,13 +112,15 @@ qtwidgets = types.ModuleType("PyQt6.QtWidgets")
 widget_names = [
     'QWidget','QLabel','QVBoxLayout','QTabWidget','QListWidget','QTextEdit','QPushButton',
     'QHBoxLayout','QComboBox','QMessageBox','QGroupBox','QMenuBar','QDialog','QFormLayout',
-    'QSpinBox','QGridLayout','QScrollArea','QLineEdit'
+    'QSpinBox','QGridLayout','QScrollArea','QLineEdit','QMainWindow','QStackedWidget',
+    'QFrame','QStatusBar','QToolButton','QSizePolicy','QSpacerItem','QApplication'
 ]
 for name in widget_names:
     setattr(qtwidgets, name, Dummy)
 qtwidgets.QMenuBar = QMenuBar
 qtwidgets.QMenu = QMenu
 qtwidgets.QAction = QAction
+qtwidgets.__getattr__ = lambda name: Dummy
 # Provide a simple QTextEdit capable of storing HTML for assertions
 class QTextEdit(Dummy):
     def __init__(self, *args, **kwargs):
@@ -160,6 +162,11 @@ qtcore.QPropertyAnimation = QPropertyAnimation
 sys.modules['PyQt6'] = types.ModuleType('PyQt6')
 sys.modules['PyQt6.QtWidgets'] = qtwidgets
 sys.modules['PyQt6.QtCore'] = qtcore
+
+theme_mod = types.ModuleType('ui.theme')
+theme_mod._toggle_theme = lambda status_bar=None: None
+theme_mod.DARK_QSS = ""
+sys.modules['ui.theme'] = theme_mod
 
 qtgui = types.ModuleType("PyQt6.QtGui")
 class QFont:
@@ -237,3 +244,39 @@ def test_schedule_windows_show_data(monkeypatch, tmp_path):
     assert team.viewer.item(0,1).text() == 'vs B'
     assert team.viewer.item(0,2).text() == 'W 3-2'
     assert team.viewer.item(1,1).text() == 'at C'
+
+
+def test_owner_dashboard_stats_windows(monkeypatch):
+    from types import SimpleNamespace
+
+    called = []
+
+    class DummyTabs:
+        def __init__(self):
+            self.idx = None
+
+        def setCurrentIndex(self, i):
+            self.idx = i
+
+    class DummyWindow:
+        def __init__(self, *a, **k):
+            self.tabs = DummyTabs()
+
+        def exec(self):
+            called.append(self.tabs.idx)
+
+    monkeypatch.setattr(owner_dashboard, 'TeamStatsWindow', DummyWindow)
+
+    def fake_init(self, team_id):
+        self.team_id = team_id
+        self.players = {}
+        self.roster = SimpleNamespace()
+        self.team = SimpleNamespace(season_stats={})
+
+    monkeypatch.setattr(owner_dashboard.OwnerDashboard, '__init__', fake_init)
+
+    dash = owner_dashboard.OwnerDashboard('X')
+    dash.open_team_stats_window()
+    dash.open_player_stats_window()
+
+    assert called == [2, 0]

--- a/tests/test_standings_window.py
+++ b/tests/test_standings_window.py
@@ -103,7 +103,8 @@ qtwidgets = types.ModuleType("PyQt6.QtWidgets")
 widget_names = [
     'QWidget','QLabel','QVBoxLayout','QTabWidget','QListWidget','QTextEdit','QPushButton',
     'QHBoxLayout','QComboBox','QMessageBox','QGroupBox','QMenuBar','QFormLayout',
-    'QSpinBox','QGridLayout','QScrollArea','QLineEdit','QTableWidget','QTableWidgetItem'
+    'QSpinBox','QGridLayout','QScrollArea','QLineEdit','QTableWidget','QTableWidgetItem',
+    'QMainWindow','QStackedWidget','QFrame','QStatusBar','QToolButton','QSizePolicy','QSpacerItem','QApplication'
 ]
 for name in widget_names:
     setattr(qtwidgets, name, Dummy)
@@ -111,6 +112,7 @@ qtwidgets.QMenuBar = QMenuBar
 qtwidgets.QMenu = QMenu
 qtwidgets.QAction = QAction
 qtwidgets.QDialog = Dialog
+qtwidgets.__getattr__ = lambda name: Dummy
 
 
 class QTextEdit(Dummy):
@@ -164,6 +166,11 @@ class QFont:
 qtgui.QFont = QFont
 qtgui.QPixmap = Dummy
 sys.modules['PyQt6.QtGui'] = qtgui
+
+theme_mod = types.ModuleType('ui.theme')
+theme_mod._toggle_theme = lambda status_bar=None: None
+theme_mod.DARK_QSS = ""
+sys.modules['ui.theme'] = theme_mod
 
 # ---- Imports after stubbing ----
 sys.modules.pop("ui.owner_dashboard", None)

--- a/ui/schedule_page.py
+++ b/ui/schedule_page.py
@@ -3,7 +3,7 @@ from .components import Card, section_title
 
 
 class SchedulePage(QWidget):
-    """Page for viewing schedules and league information."""
+    """Page for viewing league schedules and information."""
 
     def __init__(self, dashboard):
         super().__init__()
@@ -11,11 +11,7 @@ class SchedulePage(QWidget):
         layout.setContentsMargins(18, 18, 18, 18)
 
         card = Card()
-        card.layout().addWidget(section_title("Schedule"))
-
-        btn_team = QPushButton("Team Schedule", objectName="Primary")
-        btn_team.clicked.connect(dashboard.open_team_schedule_window)
-        card.layout().addWidget(btn_team)
+        card.layout().addWidget(section_title("League"))
 
         btn_league = QPushButton("League Schedule", objectName="Primary")
         btn_league.clicked.connect(dashboard.open_schedule_window)

--- a/ui/team_page.py
+++ b/ui/team_page.py
@@ -1,0 +1,30 @@
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QPushButton
+from .components import Card, section_title
+
+
+class TeamPage(QWidget):
+    """Page for viewing team-specific information."""
+
+    def __init__(self, dashboard):
+        super().__init__()
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(18, 18, 18, 18)
+
+        card = Card()
+        card.layout().addWidget(section_title("Team"))
+
+        btn_sched = QPushButton("Team Schedule", objectName="Primary")
+        btn_sched.clicked.connect(dashboard.open_team_schedule_window)
+        card.layout().addWidget(btn_sched)
+
+        btn_team_stats = QPushButton("Team Stats", objectName="Primary")
+        btn_team_stats.clicked.connect(dashboard.open_team_stats_window)
+        card.layout().addWidget(btn_team_stats)
+
+        btn_player_stats = QPushButton("Player Stats", objectName="Primary")
+        btn_player_stats.clicked.connect(dashboard.open_player_stats_window)
+        card.layout().addWidget(btn_player_stats)
+
+        card.layout().addStretch()
+        layout.addWidget(card)
+        layout.addStretch()


### PR DESCRIPTION
## Summary
- Add Team page to owner dashboard navigation
- Move team schedule to Team page and add Team Stats and Player Stats actions
- Extend tests with coverage for new stats page and broaden PyQt stubs

## Testing
- `pytest` *(fails: 65 failed, 253 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bce049218c832e9c231f7e2c32ce0c