### PR TITLE
Color team schedule by venue

### DIFF
--- a/ui/team_schedule_window.py
+++ b/ui/team_schedule_window.py
@@ -122,13 +122,11 @@ class TeamScheduleWindow(QDialog):
             item = QTableWidgetItem(text)
             if game and QColor is not None:
                 color = (
-                    QColor("#aaffaa")
+                    QColor("#aaaaff")
                     if game["opponent"].startswith("vs")
-                    else QColor("#aaaaff")
+                    else QColor("#dddddd")
                 )
                 item.setBackground(color)
-            elif not game and QColor is not None:
-                item.setBackground(QColor("#dddddd"))
             try:
                 item.setData(Qt.ItemDataRole.UserRole, date_str)
             except Exception:  # pragma: no cover


### PR DESCRIPTION
## Summary
- Show team schedule home games with blue squares and away games with grey squares

## Testing
- `pytest` *(fails: AssertionError and ValueError errors; 65 failed, 253 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bce86abd7c832e97be4bdd3cdcfdb6