### PR TITLE
Improve team schedule readability

### DIFF
--- a/ui/team_schedule_window.py
+++ b/ui/team_schedule_window.py
@@ -56,6 +56,9 @@ class TeamScheduleWindow(QDialog):
             self.viewer.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
             self.viewer.setMinimumHeight(560)
             self.viewer.cellDoubleClicked.connect(self._open_boxscore)
+            # Enlarge cells for better readability
+            self.viewer.horizontalHeader().setDefaultSectionSize(110)
+            self.viewer.verticalHeader().setDefaultSectionSize(90)
         except Exception:  # pragma: no cover
             pass
         try:
@@ -120,13 +123,16 @@ class TeamScheduleWindow(QDialog):
                 if game.get("result"):
                     text += f"\n{game['result']}"
             item = QTableWidgetItem(text)
-            if game and QColor is not None:
-                color = (
-                    QColor("#aaaaff")
-                    if game["opponent"].startswith("vs")
-                    else QColor("#dddddd")
-                )
-                item.setBackground(color)
+            if QColor is not None:
+                # Ensure text remains legible against colored backgrounds
+                item.setForeground(QColor("black"))
+                if game:
+                    color = (
+                        QColor("#aaaaff")
+                        if game["opponent"].startswith("vs")
+                        else QColor("#dddddd")
+                    )
+                    item.setBackground(color)
             try:
                 item.setData(Qt.ItemDataRole.UserRole, date_str)
             except Exception:  # pragma: no cover


### PR DESCRIPTION
## Summary
- enlarge team schedule calendar cells
- ensure schedule text uses a readable color on colored backgrounds

## Testing
- `pytest` *(fails: tests/test_physics.py::test_missed_control_expands_box_and_reduces_velocity - AssertionError: assert 3 == 11)*

------
https://chatgpt.com/codex/tasks/task_e_68bcec244204832e8066082359b29ad1