### PR TITLE
Refactor simulation config loading and integrate tuned defaults

### DIFF
--- a/logic/season_simulator.py
+++ b/logic/season_simulator.py
@@ -10,9 +10,8 @@ from logic.simulation import (
     generate_boxscore,
     render_boxscore_html,
 )
-from logic.playbalance_config import PlayBalanceConfig
 from utils.lineup_loader import build_default_game_state
-from utils.path_utils import get_base_dir
+from .sim_config import load_tuned_playbalance_config
 
 
 def _simulate_game_worker(
@@ -153,7 +152,7 @@ class SeasonSimulator:
 
         home = build_default_game_state(home_id)
         away = build_default_game_state(away_id)
-        cfg = PlayBalanceConfig.from_file(get_base_dir() / "logic" / "PBINI.txt")
+        cfg, _ = load_tuned_playbalance_config()
         sim = GameSimulation(home, away, cfg, random.Random(seed))
         sim.simulate_game()
         box = generate_boxscore(home, away)

--- a/logic/sim_config.py
+++ b/logic/sim_config.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Helpers for loading and tuning :class:`PlayBalanceConfig`."""
+
+import csv
+from typing import Tuple, Dict
+
+from .playbalance_config import PlayBalanceConfig
+from utils.path_utils import get_base_dir
+
+
+def apply_league_benchmarks(
+    cfg: PlayBalanceConfig, benchmarks: Dict[str, float]
+) -> None:
+    """Configure ``cfg`` using league-wide benchmark rates."""
+
+    hr_rate = cfg.hitHRProb / 100
+    cfg.hitProbBase = benchmarks["babip"] / (1 - hr_rate) * 1.25
+    cfg.ballInPlayPitchPct = int(round(benchmarks["pitches_put_in_play_pct"] * 100))
+    pitches_per_pa = benchmarks["pitches_per_pa"]
+    cfg.swingProbScale = round(4.0 / pitches_per_pa, 2) if pitches_per_pa else 1.0
+
+
+def load_tuned_playbalance_config(
+    ball_in_play_outs: int = 0,
+) -> Tuple[PlayBalanceConfig, Dict[str, float]]:
+    """Return a tuned :class:`PlayBalanceConfig` and MLB averages."""
+
+    base = get_base_dir()
+    cfg = PlayBalanceConfig.from_file(base / "logic" / "PBINI.txt")
+    cfg.ballInPlayOuts = ball_in_play_outs
+
+    csv_path = base / "data" / "MLB_avg" / "mlb_avg_boxscore_2020_2024_both_teams.csv"
+    with csv_path.open(newline="") as f:
+        row = next(csv.DictReader(f))
+
+    hits = float(row["Hits"])
+    singles = hits - float(row["Doubles"]) - float(row["Triples"]) - float(row["HomeRuns"])
+    cfg.hit1BProb = int(round(singles / hits * 100))
+    cfg.hit2BProb = int(round(float(row["Doubles"]) / hits * 100))
+    cfg.hit3BProb = int(round(float(row["Triples"]) / hits * 100))
+    cfg.hitHRProb = max(0, 100 - cfg.hit1BProb - cfg.hit2BProb - cfg.hit3BProb)
+
+    bench_path = base / "data" / "MLB_avg" / "mlb_league_benchmarks_2025_filled.csv"
+    with bench_path.open(newline="") as bf:
+        benchmarks = {r["metric_key"]: float(r["value"]) for r in csv.DictReader(bf)}
+
+    apply_league_benchmarks(cfg, benchmarks)
+    mlb_averages = {stat: float(val) for stat, val in row.items() if stat}
+    return cfg, mlb_averages

--- a/tests/test_league_benchmarks.py
+++ b/tests/test_league_benchmarks.py
@@ -1,7 +1,7 @@
 import pytest
 
 from logic.playbalance_config import PlayBalanceConfig
-from scripts.simulate_season_avg import apply_league_benchmarks
+from logic.sim_config import apply_league_benchmarks
 
 
 def test_apply_league_benchmarks():

--- a/ui/season_progress_window.py
+++ b/ui/season_progress_window.py
@@ -61,9 +61,14 @@ class SeasonProgressWindow(QDialog):
                 schedule = list(reader)
         # Persist league data after each game so that standings, schedules and
         # statistics remain current even if a simulation run is interrupted.
-        self.simulator = SeasonSimulator(
-            schedule or [], simulate_game, after_game=self._record_game
-        )
+        if simulate_game is not None:
+            self.simulator = SeasonSimulator(
+                schedule or [], simulate_game, after_game=self._record_game
+            )
+        else:
+            self.simulator = SeasonSimulator(
+                schedule or [], after_game=self._record_game
+            )
         # Track basic win/loss records as games are played so the standings
         # window and schedule pages can reflect results.
         self._standings: dict[str, dict[str, int]] = {}
@@ -190,7 +195,10 @@ class SeasonProgressWindow(QDialog):
                 "training_camp": False,
                 "schedule": False,
             }
-            self.simulator = SeasonSimulator([], self._simulate_game)
+            if self._simulate_game is not None:
+                self.simulator = SeasonSimulator([], self._simulate_game)
+            else:
+                self.simulator = SeasonSimulator([])
             note = f"Retired Players: {len(retired)}"
         else:
             self.manager.advance_phase()
@@ -255,9 +263,14 @@ class SeasonProgressWindow(QDialog):
         start = date(date.today().year, 4, 1)
         schedule = generate_mlb_schedule(teams, start)
         save_schedule(schedule, SCHEDULE_FILE)
-        self.simulator = SeasonSimulator(
-            schedule, self._simulate_game, after_game=self._record_game
-        )
+        if self._simulate_game is not None:
+            self.simulator = SeasonSimulator(
+                schedule, self._simulate_game, after_game=self._record_game
+            )
+        else:
+            self.simulator = SeasonSimulator(
+                schedule, after_game=self._record_game
+            )
         message = f"Schedule generated with {len(schedule)} games."
         log_news_event(f"Generated regular season schedule with {len(schedule)} games")
         self.generate_schedule_button.setEnabled(False)


### PR DESCRIPTION
## Summary
- centralize config tuning in `logic/sim_config` to apply MLB averages and benchmarks
- default season simulations now use tuned play-balance config
- season progress screen instantiates `SeasonSimulator` without custom overrides

## Testing
- `pytest` *(fails: Team DRO does not have enough position players and other assertions)*


------
https://chatgpt.com/codex/tasks/task_e_68bcf2ad39a8832ebb870ba4fd1f9703