### PR TITLE
Skip stat persistence during season average simulation

### DIFF
--- a/scripts/simulate_season_avg.py
+++ b/scripts/simulate_season_avg.py
@@ -94,6 +94,16 @@ from logic.playbalance_config import PlayBalanceConfig
 from utils.lineup_loader import build_default_game_state
 from utils.path_utils import get_base_dir
 from utils.team_loader import load_teams
+import logic.simulation as sim
+
+
+def _no_save_stats(players, teams):
+    """No-op ``save_stats`` to avoid file I/O during benchmarking."""
+
+    return None
+
+
+sim.save_stats = _no_save_stats
 
 
 STAT_ORDER = [


### PR DESCRIPTION
## Summary
- monkeypatch `logic.simulation.save_stats` to a no-op in `simulate_season_avg.py` to avoid file-locking overhead

## Testing
- ❌ `pytest` (fail: multiple assertions, environment-specific data missing)
- ⚠️ `python scripts/simulate_season_avg.py --disable-tqdm --seed 1 --ball-in-play-outs 1` (fails: Team DRO does not have enough position players)


------
https://chatgpt.com/codex/tasks/task_e_68bd7f22fe2c832eb15874eea4a57b03