### PR TITLE
Add ball-in-play out probability control

### DIFF
--- a/data/news_feed.txt
+++ b/data/news_feed.txt
@@ -14,3 +14,13 @@
 [2025-08-24 18:54:41] Generated regular season schedule with 162 games
 [2025-08-24 18:54:41] Generated regular season schedule with 162 games
 [2025-08-24 18:54:41] No unsigned players available
+[2025-09-07 13:24:57] Simulated a regular season day; 1 days until Midseason
+[2025-09-07 13:24:57] Simulated a regular season day; 0 days until Midseason
+[2025-09-07 13:24:57] Simulated week; 0 days until Midseason
+[2025-09-07 13:24:57] Simulated month; 0 days until Midseason
+[2025-09-07 13:24:57] Season advanced to Preseason
+[2025-09-07 13:24:57] No unsigned players available
+[2025-09-07 13:24:57] Training camp completed; players marked ready
+[2025-09-07 13:24:57] Generated regular season schedule with 162 games
+[2025-09-07 13:24:57] Generated regular season schedule with 162 games
+[2025-09-07 13:24:57] No unsigned players available

--- a/logic/sim_config.py
+++ b/logic/sim_config.py
@@ -22,7 +22,7 @@ def apply_league_benchmarks(
 
 
 def load_tuned_playbalance_config(
-    ball_in_play_outs: int = 0,
+    ball_in_play_outs: float = 0.0,
 ) -> Tuple[PlayBalanceConfig, Dict[str, float]]:
     """Return a tuned :class:`PlayBalanceConfig` and MLB averages."""
 

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -1819,6 +1819,9 @@ class GameSimulation:
             "line": self.config.get("lineOutProb", 0.0),
             "fly": self.config.get("flyOutProb", 0.0),
         }[self.last_batted_ball_type]
+        extra_out = float(self.config.get("ballInPlayOuts", 0.0))
+        if extra_out:
+            out_prob = 1 - (1 - out_prob) * (1 - extra_out)
         if self.rng.random() < out_prob:
             return 0, False
         roll_dist = self.physics.ball_roll_distance(

--- a/scripts/sim_halfseason_avg.py
+++ b/scripts/sim_halfseason_avg.py
@@ -168,15 +168,15 @@ def _simulate_game(home_id: str, away_id: str, seed: int) -> Counter[str]:
 
 
 def simulate_halfseason_average(
-    use_tqdm: bool = True, ball_in_play_outs: int = 0
+    use_tqdm: bool = True, ball_in_play_outs: float = 0.0
 ) -> None:
     """Run a half-season simulation and print average box score values.
 
     Args:
         use_tqdm: Whether to display a progress bar using ``tqdm``.
-        ball_in_play_outs: Value for ``PlayBalanceConfig.ballInPlayOuts``.
-            ``0`` allows normal hit/out resolution while ``1`` makes every
-            ball put in play an out.
+        ball_in_play_outs: Additional probability that any ball put in play
+            becomes an out. ``0`` allows normal hit/out resolution while ``1``
+            makes every ball in play an out.
     """
 
     teams = [t.team_id for t in load_teams()]
@@ -264,11 +264,11 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--ball-in-play-outs",
-        type=int,
-        default=0,
+        type=float,
+        default=0.0,
         help=(
-            "Set PlayBalanceConfig.ballInPlayOuts (0 normal, 1 every ball in "
-            "play is an out)."
+            "Additional out probability for balls in play (0 normal, 1 all balls in"
+            " play are outs)."
         ),
     )
     args = parser.parse_args()

--- a/scripts/simulate_season.py
+++ b/scripts/simulate_season.py
@@ -96,16 +96,16 @@ def clone_team_state(base: TeamState) -> TeamState:
 
 def simulate_season_average(
     use_tqdm: bool = True,
-    ball_in_play_outs: int = 0,
+    ball_in_play_outs: float = 0.0,
     seed: int | None = None,
 ) -> None:
     """Run a season simulation and print average box score values.
 
     Args:
         use_tqdm: Whether to display a progress bar using ``tqdm``.
-        ball_in_play_outs: Value for ``PlayBalanceConfig.ballInPlayOuts``.
-            ``0`` allows normal hit/out resolution while ``1`` makes every
-            ball put in play an out.
+        ball_in_play_outs: Additional probability that any ball put in play
+            becomes an out. ``0`` allows normal hit/out resolution while ``1``
+            makes every ball in play an out.
         seed: Optional seed for deterministic simulations. If ``None`` (the
             default) a different random seed will be used on each run.
     """
@@ -207,11 +207,11 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--ball-in-play-outs",
-        type=int,
-        default=0,
+        type=float,
+        default=0.0,
         help=(
-            "Set PlayBalanceConfig.ballInPlayOuts (0 normal, 1 every ball in "
-            "play is an out)."
+            "Additional out probability for balls in play (0 normal, 1 all balls in"
+            " play are outs)."
         ),
     )
     parser.add_argument(

--- a/scripts/simulate_season_avg.py
+++ b/scripts/simulate_season_avg.py
@@ -214,15 +214,17 @@ def apply_league_benchmarks(
 
 
 def simulate_season_average(
-    use_tqdm: bool = True, ball_in_play_outs: int = 0, seed: int | None = None
+    use_tqdm: bool = True,
+    ball_in_play_outs: float = 0.0,
+    seed: int | None = None,
 ) -> None:
     """Run a season simulation and print average box score values.
 
     Args:
         use_tqdm: Whether to display a progress bar using ``tqdm``.
-        ball_in_play_outs: Value for ``PlayBalanceConfig.ballInPlayOuts``.
-            ``0`` allows normal hit/out resolution while ``1`` makes every
-            ball put in play an out.
+        ball_in_play_outs: Additional probability that any ball put in play
+            becomes an out. ``0`` allows normal hit/out resolution while ``1``
+            makes every ball in play an out.
         seed: Optional seed for deterministic simulations. If ``None`` (the
             default) a different random seed will be used on each run.
     """
@@ -355,11 +357,11 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--ball-in-play-outs",
-        type=int,
-        default=0,
+        type=float,
+        default=0.0,
         help=(
-            "Set PlayBalanceConfig.ballInPlayOuts (0 normal, 1 every ball in "
-            "play is an out)."
+            "Additional out probability for balls in play (0 normal, 1 all balls in"
+            " play are outs)."
         ),
     )
     parser.add_argument(

--- a/tests/test_ball_in_play_outs.py
+++ b/tests/test_ball_in_play_outs.py
@@ -1,0 +1,94 @@
+import random
+
+from logic.simulation import GameSimulation, TeamState
+from models.player import Player
+from models.pitcher import Pitcher
+from tests.util.pbini_factory import make_cfg
+
+
+class ZeroRandom(random.Random):
+    """Deterministic random source returning 0 for all calls."""
+
+    def random(self):  # type: ignore[override]
+        return 0.0
+
+    def randint(self, a, b):  # type: ignore[override]
+        return a
+
+
+def _player(pid: str) -> Player:
+    return Player(
+        player_id=pid,
+        first_name="F" + pid,
+        last_name="L" + pid,
+        birthdate="2000-01-01",
+        height=72,
+        weight=180,
+        bats="R",
+        primary_position="1B",
+        other_positions=[],
+        gf=50,
+        ch=50,
+        ph=50,
+        sp=50,
+        pl=0,
+        vl=0,
+        sc=0,
+        fa=0,
+        arm=0,
+    )
+
+
+def _pitcher(pid: str) -> Pitcher:
+    return Pitcher(
+        player_id=pid,
+        first_name="PF" + pid,
+        last_name="PL" + pid,
+        birthdate="2000-01-01",
+        height=72,
+        weight=180,
+        bats="R",
+        primary_position="P",
+        other_positions=[],
+        gf=50,
+        endurance=100,
+        control=50,
+        movement=50,
+        hold_runner=50,
+        fb=50,
+        cu=0,
+        cb=0,
+        sl=0,
+        si=0,
+        scb=0,
+        kn=0,
+        arm=50,
+        fa=50,
+        role="SP",
+    )
+
+
+def test_ball_in_play_outs_forces_out():
+    cfg = make_cfg(
+        groundBallBaseRate=100,
+        flyBallBaseRate=0,
+        lineDriveBaseRate=0,
+        groundOutProb=0.0,
+        lineOutProb=0.0,
+        flyOutProb=0.0,
+        hitProbCap=1.0,
+        foulPitchBasePct=0,
+        ballInPlayPitchPct=100,
+        ballInPlayOuts=1.0,
+    )
+    home = TeamState(lineup=[_player("h1")], bench=[], pitchers=[_pitcher("hp")])
+    away = TeamState(lineup=[_player("a1")], bench=[], pitchers=[_pitcher("ap")])
+    rng = ZeroRandom()
+    sim = GameSimulation(home, away, cfg, rng)
+    outs = sim.play_at_bat(away, home)
+    assert outs == 1
+    pitcher_state = home.current_pitcher_state
+    assert pitcher_state is not None
+    batter_state = away.lineup_stats[away.lineup[0].player_id]
+    assert batter_state.pitches >= 1
+    assert all(b is None for b in away.bases)


### PR DESCRIPTION
## Summary
- allow tuning extra outs on balls put in play via `ballInPlayOuts`
- expose `--ball-in-play-outs` option for season simulation scripts
- test that forcing all balls in play to be outs works

## Testing
- `pytest tests/test_ball_in_play_outs.py -q`
- `pytest` *(fails: Team DRO does not have enough position players)*

------
https://chatgpt.com/codex/tasks/task_e_68bd84911c68832e8a96e5014e7d9c87