### PR TITLE
Tune ball-in-play out probabilities

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -166,9 +166,13 @@ _DEFAULTS: Dict[str, Any] = {
     # Cap on final hit probability to prevent excessive offense
     "hitProbCap": 0.95,
     # Baseline probabilities for converting batted balls into outs
-    "groundOutProb": 0.0,
-    "lineOutProb": 0.0,
-    "flyOutProb": 0.0,
+    # MLB averages: ground balls ~24% hits (76% outs), line drives ~68% hits
+    # (32% outs), fly balls ~14% hits (86% outs).  These defaults keep the
+    # simplified simulation in a reasonable range when league benchmarks are
+    # unavailable.
+    "groundOutProb": 0.76,
+    "lineOutProb": 0.32,
+    "flyOutProb": 0.86,
     # Foul ball tuning -----------------------------------------------
     # Percentages for foul balls and balls put in play; strike-based rate is
     # derived from all pitches.

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -1819,9 +1819,6 @@ class GameSimulation:
             "line": self.config.get("lineOutProb", 0.0),
             "fly": self.config.get("flyOutProb", 0.0),
         }[self.last_batted_ball_type]
-        extra_out = float(self.config.get("ballInPlayOuts", 0.0))
-        if extra_out:
-            out_prob = 1 - (1 - out_prob) * (1 - extra_out)
         if self.rng.random() < out_prob:
             return 0, False
         roll_dist = self.physics.ball_roll_distance(

--- a/scripts/simulate_season_avg.py
+++ b/scripts/simulate_season_avg.py
@@ -212,6 +212,17 @@ def apply_league_benchmarks(
     pitches_per_pa = benchmarks["pitches_per_pa"]
     cfg.swingProbScale = round(4.0 / pitches_per_pa, 2) if pitches_per_pa else 1.0
 
+    gb_pct = benchmarks.get("bip_gb_pct", 0.0)
+    fb_pct = benchmarks.get("bip_fb_pct", 0.0)
+    ld_pct = benchmarks.get("bip_ld_pct", 0.0)
+    babip = benchmarks.get("babip", 0.0)
+    base_gb, base_ld, base_fb = 0.76, 0.32, 0.86
+    weighted_out = base_gb * gb_pct + base_fb * fb_pct + base_ld * ld_pct
+    scale = ((1 - babip) / weighted_out) if weighted_out else 1.0
+    cfg.groundOutProb = round(min(max(base_gb * scale, 0.0), 1.0), 3)
+    cfg.lineOutProb = round(min(max(base_ld * scale, 0.0), 1.0), 3)
+    cfg.flyOutProb = round(min(max(base_fb * scale, 0.0), 1.0), 3)
+
 
 def simulate_season_average(
     use_tqdm: bool = True,

--- a/tests/test_league_benchmarks.py
+++ b/tests/test_league_benchmarks.py
@@ -10,8 +10,14 @@ def test_apply_league_benchmarks():
         "babip": 0.291,
         "pitches_put_in_play_pct": 0.175,
         "pitches_per_pa": 3.86,
+        "bip_gb_pct": 0.44,
+        "bip_fb_pct": 0.35,
+        "bip_ld_pct": 0.21,
     }
     apply_league_benchmarks(cfg, benchmarks)
     assert cfg.hitProbBase == pytest.approx(0.291 / 0.95 * 1.25, abs=0.0001)
     assert cfg.ballInPlayPitchPct == 18
     assert cfg.swingProbScale == pytest.approx(1.04, abs=0.001)
+    assert cfg.groundOutProb == pytest.approx(0.767, abs=0.001)
+    assert cfg.lineOutProb == pytest.approx(0.323, abs=0.001)
+    assert cfg.flyOutProb == pytest.approx(0.868, abs=0.001)


### PR DESCRIPTION
## Summary
- default ground/line/fly out probabilities now mirror MLB rates
- derive ball-in-play out probabilities from league benchmarks
- remove `ballInPlayOuts` fallback; simulation uses explicit out probabilities

## Testing
- `pytest` *(fails: 67 failed, 251 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8b972cc0832e87eefb5b49cbed31