### PR TITLE
Use league BABIP directly for baseline hit probability

### DIFF
--- a/logic/sim_config.py
+++ b/logic/sim_config.py
@@ -15,7 +15,8 @@ def apply_league_benchmarks(
     """Configure ``cfg`` using league-wide benchmark rates."""
 
     hr_rate = cfg.hitHRProb / 100
-    cfg.hitProbBase = benchmarks["babip"] / (1 - hr_rate) * 1.25
+    # Base hit probability derived directly from league BABIP
+    cfg.hitProbBase = benchmarks["babip"] / (1 - hr_rate)
     cfg.ballInPlayPitchPct = int(round(benchmarks["pitches_put_in_play_pct"] * 100))
     pitches_per_pa = benchmarks["pitches_per_pa"]
     cfg.swingProbScale = round(4.0 / pitches_per_pa, 2) if pitches_per_pa else 1.0

--- a/scripts/simulate_season_avg.py
+++ b/scripts/simulate_season_avg.py
@@ -202,10 +202,8 @@ def apply_league_benchmarks(
     """
 
     hr_rate = cfg.hitHRProb / 100
-    # The raw league BABIP underestimates hits in our simplified physics model.
-    # Apply a modest boost to the baseline hit probability to better match
-    # observed MLB averages.
-    cfg.hitProbBase = benchmarks["babip"] / (1 - hr_rate) * 1.25
+    # Base hit probability derived directly from league BABIP
+    cfg.hitProbBase = benchmarks["babip"] / (1 - hr_rate)
     cfg.ballInPlayPitchPct = int(
         round(benchmarks["pitches_put_in_play_pct"] * 100)
     )

--- a/tests/test_league_benchmarks.py
+++ b/tests/test_league_benchmarks.py
@@ -15,7 +15,7 @@ def test_apply_league_benchmarks():
         "bip_ld_pct": 0.21,
     }
     apply_league_benchmarks(cfg, benchmarks)
-    assert cfg.hitProbBase == pytest.approx(0.291 / 0.95 * 1.25, abs=0.0001)
+    assert cfg.hitProbBase == pytest.approx(0.291 / 0.95, abs=0.0001)
     assert cfg.ballInPlayPitchPct == 18
     assert cfg.swingProbScale == pytest.approx(1.04, abs=0.001)
     assert cfg.groundOutProb == pytest.approx(0.767, abs=0.001)


### PR DESCRIPTION
## Summary
- derive `hitProbBase` directly from league BABIP in `apply_league_benchmarks`
- mirror the same calculation in `simulate_season_avg`
- update unit test expectations

## Testing
- `pytest` *(fails: 68 failed, 250 passed, 3 skipped)*
- `python scripts/simulate_season_avg.py --disable-tqdm --seed 42` *(fails: Team DRO does not have enough position players)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8cb8d328832ea119f73c4deb8f85