### PR TITLE
Update ball-in-play out tests

### DIFF
--- a/tests/test_ball_in_play_outs.py
+++ b/tests/test_ball_in_play_outs.py
@@ -1,0 +1,73 @@
+import random
+
+import pytest
+
+from logic.simulation import GameSimulation, TeamState
+from tests.test_physics import make_player, make_pitcher
+from tests.util.pbini_factory import make_cfg
+
+
+class ZeroRandom(random.Random):
+    """Deterministic random source returning 0 for all calls."""
+
+    def random(self):  # type: ignore[override]
+        return 0.0
+
+    def randint(self, a, b):  # type: ignore[override]
+        return a
+
+
+@pytest.mark.parametrize(
+    "out_key, rates",
+    [
+        (
+            "groundOutProb",
+            {
+                "groundBallBaseRate": 100,
+                "lineDriveBaseRate": 0,
+                "flyBallBaseRate": 0,
+            },
+        ),
+        (
+            "lineOutProb",
+            {
+                "groundBallBaseRate": 0,
+                "lineDriveBaseRate": 100,
+                "flyBallBaseRate": 0,
+            },
+        ),
+        (
+            "flyOutProb",
+            {
+                "groundBallBaseRate": 0,
+                "lineDriveBaseRate": 0,
+                "flyBallBaseRate": 100,
+            },
+        ),
+    ],
+)
+def test_ball_in_play_outs(out_key, rates):
+    cfg = make_cfg(
+        hitProbCap=1.0,
+        groundOutProb=0.0,
+        lineOutProb=0.0,
+        flyOutProb=0.0,
+        **rates,
+    )
+    setattr(cfg, out_key, 1.0)
+    home = TeamState(
+        lineup=[make_player("h1")],
+        bench=[],
+        pitchers=[make_pitcher("hp")],
+    )
+    away = TeamState(
+        lineup=[make_player("a1")],
+        bench=[],
+        pitchers=[make_pitcher("ap")],
+    )
+    rng = ZeroRandom()
+    sim = GameSimulation(home, away, cfg, rng)
+    outs = sim.play_at_bat(away, home)
+    assert outs == 1
+    assert all(base is None for base in away.bases)
+

--- a/tests/test_simulation_foul_balls.py
+++ b/tests/test_simulation_foul_balls.py
@@ -18,7 +18,6 @@ def _simulate(monkeypatch, foul_lambda=None, games: int = 20):
     base_states = {tid: build_default_game_state(tid) for tid in teams}
 
     cfg = PlayBalanceConfig.from_file(get_base_dir() / "logic" / "PBINI.txt")
-    cfg.ballInPlayOuts = 0
 
     rng = random.Random(42)
     total_pitches = 0


### PR DESCRIPTION
## Summary
- add comprehensive test for ball-in-play outs using ground/line/fly probabilities
- remove deprecated ballInPlayOuts override from foul ball simulation tests

## Testing
- `pytest` *(fails: Team DRO does not have enough position players, foul distribution mismatch, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8e1ee840832e860168565461d324