### PR TITLE
Boost simulated BABIP

### DIFF
--- a/logic/sim_config.py
+++ b/logic/sim_config.py
@@ -8,6 +8,9 @@ from typing import Tuple, Dict
 from .playbalance_config import PlayBalanceConfig
 from utils.path_utils import get_base_dir
 
+# Slight reduction in outs on balls in play to raise simulated BABIP
+_BABIP_OUT_ADJUST = 0.9
+
 
 def apply_league_benchmarks(
     cfg: PlayBalanceConfig, benchmarks: Dict[str, float]
@@ -31,6 +34,7 @@ def apply_league_benchmarks(
     base_gb, base_ld, base_fb = 0.76, 0.32, 0.86
     weighted_out = base_gb * gb_pct + base_fb * fb_pct + base_ld * ld_pct
     scale = ((1 - babip) / weighted_out) if weighted_out else 1.0
+    scale *= _BABIP_OUT_ADJUST
     cfg.groundOutProb = round(min(max(base_gb * scale, 0.0), 1.0), 3)
     cfg.lineOutProb = round(min(max(base_ld * scale, 0.0), 1.0), 3)
     cfg.flyOutProb = round(min(max(base_fb * scale, 0.0), 1.0), 3)

--- a/tests/test_league_benchmarks.py
+++ b/tests/test_league_benchmarks.py
@@ -18,6 +18,6 @@ def test_apply_league_benchmarks():
     assert cfg.hitProbBase == pytest.approx(0.291 / 0.95, abs=0.0001)
     assert cfg.ballInPlayPitchPct == 18
     assert cfg.swingProbScale == pytest.approx(1.04, abs=0.001)
-    assert cfg.groundOutProb == pytest.approx(0.767, abs=0.001)
-    assert cfg.lineOutProb == pytest.approx(0.323, abs=0.001)
-    assert cfg.flyOutProb == pytest.approx(0.868, abs=0.001)
+    assert cfg.groundOutProb == pytest.approx(0.69, abs=0.001)
+    assert cfg.lineOutProb == pytest.approx(0.291, abs=0.001)
+    assert cfg.flyOutProb == pytest.approx(0.781, abs=0.001)


### PR DESCRIPTION
## Summary
- Nudge league benchmark application to allow more hits on balls in play
- Adjust unit test expectations for updated out probabilities

## Testing
- `python -m pytest` (fails: 68 failed, 253 passed, 3 skipped)


------
https://chatgpt.com/codex/tasks/task_e_68bd939ee69c832ebfbfd13be4b32e2b