### PR TITLE
Adjust BABIP tuning

### DIFF
--- a/logic/sim_config.py
+++ b/logic/sim_config.py
@@ -8,8 +8,8 @@ from typing import Tuple, Dict
 from .playbalance_config import PlayBalanceConfig
 from utils.path_utils import get_base_dir
 
-# Slight reduction in outs on balls in play to raise simulated BABIP
-_BABIP_OUT_ADJUST = 0.9
+# Further reduction in outs on balls in play to raise simulated BABIP
+_BABIP_OUT_ADJUST = 0.8
 
 
 def apply_league_benchmarks(

--- a/tests/test_league_benchmarks.py
+++ b/tests/test_league_benchmarks.py
@@ -18,6 +18,6 @@ def test_apply_league_benchmarks():
     assert cfg.hitProbBase == pytest.approx(0.291 / 0.95, abs=0.0001)
     assert cfg.ballInPlayPitchPct == 18
     assert cfg.swingProbScale == pytest.approx(1.04, abs=0.001)
-    assert cfg.groundOutProb == pytest.approx(0.69, abs=0.001)
-    assert cfg.lineOutProb == pytest.approx(0.291, abs=0.001)
-    assert cfg.flyOutProb == pytest.approx(0.781, abs=0.001)
+    assert cfg.groundOutProb == pytest.approx(0.614, abs=0.001)
+    assert cfg.lineOutProb == pytest.approx(0.258, abs=0.001)
+    assert cfg.flyOutProb == pytest.approx(0.694, abs=0.001)


### PR DESCRIPTION
## Summary
- lower outs-on-balls-in-play adjustment to boost simulated BABIP
- update league benchmark tests for new BABIP tuning

## Testing
- `pytest` *(fails: AssertionError in multiple tests, 67 failed, 254 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd96652af0832eb780ccddfe681230