### PR TITLE
Reduce BABIP out adjust constant

### DIFF
--- a/logic/sim_config.py
+++ b/logic/sim_config.py
@@ -9,7 +9,7 @@ from .playbalance_config import PlayBalanceConfig
 from utils.path_utils import get_base_dir
 
 # Further reduction in outs on balls in play to raise simulated BABIP
-_BABIP_OUT_ADJUST = 0.8
+_BABIP_OUT_ADJUST = 0.5
 
 
 def apply_league_benchmarks(


### PR DESCRIPTION
## Summary
- Reduce `_BABIP_OUT_ADJUST` from 0.8 to 0.5 to adjust simulated BABIP calculation

## Testing
- `pytest` *(fails: 69 failed, 252 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bd97d29a68832ebe788b60af60a2d7