### PR TITLE
Add pitchers roster dialog with sortable columns

### DIFF
--- a/ui/owner_dashboard.py
+++ b/ui/owner_dashboard.py
@@ -31,6 +31,7 @@ from .team_page import TeamPage
 from .lineup_editor import LineupEditor
 from .pitching_editor import PitchingEditor
 from .position_players_dialog import PositionPlayersDialog
+from .pitchers_dialog import PitchersDialog
 from .reassign_players_dialog import ReassignPlayersDialog
 from .transactions_window import TransactionsWindow
 from .trade_dialog import TradeDialog
@@ -198,6 +199,9 @@ class OwnerDashboard(QMainWindow):
 
     def open_position_players_dialog(self) -> None:
         PositionPlayersDialog(self.players, self.roster).exec()
+
+    def open_pitchers_dialog(self) -> None:
+        PitchersDialog(self.players, self.roster).exec()
 
     def open_reassign_players_dialog(self) -> None:
         ReassignPlayersDialog(self.players, self.roster, self).exec()

--- a/ui/roster_page.py
+++ b/ui/roster_page.py
@@ -17,6 +17,10 @@ class RosterPage(QWidget):
         btn_pos.clicked.connect(dashboard.open_position_players_dialog)
         card.layout().addWidget(btn_pos)
 
+        btn_pitchers = QPushButton("Pitchers", objectName="Primary")
+        btn_pitchers.clicked.connect(dashboard.open_pitchers_dialog)
+        card.layout().addWidget(btn_pitchers)
+
         btn_pitch = QPushButton("Pitching Staff", objectName="Primary")
         btn_pitch.clicked.connect(dashboard.open_pitching_editor)
         card.layout().addWidget(btn_pitch)


### PR DESCRIPTION
## Summary
- allow sorting in position player roster table
- add pitchers roster dialog with sortable pitching columns
- link new Pitchers dialog from roster page and dashboard

## Testing
- `pytest` *(fails: assert 20 == 0, ValueError: Team DRO does not have enough..., ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bd98ee74e0832e8ed5aa07b121c59e