### PR TITLE
Increase balls-in-play hits via BABIP tuning

### DIFF
--- a/logic/sim_config.py
+++ b/logic/sim_config.py
@@ -8,8 +8,10 @@ from typing import Tuple, Dict
 from .playbalance_config import PlayBalanceConfig
 from utils.path_utils import get_base_dir
 
-# Further reduction in outs on balls in play to raise simulated BABIP
-_BABIP_OUT_ADJUST = 0.5
+# Greater reduction in outs on balls in play to roughly
+# triple the rate that balls in play become hits.
+# This substantially boosts the simulated BABIP.
+_BABIP_OUT_ADJUST = 0.17
 
 
 def apply_league_benchmarks(


### PR DESCRIPTION
## Summary
- reduce outs-on-ball-in-play scaling to boost BABIP

## Testing
- `pytest` *(fails: 69 failed, 252 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9d29acfc832ea27b4a403a654c1a