### PR TITLE
chore: moderate babip boost

### DIFF
--- a/logic/sim_config.py
+++ b/logic/sim_config.py
@@ -8,10 +8,10 @@ from typing import Tuple, Dict
 from .playbalance_config import PlayBalanceConfig
 from utils.path_utils import get_base_dir
 
-# Greater reduction in outs on balls in play to roughly
-# triple the rate that balls in play become hits.
-# This substantially boosts the simulated BABIP.
-_BABIP_OUT_ADJUST = 0.17
+# Reduction in outs on balls in play to boost the rate that balls in play
+# become hits.  Values below ``1`` decrease outs and raise the simulated
+# BABIP.  A lower number increases offense; raising the value dials it back.
+_BABIP_OUT_ADJUST = 0.25
 # Additional scaling factor applied to outs on balls in play.
 # Allow external configuration to raise or lower simulated BABIP
 # without modifying code directly.

--- a/tests/test_league_benchmarks.py
+++ b/tests/test_league_benchmarks.py
@@ -19,6 +19,6 @@ def test_apply_league_benchmarks():
     assert cfg.hitProbBase == pytest.approx(0.300 / 0.95, abs=0.0001)
     assert cfg.ballInPlayPitchPct == 18
     assert cfg.swingProbScale == pytest.approx(1.04, abs=0.001)
-    assert cfg.groundOutProb == pytest.approx(0.379, abs=0.001)
-    assert cfg.lineOutProb == pytest.approx(0.159, abs=0.001)
-    assert cfg.flyOutProb == pytest.approx(0.428, abs=0.001)
+    assert cfg.groundOutProb == pytest.approx(0.189, abs=0.001)
+    assert cfg.lineOutProb == pytest.approx(0.08, abs=0.001)
+    assert cfg.flyOutProb == pytest.approx(0.214, abs=0.001)


### PR DESCRIPTION
## Summary
- increase outs on balls in play to tone down inflated BABIP
- update league benchmark test expectations

## Testing
- `pytest -q` *(fails: 68 failed, 253 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf9036140832e86bbea6d915d9968