### PR TITLE
Correct BABIP scaling for league benchmarks

### DIFF
--- a/logic/sim_config.py
+++ b/logic/sim_config.py
@@ -8,10 +8,11 @@ from typing import Tuple, Dict
 from .playbalance_config import PlayBalanceConfig
 from utils.path_utils import get_base_dir
 
-# Reduction in outs on balls in play to boost the rate that balls in play
-# become hits.  Values below ``1`` decrease outs and raise the simulated
-# BABIP.  A lower number increases offense; raising the value dials it back.
-_BABIP_OUT_ADJUST = 0.25
+# Scaling factor applied to outs on balls in play to tune the simulated
+# batting average on balls in play (BABIP). Values below ``1`` decrease outs
+# and raise BABIP, values above ``1`` increase outs and lower BABIP. ``1.0``
+# uses the MLB averages without additional adjustment.
+_BABIP_OUT_ADJUST = 1.0
 # Additional scaling factor applied to outs on balls in play.
 # Allow external configuration to raise or lower simulated BABIP
 # without modifying code directly.

--- a/tests/test_league_benchmarks.py
+++ b/tests/test_league_benchmarks.py
@@ -19,6 +19,6 @@ def test_apply_league_benchmarks():
     assert cfg.hitProbBase == pytest.approx(0.300 / 0.95, abs=0.0001)
     assert cfg.ballInPlayPitchPct == 18
     assert cfg.swingProbScale == pytest.approx(1.04, abs=0.001)
-    assert cfg.groundOutProb == pytest.approx(0.189, abs=0.001)
-    assert cfg.lineOutProb == pytest.approx(0.08, abs=0.001)
-    assert cfg.flyOutProb == pytest.approx(0.214, abs=0.001)
+    assert cfg.groundOutProb == pytest.approx(0.757, abs=0.001)
+    assert cfg.lineOutProb == pytest.approx(0.319, abs=0.001)
+    assert cfg.flyOutProb == pytest.approx(0.857, abs=0.001)


### PR DESCRIPTION
## Summary
- ensure BABIP adjustments default to MLB averages by setting `_BABIP_OUT_ADJUST` to `1.0`
- update league benchmark tests to reflect neutral BABIP scaling

## Testing
- `pytest` *(fails: Team DRO does not have enough position players, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfa80d8d0832e938842d8ddbc7ee5