### PR TITLE
Fix slot sorting order for roster dialogs

### DIFF
--- a/ui/pitchers_dialog.py
+++ b/ui/pitchers_dialog.py
@@ -139,7 +139,8 @@ class RosterTable(QtWidgets.QTableWidget):
         self.setHorizontalHeaderLabels(COLUMNS)
         self.setRowCount(len(rows))
 
-        slot_order = {"ACT": 0, "AAA": 1, "LOW": 2}
+        # Custom slot order so sorting ascending yields LOW -> AAA -> ACT
+        slot_order = {"LOW": 0, "AAA": 1, "ACT": 2}
         for r, row in enumerate(rows):
             # The player ID is stored as a hidden element at the end of the row.
             *data, pid = row

--- a/ui/position_players_dialog.py
+++ b/ui/position_players_dialog.py
@@ -138,7 +138,8 @@ class RosterTable(QtWidgets.QTableWidget):
         self.setHorizontalHeaderLabels(COLUMNS)
         self.setRowCount(len(rows))
 
-        slot_order = {"ACT": 0, "AAA": 1, "LOW": 2}
+        # Custom slot order so sorting ascending yields LOW -> AAA -> ACT
+        slot_order = {"LOW": 0, "AAA": 1, "ACT": 2}
         for r, row in enumerate(rows):
             # The player ID is stored as a hidden element at the end of the row.
             *data, pid = row


### PR DESCRIPTION
## Summary
- Ensure slot column sorts LOW → AAA → ACT for ascending and ACT → AAA → LOW for descending in position player and pitcher dialogs

## Testing
- `pytest -q` *(fails: assert mismatches in simulation-related tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfe1fffb8832e8e8356eb2835bfc4