### PR TITLE
Refactor swing result RNG

### DIFF
--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -1287,7 +1287,6 @@ class GameSimulation:
                     batter_state,
                     pitcher_state,
                     pitch_speed=pitch_speed,
-                    rand=dec_r,
                     contact_quality=contact_quality,
                     is_third_strike=strikes >= 2,
                 )
@@ -1757,7 +1756,6 @@ class GameSimulation:
         pitcher_state: PitcherState,
         *,
         pitch_speed: float,
-        rand: float,
         contact_quality: float = 1.0,
         swing_type: str = "normal",
         is_third_strike: bool = False,
@@ -1774,7 +1772,7 @@ class GameSimulation:
         bat_speed = self.physics.bat_speed(
             batter.ph, swing_type=swing_type, pitch_speed=pitch_speed
         )
-        bat_speed, _ = self.physics.bat_impact(bat_speed, rand=rand)
+        bat_speed, _ = self.physics.bat_impact(bat_speed)
         # Calculate and store angles for potential future physics steps.
         swing_angle = self.physics.swing_angle(batter.gf, swing_type=swing_type)
         vert_base = abs(
@@ -1853,8 +1851,7 @@ class GameSimulation:
             if normal_depth > 0:
                 hit_prob *= cur_depth / normal_depth
 
-        hit_rand = self.rng.random()
-        if hit_rand >= hit_prob:
+        if self.rng.random() >= hit_prob:
             if is_third_strike:
                 self._last_swing_strikeout = True
                 self.logged_strikeouts += 1

--- a/tests/test_bip_type_distribution.py
+++ b/tests/test_bip_type_distribution.py
@@ -26,7 +26,7 @@ def test_bip_type_distribution():
     counts = {"ground": 0, "line": 0, "fly": 0}
     for _ in range(total):
         sim._swing_result(
-            batter, pitcher, defense, b_state, p_state, pitch_speed=90, rand=rng.random()
+            batter, pitcher, defense, b_state, p_state, pitch_speed=90
         )
         counts[sim.last_batted_ball_type] += 1
 

--- a/tests/test_ground_fly_distribution.py
+++ b/tests/test_ground_fly_distribution.py
@@ -26,7 +26,7 @@ def test_ground_air_distribution():
     ground = line = fly = 0
     for _ in range(total):
         sim._swing_result(
-            batter, pitcher, defense, b_state, p_state, pitch_speed=90, rand=rng.random()
+            batter, pitcher, defense, b_state, p_state, pitch_speed=90
         )
         if sim.last_batted_ball_type == "ground":
             ground += 1
@@ -62,7 +62,7 @@ def test_vert_angle_gf_pct_shifts_distribution():
         ground = air = 0
         for _ in range(1000):
             sim._swing_result(
-                batter, pitcher, defense, b_state, p_state, pitch_speed=90, rand=rng.random()
+                batter, pitcher, defense, b_state, p_state, pitch_speed=90
             )
             if sim.last_batted_ball_type == "ground":
                 ground += 1

--- a/tests/test_ground_fly_stats.py
+++ b/tests/test_ground_fly_stats.py
@@ -26,7 +26,7 @@ def test_swing_result_tracks_ground_line_fly(monkeypatch):
     monkeypatch.setattr(sim.physics, "ball_bounce", lambda *a, **k: (0.0, 0.0))
     b_state = BatterState(batter)
     p_state = PitcherState(pitcher)
-    sim._swing_result(batter, pitcher, defense, b_state, p_state, pitch_speed=90, rand=0.0)
+    sim._swing_result(batter, pitcher, defense, b_state, p_state, pitch_speed=90)
     assert (
         b_state.gb == 1
         and p_state.gb == 1
@@ -45,7 +45,7 @@ def test_swing_result_tracks_ground_line_fly(monkeypatch):
     b_state_line = BatterState(batter)
     p_state_line = PitcherState(pitcher)
     sim_line._swing_result(
-        batter, pitcher, defense, b_state_line, p_state_line, pitch_speed=90, rand=0.0
+        batter, pitcher, defense, b_state_line, p_state_line, pitch_speed=90
     )
     assert (
         b_state_line.ld == 1
@@ -63,7 +63,7 @@ def test_swing_result_tracks_ground_line_fly(monkeypatch):
     b_state_fly = BatterState(batter)
     p_state_fly = PitcherState(pitcher)
     sim_fly._swing_result(
-        batter, pitcher, defense, b_state_fly, p_state_fly, pitch_speed=90, rand=0.0
+        batter, pitcher, defense, b_state_fly, p_state_fly, pitch_speed=90
     )
     assert (
         b_state_fly.fb == 1

--- a/tests/test_line_drive_distribution.py
+++ b/tests/test_line_drive_distribution.py
@@ -21,7 +21,7 @@ def test_line_drive_distribution():
     line = 0
     for _ in range(total):
         sim._swing_result(
-            batter, pitcher, defense, b_state, p_state, pitch_speed=90, rand=rng.random()
+            batter, pitcher, defense, b_state, p_state, pitch_speed=90
         )
         if sim.last_batted_ball_type == "line":
             line += 1

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -161,24 +161,26 @@ def test_swing_result_respects_bat_speed():
     batter1 = make_player("b1")
     pitcher1 = make_pitcher("p1")
     defense1 = TeamState(lineup=[make_player("d1")], bench=[], pitchers=[pitcher1])
-    sim1 = GameSimulation(defense1, defense1, cfg_slow, MockRandom([0.9]))
+    sim1 = GameSimulation(defense1, defense1, cfg_slow, MockRandom([0.9, 0.0, 0.99]))
     b_state1 = BatterState(batter1)
     p_state1 = PitcherState(pitcher1)
     bases1, error1 = sim1._swing_result(
-        batter1, pitcher1, defense1, b_state1, p_state1, pitch_speed=50, rand=0.99
+        batter1, pitcher1, defense1, b_state1, p_state1, pitch_speed=50
     )
-    assert bases1 == 0 and not error1
+    assert bases1 is None and not error1
 
     # High bat speed -> batter reaches safely
     cfg_fast = make_cfg(swingSpeedBase=80, averagePitchSpeed=50)
     batter2 = make_player("b2")
     pitcher2 = make_pitcher("p2")
     defense2 = TeamState(lineup=[make_player("d2")], bench=[], pitchers=[pitcher2])
-    sim2 = GameSimulation(defense2, defense2, cfg_fast, MockRandom([0.9]))
+    sim2 = GameSimulation(
+        defense2, defense2, cfg_fast, MockRandom([0.9, 0.0, 0.0, 0.9, 0.99, 0.99])
+    )
     b_state2 = BatterState(batter2)
     p_state2 = PitcherState(pitcher2)
     bases2, error2 = sim2._swing_result(
-        batter2, pitcher2, defense2, b_state2, p_state2, pitch_speed=50, rand=0.0
+        batter2, pitcher2, defense2, b_state2, p_state2, pitch_speed=50
     )
     assert bases2 > 0
 
@@ -272,7 +274,7 @@ def test_power_hitter_can_hit_home_run(monkeypatch):
     b_state = BatterState(batter)
     p_state = PitcherState(pitcher)
     bases, error = sim._swing_result(
-        batter, pitcher, home, b_state, p_state, pitch_speed=50, rand=0.0
+        batter, pitcher, home, b_state, p_state, pitch_speed=50
     )
     assert bases == 4
     assert not error

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -880,7 +880,7 @@ def test_throw_error_results_in_roe(monkeypatch):
     monkeypatch.setattr(sim.fielding_ai, "resolve_throw", lambda *a, **k: (False, True))
     pitcher_state = PitcherState(pitcher)
     bases, error = sim._swing_result(
-        batter, pitcher, defense, batter_state, pitcher_state, pitch_speed=50, rand=0.0
+        batter, pitcher, defense, batter_state, pitcher_state, pitch_speed=50
     )
     assert error and bases == 1
     sim._advance_runners(offense, defense, batter_state, bases=bases, error=error)

--- a/tests/test_stadium_dimensions.py
+++ b/tests/test_stadium_dimensions.py
@@ -77,7 +77,7 @@ def test_custom_stadium_affects_hit_value(monkeypatch):
     b_state = BatterState(batter)
     p_state = PitcherState(pitcher)
     bases, _ = sim._swing_result(
-        batter, pitcher, home, b_state, p_state, pitch_speed=50, rand=0.0
+        batter, pitcher, home, b_state, p_state, pitch_speed=50
     )
     assert bases == 2
 
@@ -95,7 +95,7 @@ def test_custom_stadium_affects_hit_value(monkeypatch):
     b_state = BatterState(batter)
     p_state = PitcherState(pitcher)
     bases_small, _ = sim_small._swing_result(
-        batter, pitcher, home, b_state, p_state, pitch_speed=50, rand=0.0
+        batter, pitcher, home, b_state, p_state, pitch_speed=50
     )
     assert bases_small == 4
 


### PR DESCRIPTION
## Summary
- remove explicit rand parameter from `_swing_result`
- drive hit probability check from simulation RNG
- update tests for new interface

## Testing
- `pytest` *(fails: assert 20 == 0, ValueError: Team DRO does not have enough position players, ...)*
- `python - <<'PY'
import random
from logic.simulation import GameSimulation, TeamState, BatterState, PitcherState
from logic.playbalance_config import PlayBalanceConfig
from tests.test_physics import make_player, make_pitcher, MockRandom

cfg = PlayBalanceConfig.from_dict({})
batter = make_player('b', ph=50)
pitcher = make_pitcher('p')
defense = TeamState(lineup=[make_player('d')], bench=[], pitchers=[pitcher])
offense = TeamState(lineup=[batter], bench=[], pitchers=[make_pitcher('op')])

rng = MockRandom([0.9,0.0,0.99])
sim = GameSimulation(defense, offense, cfg, rng)
b_state=BatterState(batter)
p_state=PitcherState(pitcher)
print('low speed swing result:', sim._swing_result(batter,pitcher,defense,b_state,p_state,pitch_speed=50))

cfg2 = PlayBalanceConfig.from_dict({'swingSpeedBase':80})
sim2 = GameSimulation(defense, offense, cfg2, MockRandom([0.9,0.0,0.0,0.9,0.99,0.99]))
print('high speed swing result:', sim2._swing_result(batter,pitcher,defense,b_state,p_state,pitch_speed=50))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bdfe88b464832e846d2e86a54c2287