### PR TITLE
Tune hit-by-pitch frequency

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -193,7 +193,7 @@ _DEFAULTS: Dict[str, Any] = {
     # Baseline aggression for runners attempting extra bases
     "baserunningAggression": 0.45,
     # Hit by pitch avoidance ----------------------------------------
-    "hbpBatterStepOutChance": 60,
+    "hbpBatterStepOutChance": 18,
     # Pitcher AI ------------------------------------------------------
     "pitchRatVariationCount": 1,
     "pitchRatVariationFaces": 3,

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -1532,7 +1532,7 @@ class GameSimulation:
                     strikes += 1
                     pitcher_state.strikes_thrown += 1
                 else:
-                    hbp_dist = self.config.get("closeBallDist", 5) + 3
+                    hbp_dist = self.config.get("closeBallDist", 5) + self.rng.randint(1, 2)
                     if dist >= hbp_dist:
                         step_out_chance = (
                             self.config.get("hbpBatterStepOutChance", 0) / 100.0


### PR DESCRIPTION
## Summary
- Lower default batter step-out chance to encourage more HBPs
- Randomize HBP distance threshold so more close pitches can plunk hitters

## Testing
- `pytest` *(fails: 66 failed, 255 passed)*
- `python scripts/simulate_season_avg.py` *(fails: Team DRO does not have enough position players)*

------
https://chatgpt.com/codex/tasks/task_e_68be00b4857c832e82c639ac72b5ca5c