### PR TITLE
Tune baserunning aggression and expose config

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -189,7 +189,7 @@ _DEFAULTS: Dict[str, Any] = {
     # Probability that a ground ball with a force at second becomes a double play
     "doublePlayProb": 0.35,
     # Baseline aggression for runners attempting extra bases
-    "baserunningAggression": 0.45,
+    "baserunningAggression": 0.35,
     # Hit by pitch avoidance ----------------------------------------
     "hbpBatterStepOutChance": 18,
     "hbpBaseChance": 0.0,

--- a/logic/sim_config.py
+++ b/logic/sim_config.py
@@ -85,6 +85,7 @@ def apply_league_benchmarks(
 
 def load_tuned_playbalance_config(
     babip_scale_param: float | None = None,
+    baserunning_aggression: float | None = None,
 ) -> Tuple[PlayBalanceConfig, Dict[str, float]]:
     """Return a tuned :class:`PlayBalanceConfig` and MLB averages.
 
@@ -93,6 +94,9 @@ def load_tuned_playbalance_config(
     babip_scale_param:
         Optional scale applied to outs on balls in play. When ``None``
         (the default) the value is read from ``PlayBalanceConfig``.
+    baserunning_aggression:
+        Optional aggression factor for advancing on the basepaths. When
+        ``None`` the value from ``PlayBalanceConfig`` is used.
     """
 
     base = get_base_dir()
@@ -100,6 +104,8 @@ def load_tuned_playbalance_config(
 
     if babip_scale_param is not None:
         cfg.babip_scale = babip_scale_param
+    if baserunning_aggression is not None:
+        cfg.baserunningAggression = baserunning_aggression
 
     csv_path = base / "data" / "MLB_avg" / "mlb_avg_boxscore_2020_2024_both_teams.csv"
     with csv_path.open(newline="") as f:

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -2285,10 +2285,14 @@ class GameSimulation:
                 return True
             fa = catcher_fs.player.fa if catcher_fs else 0
             delay = self.physics.reaction_delay("C", fa)
-            tag_out = self.fielding_ai.should_tag_runner(delay, 10)
+            # Original logic assumes the tag play beats the runner; incorporate
+            # arm strength by reducing the success probability for stronger
+            # pitcher/catcher arms.
+            self.fielding_ai.should_tag_runner(delay, 10)
             tag_pct = self.config.get("stealSuccessTagOutPct", 20) / 100.0
-            safe_pct = self.config.get("stealSuccessSafePct", 60) / 100.0
-            success_prob = tag_pct if tag_out else safe_pct
+            catcher_arm = catcher_fs.player.arm if catcher_fs else 0
+            arm_factor = (catcher_arm + pitcher.arm) / 200.0
+            success_prob = tag_pct * (1 - arm_factor / 2)
             if self.rng.random() < success_prob:
                 ps_runner = offense.base_pitchers[base_idx]
                 offense.bases[base_idx] = None


### PR DESCRIPTION
## Summary
- Expose baserunning aggression through simulation configuration and CLI
- Factor pitcher and catcher arm strength into steal attempt success
- Lower default baserunning aggression for more conservative base running

## Testing
- `pytest` *(fails: Team DRO does not have enough position players and other assertion errors)*
- `python scripts/simulate_season.py --disable-tqdm --seed 123 --baserunning-aggression 0.35` *(fails: Team DRO does not have enough position players)*

------
https://chatgpt.com/codex/tasks/task_e_68be0a45d4c4832ebcf466175b3323ee