### PR TITLE
Tweak contact and ball-in-play out probabilities

### DIFF
--- a/logic/batter_ai.py
+++ b/logic/batter_ai.py
@@ -402,6 +402,8 @@ class BatterAI:
                 * disc_adj
             )
             contact = max(0.0, min(1.0, contact))
+            contact += self.config.get("contactProbBoost", 0.0)
+            contact = max(0.0, min(1.0, contact))
 
         self.last_decision = (swing, contact)
         return self.last_decision

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -1938,7 +1938,8 @@ class GameSimulation:
             if action == "no_attempt":
                 continue
             prob = self.fielding_ai.catch_probability(pos, fa, hang_time, action)
-            prob *= out_prob
+            prob *= out_prob * (1 + self.config.get("ballInPlayOuts", 0))
+            prob = min(prob, 1.0)
             if self.rng.random() < prob:
                 caught, error = self.fielding_ai.resolve_throw(pos, fa, hang_time)
                 if caught:


### PR DESCRIPTION
## Summary
- allow a flat contact probability boost after swing calculations
- scale fielder catch chances with `ballInPlayOuts`

## Testing
- `pytest` *(fails: Team DRO does not have enough position players, and other assertions)*
- `pytest tests/test_batter_ai.py` *(fails: expected contact values differ from config defaults)*

------
https://chatgpt.com/codex/tasks/task_e_68be0cd9e6bc832eba7264208392c1ce