### PR TITLE
Increase pitch identification base and add CLI override

### DIFF
--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -245,7 +245,7 @@ _DEFAULTS: Dict[str, Any] = {
     "lookBestType31CountAdjust": 15,
     "lookBestType32CountAdjust": 0,
     # Pitch identification and discipline ---------------------------------
-    "idRatingBase": 10,
+    "idRatingBase": 25,
     "idRatingCHPct": 40,
     "idRatingExpPct": 30,
     "idRatingPitchRatPct": 0,

--- a/scripts/simulate_season_avg.py
+++ b/scripts/simulate_season_avg.py
@@ -189,6 +189,7 @@ def _simulate_game_star(args: tuple[str, str, int]) -> Counter[str]:
 def simulate_season_average(
     use_tqdm: bool = True,
     seed: int | None = None,
+    id_rating_base: int | None = None,
 ) -> None:
     """Run a season simulation and print average box score values.
 
@@ -212,6 +213,8 @@ def simulate_season_average(
     base_states = {tid: build_default_game_state(tid) for tid in teams}
 
     cfg, mlb_averages = load_tuned_playbalance_config()
+    if id_rating_base is not None:
+        cfg.idRatingBase = id_rating_base
 
     # Prepare list of (home, away, seed) tuples for multiprocessing
     rng = random.Random(seed)
@@ -283,9 +286,17 @@ if __name__ == "__main__":
         default=None,
         help="Seed for deterministic runs (default: random)",
     )
+    parser.add_argument(
+        "--id-rating-base",
+        type=int,
+        default=None,
+        help="Override idRatingBase in PlayBalanceConfig",
+    )
     args = parser.parse_args()
 
     env_disable = os.getenv("DISABLE_TQDM", "").lower() in {"1", "true", "yes"}
     use_tqdm = not (args.disable_tqdm or env_disable)
     configure_perf_tuning()
-    simulate_season_average(use_tqdm=use_tqdm, seed=args.seed)
+    simulate_season_average(
+        use_tqdm=use_tqdm, seed=args.seed, id_rating_base=args.id_rating_base
+    )


### PR DESCRIPTION
## Summary
- raise `idRatingBase` default to 25 for stronger baseline pitch identification
- allow `scripts/simulate_season_avg.py` to override `idRatingBase` via `--id-rating-base`

## Testing
- `pytest` *(fails: 60 failed, 261 passed, 3 skipped)*
- `python scripts/simulate_season_avg.py --disable-tqdm --seed 42 --id-rating-base 25` *(fails: Team DRO does not have enough position players)*

------
https://chatgpt.com/codex/tasks/task_e_68be19211210832e80b2245ea7adb302