### PR TITLE
Add config to ease pitch recognition

### DIFF
--- a/logic/PBINI.txt
+++ b/logic/PBINI.txt
@@ -1368,6 +1368,7 @@ idRatingBase=10             ; Base identification chance
 idRatingCHPct=40            ; Percent multiplier on CH component of formula
 idRatingExpPct=30           ; Percent multiplier on EXP component of formula
 idRatingPitchRatPct=0       ; Percent multiplier on Pitch component of formula
+idRatingEaseScale=1.0       ; Multiplier on base identification chance
 idRatingTypeWeight=100      ; Percent multiplier on chance to ID pitch type
 idRatingLocWeight=100       ; Percent multiplier on chance to ID pitch location
 idRatingTimingWeight=100    ; Percent multiplier on chance to ID pitch timing

--- a/logic/batter_ai.py
+++ b/logic/batter_ai.py
@@ -32,6 +32,11 @@ Only a handful of options are supported:
     Base chance in percent to correctly identify the pitch type.  Higher values
     improve both swing decisions and contact quality.
 
+``idRatingEaseScale``
+    Multiplier applied to the base identification chance.  Values greater than
+    ``1.0`` make pitch recognition easier, reducing misreads and swinging
+    strikes.
+
 The :class:`BatterAI` exposes :func:`decide_swing` which returns a tuple of
 ``(swing, contact_quality)``.  ``swing`` determines whether the batter offers at
         the pitch.  ``contact_quality`` is a multiplier in the range ``0.0`` to
@@ -262,6 +267,7 @@ class BatterAI:
             + batter_exp * exp_pct
             + (100 - pitch_rating) / 2.0 * pitch_pct
         )
+        base_percent *= self.config.get("idRatingEaseScale", 1.0)
 
         # Choose timing curve based on base identification chance
         curves = [

--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -249,6 +249,7 @@ _DEFAULTS: Dict[str, Any] = {
     "idRatingCHPct": 40,
     "idRatingExpPct": 30,
     "idRatingPitchRatPct": 0,
+    "idRatingEaseScale": 1.0,
     "disciplineRatingBase": 0,
     "disciplineRatingCHPct": 150,
     "disciplineRatingExpPct": 100,

--- a/tests/test_batter_ai.py
+++ b/tests/test_batter_ai.py
@@ -235,6 +235,40 @@ def test_pitch_rating_makes_identification_harder():
     assert swing_h is True and contact_h > 0
 
 
+def test_recognition_ease_scale_improves_contact():
+    cfg = make_cfg(
+        idRatingBase=20,
+        idRatingCHPct=0,
+        idRatingExpPct=0,
+        idRatingPitchRatPct=0,
+    )
+    ai = BatterAI(cfg)
+    batter = make_player("b1", ch=0)
+    batter.exp = 0
+    pitcher = make_pitcher("p1")
+    swing_low, contact_low = ai.decide_swing(
+        batter,
+        pitcher,
+        pitch_type="fb",
+        balls=0,
+        strikes=0,
+        dist=0,
+        random_value=0.3,
+    )
+    cfg.idRatingEaseScale = 2.0
+    swing_high, contact_high = ai.decide_swing(
+        batter,
+        pitcher,
+        pitch_type="fb",
+        balls=0,
+        strikes=0,
+        dist=0,
+        random_value=0.3,
+    )
+    assert swing_low is True and swing_high is True
+    assert contact_high > contact_low
+
+
 def test_pitch_classification():
     cfg = load_config()
     ai = BatterAI(cfg)


### PR DESCRIPTION
## Summary
- add `idRatingEaseScale` to PlayBalance to scale pitch identification difficulty
- scale batter recognition chance by new config
- document new option in PBINI and add unit test for improved contact

## Testing
- `pytest` *(fails: Team DRO does not have enough position players, others)*
- `pytest tests/test_batter_ai.py::test_recognition_ease_scale_improves_contact -q`


------
https://chatgpt.com/codex/tasks/task_e_68be1d11d340832e91bf9ca8072df732