### PR TITLE
Add playbalance scaffolding and config loaders

### DIFF
--- a/playbalance/__init__.py
+++ b/playbalance/__init__.py
@@ -1,0 +1,13 @@
+"""Play-balance simulation package.
+
+This package hosts the next generation simulation engine derived from
+PBINI.txt configuration and MLB league benchmarks. The modules are
+organized for clarity and unit-testability.
+
+This is an early scaffolding of the full engine.
+"""
+
+from .config import PlayBalanceConfig, load_config  # noqa: F401
+from .benchmarks import load_benchmarks  # noqa: F401
+
+__all__ = ["PlayBalanceConfig", "load_config", "load_benchmarks"]

--- a/playbalance/benchmarks.py
+++ b/playbalance/benchmarks.py
@@ -1,0 +1,37 @@
+"""League benchmark ingestion utilities.
+
+The project contains a CSV of aggregated MLB statistics that serve as target
+values for tuning the simulation. This module loads the file into a
+``dict`` for convenient lookups.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+import csv
+
+
+BENCHMARK_CSV = Path("data/MLB_avg/mlb_league_benchmarks_2025_filled.csv")
+
+
+def load_benchmarks(path: str | Path = BENCHMARK_CSV) -> Dict[str, float]:
+    """Load benchmark metrics from ``path``.
+
+    Parameters
+    ----------
+    path:
+        CSV file with two columns: ``metric_key`` and ``value``.
+    """
+    path = Path(path)
+    benchmarks: Dict[str, float] = {}
+    with path.open(newline="") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            try:
+                benchmarks[row["metric_key"]] = float(row["value"])
+            except (KeyError, ValueError):
+                continue
+    return benchmarks
+
+
+__all__ = ["load_benchmarks"]

--- a/playbalance/config.py
+++ b/playbalance/config.py
@@ -1,0 +1,77 @@
+"""Configuration loader for the play-balance engine.
+
+The classic project stores simulation tuning values in a ``PBINI.txt`` file
+using an ``INI``-like format. This module provides a thin wrapper around the
+:func:`logic.pbini_loader.load_pbini` function and exposes the data through a
+simple dataclass. An optional JSON overrides file can supply adjustments
+without modifying the original configuration file.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+import json
+
+from logic.pbini_loader import load_pbini
+
+
+@dataclass
+class PlayBalanceConfig:
+    """Container for configuration values loaded from ``PBINI.txt``.
+
+    Attributes
+    ----------
+    sections:
+        Mapping of section names to dictionaries of key/value pairs.
+    """
+
+    sections: Dict[str, Dict[str, Any]]
+
+    def get(self, section: str, key: str, default: Any | None = None) -> Any:
+        """Return a configuration value.
+
+        Parameters
+        ----------
+        section:
+            Name of the section in the configuration file.
+        key:
+            The configuration key within ``section``.
+        default:
+            Value returned when the key is missing.
+        """
+        return self.sections.get(section, {}).get(key, default)
+
+
+def load_config(
+    pbini_path: str | Path = Path("logic/PBINI.txt"),
+    overrides_path: str | Path = Path("data/playbalance_overrides.json"),
+) -> PlayBalanceConfig:
+    """Load configuration from ``PBINI.txt`` and optional overrides.
+
+    Parameters
+    ----------
+    pbini_path:
+        Location of the ``PBINI.txt`` file.
+    overrides_path:
+        JSON file containing ``{"Section": {"Key": value}}`` overrides.
+    """
+    sections = load_pbini(pbini_path)
+
+    overrides_path = Path(overrides_path)
+    if overrides_path.exists():
+        with overrides_path.open() as fh:
+            overrides = json.load(fh)
+        for key, value in overrides.items():
+            if isinstance(value, dict):
+                section_dict = sections.setdefault(key, {})
+                section_dict.update(value)
+            else:
+                # Allow flat key/value overrides without specifying a section.
+                section_dict = sections.setdefault("", {})
+                section_dict[key] = value
+
+    return PlayBalanceConfig(sections)
+
+
+__all__ = ["PlayBalanceConfig", "load_config"]

--- a/playbalance/probability.py
+++ b/playbalance/probability.py
@@ -1,0 +1,41 @@
+"""Generic probability utilities for the play-balance engine."""
+from __future__ import annotations
+
+from random import random
+from typing import Dict, Sequence, TypeVar
+
+T = TypeVar("T")
+
+
+def roll(chance: float) -> bool:
+    """Return ``True`` with the given probability.
+
+    Parameters
+    ----------
+    chance:
+        Probability in the range ``0.0``-``1.0``.
+    """
+    return random() < chance
+
+
+def weighted_choice(weights: Dict[T, float] | Sequence[float], items: Sequence[T] | None = None) -> T:
+    """Select an item based on provided ``weights``.
+
+    ``weights`` can be a mapping of item→weight or a sequence of weights with a
+    parallel ``items`` sequence.
+    """
+    if isinstance(weights, dict):
+        items, weights = zip(*weights.items())
+    assert items is not None
+    total = sum(weights)
+    r = random() * total
+    upto = 0.0
+    for item, weight in zip(items, weights):
+        upto += weight
+        if upto >= r:
+            return item
+    # Fallback to last item (avoid mypy complaints)
+    return items[-1]
+
+
+__all__ = ["roll", "weighted_choice"]

--- a/playbalance/ratings.py
+++ b/playbalance/ratings.py
@@ -1,0 +1,25 @@
+"""Utility functions for computing combined player ratings."""
+from __future__ import annotations
+
+
+def combine_offense(contact: float, power: float) -> float:
+    """Return a naive offensive rating.
+
+    This placeholder simply averages contact and power values. Future
+    implementations will incorporate the extensive formulas defined in
+    ``PBINI.txt``.
+    """
+    return (contact + power) / 2.0
+
+
+def combine_slugging(power: float, discipline: float) -> float:
+    """Return a naive slugging rating placeholder."""
+    return (power * 0.7) + (discipline * 0.3)
+
+
+def combine_defense(fielding: float, arm: float) -> float:
+    """Return a naive defensive rating placeholder."""
+    return (fielding + arm) / 2.0
+
+
+__all__ = ["combine_offense", "combine_slugging", "combine_defense"]

--- a/playbalance/state.py
+++ b/playbalance/state.py
@@ -1,0 +1,26 @@
+"""Basic state containers used across the play-balance engine."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class PlayerState:
+    """Minimal representation of an active player."""
+
+    name: str
+    ratings: Dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
+class GameState:
+    """Simplified snapshot of a game's progress."""
+
+    inning: int = 1
+    outs: int = 0
+    home_score: int = 0
+    away_score: int = 0
+
+
+__all__ = ["PlayerState", "GameState"]

--- a/tests/test_playbalance_foundation.py
+++ b/tests/test_playbalance_foundation.py
@@ -1,0 +1,14 @@
+"""Basic tests for the playbalance scaffolding."""
+from playbalance import load_config, load_benchmarks
+
+
+def test_load_config_sections():
+    cfg = load_config()
+    # The PBINI file is a single "PlayBalance" section with many entries.
+    assert "PlayBalance" in cfg.sections
+    assert cfg.get("PlayBalance", "speedBase") is not None
+
+
+def test_load_benchmarks_has_values():
+    benchmarks = load_benchmarks()
+    assert benchmarks["pitches_put_in_play_pct"] == 0.175


### PR DESCRIPTION
## Summary
- scaffold new `playbalance` package for future simulation engine
- load PBINI config and optional JSON overrides via `PlayBalanceConfig`
- ingest MLB league benchmark metrics into dict lookups
- add probability and rating helper utilities plus basic state dataclasses
- create basic tests covering config and benchmark ingestion

## Testing
- `pytest` *(fails: Pitcher AI objective weights assertion error and others)*
- `pytest tests/test_playbalance_foundation.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68be39283f60832e9cee7e9e8f317af3