### PR TITLE
Document tasks for playbalance engine

### DIFF
--- a/playbalance/TASKS.md
+++ b/playbalance/TASKS.md
@@ -1,0 +1,70 @@
+# Play-Balance Simulation Engine Tasks
+
+This document tracks outstanding work required to build a new simulation engine
+that mirrors all formulas and decisions in `logic/PBINI.txt` and validates
+outputs against `data/MLB_avg/mlb_league_benchmarks_2025_filled.csv`.
+
+## 1. Foundation & Utilities
+- Implement full `PlayBalanceConfig` covering every PBINI entry and merge JSON overrides.
+- Provide benchmark loader with helpers for park/weather and league averages.
+- Flesh out `ratings`, `probability`, and `state` utilities to support later modules.
+
+## 2. Defensive Manager
+- Port bunt charging, runner holding, pickoff, pitch-out, pitch-around/IBB,
+  outfielder positioning, and fielder templates using PBINI formulas.
+- Expose APIs that return probabilities or fielding coordinates.
+- Unit tests verifying each calculation falls within expected ranges.
+
+## 3. Offensive Manager
+- Implement steal, hit-and-run, sacrifice bunt, and squeeze chance calculations
+  with situational and rating modifiers from PBINI.
+- Add decision utilities that determine whether tactics are attempted.
+- Unit tests ensuring probabilities react correctly to input variables.
+
+## 4. Substitutions
+- Add combined rating helpers (offense, slugging, defense) and percentage modifiers.
+- Implement pinch-hitting, pinch-running, defensive substitutions, double switches,
+  pitcher replacement, and warm-up/cool-down management with toast tracking.
+- Unit tests validating substitution decisions and pitcher fatigue handling.
+
+## 5. Physics
+- Translate environmental and player interaction formulas: friction, air resistance,
+  swing angle, bat speed, power zones, hit angle distributions, pitch fatigue,
+  warm-up, speed ranges, control-miss effects, and AI timing constants.
+- Unit tests for representative calculations (exit velocity, pitch movement, fatigue).
+
+## 6. Pitcher AI
+- Implement pitch rating variation, selection adjustments, objective weight tables
+  by count, and decision flow returning pitch type and location.
+- Unit tests verifying correct objective weighting and selection behaviour.
+
+## 7. Batter AI
+- Build strike-zone grid classes, look-for logic, pitch identification formula,
+  swing timing curves, swing adjustments, discipline and check-swing mechanics,
+  foul-ball and HBP avoidance per PBINI settings.
+- Unit tests ensuring discipline and identification outputs vary with ratings and count.
+
+## 8. Fielder Abilities
+- Implement reaction delay, catch chance, throw distance/speed/accuracy, wild pitch
+  catching, and chase distance calculations.
+- Unit tests validating catch/throw probabilities and distances against PBINI ranges.
+
+## 9. Baserunners
+- Implement long lead logic and pickoff scare reactions.
+- Unit tests verifying speed thresholds and behaviour around pickoffs.
+
+## 10. Engine Orchestrator
+- Compose modules into a pitch-by-pitch loop updating player and team state.
+- Provide `simulate_day`, `simulate_week`, `simulate_month`, and `simulate_season`
+  helpers with state persistence.
+- Integration tests simulating short seasons to validate stat accumulation.
+
+## 11. Benchmark-Based Integration Tests
+- Run simulated game batches and compare aggregated stats (K%, BB%, BABIP, SB rates,
+  etc.) to benchmark targets within tolerances.
+
+## 12. Documentation & Examples
+- Add module docstrings summarising formulas and config references.
+- Create README outlining how to run simulations and tests plus example scripts.
+- Document meanings of MLB benchmark metrics for contributor reference.
+

--- a/playbalance/__init__.py
+++ b/playbalance/__init__.py
@@ -1,0 +1,13 @@
+"""Play-balance simulation package.
+
+This package hosts the next generation simulation engine derived from
+PBINI.txt configuration and MLB league benchmarks. The modules are
+organized for clarity and unit-testability.
+
+This is an early scaffolding of the full engine.
+"""
+
+from .config import PlayBalanceConfig, load_config  # noqa: F401
+from .benchmarks import Benchmarks, load_benchmarks  # noqa: F401
+
+__all__ = ["PlayBalanceConfig", "load_config", "Benchmarks", "load_benchmarks"]

--- a/playbalance/benchmarks.py
+++ b/playbalance/benchmarks.py
@@ -1,0 +1,64 @@
+"""League benchmark ingestion utilities.
+
+The project contains a CSV of aggregated MLB statistics that serve as target
+values for tuning the simulation. This module loads the file into a
+``dict`` for convenient lookups.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict
+import csv
+
+
+BENCHMARK_CSV = Path("data/MLB_avg/mlb_league_benchmarks_2025_filled.csv")
+
+
+@dataclass
+class Benchmarks:
+    """Container for league-wide benchmark metrics."""
+
+    metrics: Dict[str, float]
+
+    def __getitem__(self, key: str) -> float:
+        return self.metrics[key]
+
+    def league_average(self, key: str, default: float | None = None) -> float | None:
+        """Return a league-average metric by ``key``."""
+        return self.metrics.get(key, default)
+
+    def park_factors(self) -> Dict[str, float]:
+        """Return park factor metrics."""
+        return {
+            "overall": self.metrics.get("park_factor_overall", 100.0),
+            "1b": self.metrics.get("park_factor_1b", 100.0),
+            "2b": self.metrics.get("park_factor_2b", 100.0),
+            "3b": self.metrics.get("park_factor_3b", 100.0),
+            "hr": self.metrics.get("park_factor_hr", 100.0),
+        }
+
+    def weather_means(self) -> Dict[str, float]:
+        """Return typical weather conditions used for tuning."""
+        return {
+            "temperature": self.metrics.get("weather_temp_mean", 70.0),
+            "wind_speed": self.metrics.get("wind_speed_mean", 0.0),
+        }
+
+
+def load_benchmarks(path: str | Path = BENCHMARK_CSV) -> Benchmarks:
+    """Load benchmark metrics from ``path`` into a :class:`Benchmarks` object."""
+
+    path = Path(path)
+    metrics: Dict[str, float] = {}
+    with path.open(newline="") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            try:
+                metrics[row["metric_key"]] = float(row["value"])
+            except (KeyError, ValueError):
+                continue
+    return Benchmarks(metrics)
+
+
+__all__ = ["Benchmarks", "load_benchmarks"]

--- a/playbalance/config.py
+++ b/playbalance/config.py
@@ -1,0 +1,113 @@
+"""Configuration loader for the play-balance engine.
+
+The classic project stores simulation tuning values in a ``PBINI.txt`` file
+using an ``INI``-like format. This module provides a thin wrapper around the
+:func:`logic.pbini_loader.load_pbini` function and exposes the data through a
+simple dataclass. An optional JSON overrides file can supply adjustments
+without modifying the original configuration file.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterator, Mapping
+import json
+
+from logic.pbini_loader import load_pbini
+
+
+@dataclass
+class SectionView(Mapping[str, Any]):
+    """Expose section values with both mapping and attribute access."""
+
+    values: Dict[str, Any]
+
+    def __getitem__(self, key: str) -> Any:  # Mapping requirement
+        return self.values[key]
+
+    def __iter__(self) -> Iterator[str]:  # Mapping requirement
+        return iter(self.values)
+
+    def __len__(self) -> int:  # Mapping requirement
+        return len(self.values)
+
+    def get(self, key: str, default: Any | None = None) -> Any:
+        return self.values.get(key, default)
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return self.values[name]
+        except KeyError as exc:  # pragma: no cover - attribute error path
+            raise AttributeError(name) from exc
+
+
+@dataclass
+class PlayBalanceConfig(Mapping[str, SectionView]):
+    """Container for configuration values loaded from ``PBINI.txt``.
+
+    The configuration may contain many sections. Each section is accessible as a
+    mapping or via attribute access::
+
+        cfg.PlayBalance.speedBase
+
+    JSON overrides can modify or extend values without editing the original
+    ``PBINI.txt``.
+    """
+
+    sections: Dict[str, SectionView]
+
+    # ``Mapping`` protocol methods
+    def __getitem__(self, section: str) -> SectionView:
+        return self.sections[section]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.sections)
+
+    def __len__(self) -> int:
+        return len(self.sections)
+
+    def get(self, section: str, key: str, default: Any | None = None) -> Any:
+        return self.sections.get(section, SectionView({})).get(key, default)
+
+    def __getattr__(self, name: str) -> SectionView:
+        try:
+            return self.sections[name]
+        except KeyError as exc:  # pragma: no cover - attribute error path
+            raise AttributeError(name) from exc
+
+
+def load_config(
+    pbini_path: str | Path = Path("logic/PBINI.txt"),
+    overrides_path: str | Path = Path("data/playbalance_overrides.json"),
+) -> PlayBalanceConfig:
+    """Load configuration from ``PBINI.txt`` and optional overrides.
+
+    Parameters
+    ----------
+    pbini_path:
+        Location of the ``PBINI.txt`` file.
+    overrides_path:
+        JSON file containing ``{"Section": {"Key": value}}`` overrides.
+    """
+    raw_sections = load_pbini(pbini_path)
+
+    overrides_path = Path(overrides_path)
+    if overrides_path.exists():
+        with overrides_path.open() as fh:
+            overrides = json.load(fh)
+        for key, value in overrides.items():
+            if isinstance(value, dict):
+                section_dict = raw_sections.setdefault(key, {})
+                section_dict.update(value)
+            else:
+                # Allow flat key/value overrides without specifying a section.
+                section_dict = raw_sections.setdefault("", {})
+                section_dict[key] = value
+
+    sections: Dict[str, SectionView] = {
+        name: SectionView(values) for name, values in raw_sections.items()
+    }
+    return PlayBalanceConfig(sections)
+
+
+__all__ = ["SectionView", "PlayBalanceConfig", "load_config"]

--- a/playbalance/probability.py
+++ b/playbalance/probability.py
@@ -1,0 +1,68 @@
+"""Generic probability utilities for the play-balance engine."""
+from __future__ import annotations
+
+from random import random, uniform
+from typing import Dict, Sequence, TypeVar
+
+T = TypeVar("T")
+
+
+def roll(chance: float) -> bool:
+    """Return ``True`` with the given probability.
+
+    Parameters
+    ----------
+    chance:
+        Probability in the range ``0.0``-``1.0``.
+    """
+    return random() < chance
+
+
+def rand_range(low: float, high: float) -> float:
+    """Return a random float between ``low`` and ``high``."""
+    return uniform(low, high)
+
+
+def clamp01(value: float) -> float:
+    """Clamp ``value`` into the inclusive ``0.0``-``1.0`` range."""
+    return max(0.0, min(1.0, value))
+
+
+def chance_from_rating(rating: float, max_rating: float = 100.0) -> float:
+    """Convert a ``rating`` into a probability value."""
+    return clamp01(rating / max_rating)
+
+
+def roll_rating(rating: float, max_rating: float = 100.0) -> bool:
+    """Roll against a rating scaled to ``max_rating``."""
+    return roll(chance_from_rating(rating, max_rating))
+
+
+def weighted_choice(weights: Dict[T, float] | Sequence[float], items: Sequence[T] | None = None) -> T:
+    """Select an item based on provided ``weights``.
+
+    ``weights`` can be a mapping of item→weight or a sequence of weights with a
+    parallel ``items`` sequence.
+    """
+    if isinstance(weights, dict):
+        items, weights = zip(*weights.items())
+    assert items is not None
+    total = sum(weights)
+    r = random() * total
+    upto = 0.0
+    for item, weight in zip(items, weights):
+        upto += weight
+        if upto >= r:
+            return item
+    # Fallback to last item (avoid mypy complaints)
+    return items[-1]
+
+
+__all__ = [
+    "roll",
+    "rand_range",
+    "clamp01",
+    "chance_from_rating",
+    "roll_rating",
+    "weighted_choice",
+]

--- a/playbalance/ratings.py
+++ b/playbalance/ratings.py
@@ -1,0 +1,42 @@
+"""Utility functions for computing and converting player ratings."""
+from __future__ import annotations
+
+
+def clamp_rating(value: float, minimum: float = 0.0, maximum: float = 100.0) -> float:
+    """Clamp a rating between ``minimum`` and ``maximum``."""
+    return max(minimum, min(maximum, value))
+
+
+def rating_to_pct(rating: float, maximum: float = 100.0) -> float:
+    """Convert a ``rating`` to a probability-like percentage (0-1)."""
+    rating = clamp_rating(rating, 0.0, maximum)
+    return rating / maximum
+
+
+def combine_offense(contact: float, power: float, discipline: float) -> float:
+    """Return a composite offensive rating.
+
+    Weights roughly follow common sabermetric intuition where contact and power
+    drive most of the offensive value while plate discipline provides a
+    supporting role.
+    """
+    return (contact * 0.4) + (power * 0.4) + (discipline * 0.2)
+
+
+def combine_slugging(power: float, discipline: float, contact: float) -> float:
+    """Return a composite slugging rating."""
+    return (power * 0.5) + (discipline * 0.2) + (contact * 0.3)
+
+
+def combine_defense(fielding: float, arm: float, range_rating: float) -> float:
+    """Return a composite defensive rating."""
+    return (fielding * 0.5) + (arm * 0.3) + (range_rating * 0.2)
+
+
+__all__ = [
+    "clamp_rating",
+    "rating_to_pct",
+    "combine_offense",
+    "combine_slugging",
+    "combine_defense",
+]

--- a/playbalance/state.py
+++ b/playbalance/state.py
@@ -1,0 +1,51 @@
+"""State containers used across the play-balance engine."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class PlayerState:
+    """Representation of a player's dynamic state."""
+
+    name: str
+    ratings: Dict[str, float] = field(default_factory=dict)
+    position: Optional[str] = None
+    fatigue: float = 0.0
+
+
+@dataclass
+class BaseState:
+    """Tracks which players occupy the bases."""
+
+    first: Optional[PlayerState] = None
+    second: Optional[PlayerState] = None
+    third: Optional[PlayerState] = None
+
+
+@dataclass
+class TeamState:
+    """Runtime information for a team participating in a game."""
+
+    name: str
+    lineup: List[PlayerState]
+    bench: List[PlayerState] = field(default_factory=list)
+    bullpen: List[PlayerState] = field(default_factory=list)
+    lineup_index: int = 0
+
+
+@dataclass
+class GameState:
+    """Simplified snapshot of a game's progress."""
+
+    inning: int = 1
+    half: str = "top"  # "top" or "bottom"
+    outs: int = 0
+    bases: BaseState = field(default_factory=BaseState)
+    score: Dict[str, int] = field(default_factory=lambda: {"home": 0, "away": 0})
+    teams: Dict[str, TeamState] = field(default_factory=dict)
+
+
+__all__ = ["PlayerState", "BaseState", "TeamState", "GameState"]
+

--- a/tests/test_playbalance_foundation.py
+++ b/tests/test_playbalance_foundation.py
@@ -1,0 +1,38 @@
+"""Basic tests for the playbalance scaffolding."""
+import random
+
+from playbalance import Benchmarks, PlayBalanceConfig, load_benchmarks, load_config
+from playbalance.probability import roll, weighted_choice
+from playbalance.ratings import rating_to_pct
+from playbalance.state import GameState, PlayerState, TeamState
+
+
+def test_load_config_sections(tmp_path):
+    override = tmp_path / "override.json"
+    override.write_text('{"PlayBalance": {"speedBase": 42}}')
+
+    cfg = load_config(overrides_path=override)
+    # The PBINI file uses a single "PlayBalance" section with many entries.
+    assert isinstance(cfg, PlayBalanceConfig)
+    assert cfg.PlayBalance.speedBase == 42
+    assert cfg.get("PlayBalance", "speedBase") == 42
+
+
+def test_benchmarks_helpers():
+    benchmarks = load_benchmarks()
+    assert isinstance(benchmarks, Benchmarks)
+    assert benchmarks.league_average("babip") == 0.291
+    assert benchmarks.park_factors()["overall"] == 100.0
+    assert benchmarks.weather_means()["temperature"] == 75.0
+
+
+def test_probability_and_state():
+    random.seed(0)
+    assert weighted_choice([0.0, 1.0], items=["a", "b"]) == "b"
+    assert roll(1.0) is True
+
+    player = PlayerState("Test", {"contact": 50})
+    team = TeamState("A", [player])
+    game = GameState(teams={"home": team, "away": team})
+    assert game.teams["home"].lineup[0].name == "Test"
+    assert rating_to_pct(50) == 0.5


### PR DESCRIPTION
## Summary
- expand PlayBalanceConfig with section objects, mapping interface, and JSON overrides
- add Benchmarks helper with league averages plus park and weather accessors
- provide richer ratings, probability, and state utilities for upcoming engine modules

## Testing
- `pytest tests/test_playbalance_foundation.py -vv`
- `pytest` *(fails: test_pitcher_ai and simulation suite)*

------
https://chatgpt.com/codex/tasks/task_e_68be39283f60832e9cee7e9e8f317af3