### PR TITLE
feat: expand playbalance foundation utilities

### DIFF
--- a/playbalance/__init__.py
+++ b/playbalance/__init__.py
@@ -8,6 +8,44 @@ This is an early scaffolding of the full engine.
 """
 
 from .config import PlayBalanceConfig, load_config  # noqa: F401
-from .benchmarks import load_benchmarks  # noqa: F401
+from .benchmarks import (  # noqa: F401
+    load_benchmarks,
+    park_factors,
+    weather_profile,
+    league_averages,
+)
+from .ratings import (  # noqa: F401
+    clamp_rating,
+    combine_offense,
+    combine_slugging,
+    combine_defense,
+)
+from .probability import (  # noqa: F401
+    clamp01,
+    roll,
+    weighted_choice,
+    prob_or,
+    prob_and,
+)
+from .state import PlayerState, BaseState, GameState  # noqa: F401
 
-__all__ = ["PlayBalanceConfig", "load_config", "load_benchmarks"]
+__all__ = [
+    "PlayBalanceConfig",
+    "load_config",
+    "load_benchmarks",
+    "park_factors",
+    "weather_profile",
+    "league_averages",
+    "clamp_rating",
+    "combine_offense",
+    "combine_slugging",
+    "combine_defense",
+    "clamp01",
+    "roll",
+    "weighted_choice",
+    "prob_or",
+    "prob_and",
+    "PlayerState",
+    "BaseState",
+    "GameState",
+]

--- a/playbalance/benchmarks.py
+++ b/playbalance/benchmarks.py
@@ -34,4 +34,42 @@ def load_benchmarks(path: str | Path = BENCHMARK_CSV) -> Dict[str, float]:
     return benchmarks
 
 
-__all__ = ["load_benchmarks"]
+def park_factors(benchmarks: Dict[str, float]) -> Dict[str, float]:
+    """Extract park factor metrics from ``benchmarks``.
+
+    Parameters
+    ----------
+    benchmarks:
+        Mapping of metric keys to values as returned by :func:`load_benchmarks`.
+    """
+
+    return {
+        "overall": benchmarks.get("park_factor_overall", 100.0),
+        "1b": benchmarks.get("park_factor_1b", 100.0),
+        "2b": benchmarks.get("park_factor_2b", 100.0),
+        "3b": benchmarks.get("park_factor_3b", 100.0),
+        "hr": benchmarks.get("park_factor_hr", 100.0),
+    }
+
+
+def weather_profile(benchmarks: Dict[str, float]) -> Dict[str, float]:
+    """Return typical weather conditions from the benchmark data."""
+
+    return {
+        "temperature": benchmarks.get("weather_temp_mean", 72.0),
+        "wind_speed": benchmarks.get("wind_speed_mean", 0.0),
+    }
+
+
+def league_averages(benchmarks: Dict[str, float]) -> Dict[str, float]:
+    """Return only metrics prefixed with ``avg_`` from ``benchmarks``."""
+
+    return {k[4:]: v for k, v in benchmarks.items() if k.startswith("avg_")}
+
+
+__all__ = [
+    "load_benchmarks",
+    "park_factors",
+    "weather_profile",
+    "league_averages",
+]

--- a/playbalance/config.py
+++ b/playbalance/config.py
@@ -1,11 +1,11 @@
 """Configuration loader for the play-balance engine.
 
-The classic project stores simulation tuning values in a ``PBINI.txt`` file
-using an ``INI``-like format. This module provides a thin wrapper around the
-:func:`logic.pbini_loader.load_pbini` function and exposes the data through a
-simple dataclass. An optional JSON overrides file can supply adjustments
-without modifying the original configuration file.
+This module reads tuning values from the project's ``PBINI.txt`` file.  The
+file follows a simple INI-style structure and all entries are exposed through
+the :class:`PlayBalanceConfig` dataclass.  An optional JSON file may supply
+override values without touching the original configuration.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -18,60 +18,66 @@ from logic.pbini_loader import load_pbini
 
 @dataclass
 class PlayBalanceConfig:
-    """Container for configuration values loaded from ``PBINI.txt``.
+    """Container for configuration sections loaded from ``PBINI.txt``.
 
-    Attributes
-    ----------
-    sections:
-        Mapping of section names to dictionaries of key/value pairs.
+    The underlying data structure mirrors the INI format: a mapping of section
+    names to dictionaries of key/value pairs.  Convenience attribute access is
+    provided for the ``PlayBalance`` section which contains the majority of
+    simulation tuning values.
     """
 
     sections: Dict[str, Dict[str, Any]]
 
-    def get(self, section: str, key: str, default: Any | None = None) -> Any:
-        """Return a configuration value.
+    def __post_init__(self) -> None:
+        """Expose ``PlayBalance`` values as direct attributes."""
 
-        Parameters
-        ----------
-        section:
-            Name of the section in the configuration file.
-        key:
-            The configuration key within ``section``.
-        default:
-            Value returned when the key is missing.
-        """
+        for key, value in self.sections.get("PlayBalance", {}).items():
+            setattr(self, key, value)
+
+    # ------------------------------------------------------------------
+    # Access helpers
+    # ------------------------------------------------------------------
+    def get(self, section: str, key: str, default: Any | None = None) -> Any:
+        """Return a configuration value from ``section`` or ``default``."""
+
         return self.sections.get(section, {}).get(key, default)
+
+    def __getattr__(self, item: str) -> Any:  # pragma: no cover - delegation
+        """Expose ``PlayBalance`` entries as attributes returning ``0`` when
+        missing.
+        """
+
+        return self.get("PlayBalance", item, 0)
 
 
 def load_config(
     pbini_path: str | Path = Path("logic/PBINI.txt"),
     overrides_path: str | Path = Path("data/playbalance_overrides.json"),
 ) -> PlayBalanceConfig:
-    """Load configuration from ``PBINI.txt`` and optional overrides.
+    """Load configuration from ``pbini_path`` and optional JSON overrides."""
 
-    Parameters
-    ----------
-    pbini_path:
-        Location of the ``PBINI.txt`` file.
-    overrides_path:
-        JSON file containing ``{"Section": {"Key": value}}`` overrides.
-    """
     sections = load_pbini(pbini_path)
 
     overrides_path = Path(overrides_path)
     if overrides_path.exists():
-        with overrides_path.open() as fh:
-            overrides = json.load(fh)
-        for key, value in overrides.items():
-            if isinstance(value, dict):
-                section_dict = sections.setdefault(key, {})
-                section_dict.update(value)
-            else:
-                # Allow flat key/value overrides without specifying a section.
-                section_dict = sections.setdefault("", {})
-                section_dict[key] = value
+        try:
+            with overrides_path.open("r", encoding="utf-8") as fh:
+                overrides = json.load(fh)
+        except json.JSONDecodeError:
+            overrides = {}
+
+        if isinstance(overrides, dict):
+            for sect, values in overrides.items():
+                if isinstance(values, dict):
+                    section_dict = sections.setdefault(sect, {})
+                    section_dict.update(values)
+                else:
+                    # Allow flat overrides applied to a default section.
+                    section_dict = sections.setdefault("", {})
+                    section_dict[sect] = values
 
     return PlayBalanceConfig(sections)
 
 
 __all__ = ["PlayBalanceConfig", "load_config"]
+

--- a/playbalance/probability.py
+++ b/playbalance/probability.py
@@ -7,23 +7,21 @@ from typing import Dict, Sequence, TypeVar
 T = TypeVar("T")
 
 
-def roll(chance: float) -> bool:
-    """Return ``True`` with the given probability.
+def clamp01(value: float) -> float:
+    """Clamp ``value`` to the inclusive ``0.0``–``1.0`` range."""
 
-    Parameters
-    ----------
-    chance:
-        Probability in the range ``0.0``-``1.0``.
-    """
-    return random() < chance
+    return max(0.0, min(1.0, value))
+
+
+def roll(chance: float) -> bool:
+    """Return ``True`` with the given probability."""
+
+    return random() < clamp01(chance)
 
 
 def weighted_choice(weights: Dict[T, float] | Sequence[float], items: Sequence[T] | None = None) -> T:
-    """Select an item based on provided ``weights``.
+    """Select an item based on provided ``weights``."""
 
-    ``weights`` can be a mapping of item→weight or a sequence of weights with a
-    parallel ``items`` sequence.
-    """
     if isinstance(weights, dict):
         items, weights = zip(*weights.items())
     assert items is not None
@@ -34,8 +32,25 @@ def weighted_choice(weights: Dict[T, float] | Sequence[float], items: Sequence[T
         upto += weight
         if upto >= r:
             return item
-    # Fallback to last item (avoid mypy complaints)
     return items[-1]
 
 
-__all__ = ["roll", "weighted_choice"]
+def prob_or(probabilities: Sequence[float]) -> float:
+    """Return probability that at least one of ``probabilities`` occurs."""
+
+    p = 0.0
+    for chance in probabilities:
+        p = p + chance - (p * chance)
+    return clamp01(p)
+
+
+def prob_and(probabilities: Sequence[float]) -> float:
+    """Return probability that all of ``probabilities`` occur."""
+
+    p = 1.0
+    for chance in probabilities:
+        p *= chance
+    return clamp01(p)
+
+
+__all__ = ["clamp01", "roll", "weighted_choice", "prob_or", "prob_and"]

--- a/playbalance/ratings.py
+++ b/playbalance/ratings.py
@@ -1,25 +1,43 @@
-"""Utility functions for computing combined player ratings."""
+"""Utility helpers for computing combined player ratings.
+
+These functions are intentionally light-weight; they provide reasonably
+documented behaviour without yet replicating all of the formulas contained in
+``PBINI.txt``.  The helpers will be expanded as later modules require more
+fidelity.
+"""
 from __future__ import annotations
 
 
-def combine_offense(contact: float, power: float) -> float:
-    """Return a naive offensive rating.
+def clamp_rating(value: float, minimum: float = 0.0, maximum: float = 100.0) -> float:
+    """Clamp ``value`` between ``minimum`` and ``maximum``."""
 
-    This placeholder simply averages contact and power values. Future
-    implementations will incorporate the extensive formulas defined in
-    ``PBINI.txt``.
-    """
-    return (contact + power) / 2.0
+    return max(minimum, min(maximum, value))
+
+
+def combine_offense(contact: float, power: float, discipline: float = 50.0) -> float:
+    """Return a blended offensive rating on a ``0``-``100`` scale."""
+
+    rating = (contact * 0.5) + (power * 0.4) + (discipline * 0.1)
+    return clamp_rating(rating)
 
 
 def combine_slugging(power: float, discipline: float) -> float:
-    """Return a naive slugging rating placeholder."""
-    return (power * 0.7) + (discipline * 0.3)
+    """Return a blended slugging rating on a ``0``-``100`` scale."""
+
+    rating = (power * 0.8) + (discipline * 0.2)
+    return clamp_rating(rating)
 
 
-def combine_defense(fielding: float, arm: float) -> float:
-    """Return a naive defensive rating placeholder."""
-    return (fielding + arm) / 2.0
+def combine_defense(fielding: float, arm: float, range_: float = 50.0) -> float:
+    """Return a blended defensive rating on a ``0``-``100`` scale."""
+
+    rating = (fielding * 0.6) + (arm * 0.3) + (range_ * 0.1)
+    return clamp_rating(rating)
 
 
-__all__ = ["combine_offense", "combine_slugging", "combine_defense"]
+__all__ = [
+    "clamp_rating",
+    "combine_offense",
+    "combine_slugging",
+    "combine_defense",
+]

--- a/playbalance/state.py
+++ b/playbalance/state.py
@@ -11,6 +11,29 @@ class PlayerState:
 
     name: str
     ratings: Dict[str, float] = field(default_factory=dict)
+    position: str | None = None
+
+
+@dataclass
+class BaseState:
+    """Tracks which bases currently have runners."""
+
+    first: bool = False
+    second: bool = False
+    third: bool = False
+
+    def clear(self) -> None:
+        """Remove all runners from the bases."""
+
+        self.first = self.second = self.third = False
+
+    def as_list(self) -> list[bool]:  # pragma: no cover - trivial
+        return [self.first, self.second, self.third]
+
+    def occupied(self) -> int:
+        """Return the number of occupied bases."""
+
+        return sum(self.as_list())
 
 
 @dataclass
@@ -18,9 +41,28 @@ class GameState:
     """Simplified snapshot of a game's progress."""
 
     inning: int = 1
+    top: bool = True
     outs: int = 0
     home_score: int = 0
     away_score: int = 0
+    bases: BaseState = field(default_factory=BaseState)
+
+    def advance_inning(self) -> None:
+        """Advance to the next half-inning and reset counters."""
+
+        self.top = not self.top
+        if self.top:
+            self.inning += 1
+        self.outs = 0
+        self.bases.clear()
+
+    def score_run(self, home_team: bool) -> None:
+        """Increment the score for the appropriate team."""
+
+        if home_team:
+            self.home_score += 1
+        else:
+            self.away_score += 1
 
 
-__all__ = ["PlayerState", "GameState"]
+__all__ = ["PlayerState", "BaseState", "GameState"]


### PR DESCRIPTION
## Summary
- add park, weather and league average helpers to benchmark loader
- flesh out ratings, probability and state helper modules
- expose foundational utilities through package interface
- surface PBINI PlayBalance values as direct attributes

## Testing
- `pytest` *(fails: 59 failed, 265 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68be43622400832e9075422aff8de078