### PR TITLE
Expand playbalance foundations with typed config and helpers

### DIFF
--- a/playbalance/__init__.py
+++ b/playbalance/__init__.py
@@ -26,6 +26,10 @@ from .probability import (  # noqa: F401
     weighted_choice,
     prob_or,
     prob_and,
+    pct_modifier,
+    adjustment,
+    dice_roll,
+    final_chance,
 )
 from .state import PlayerState, BaseState, GameState  # noqa: F401
 
@@ -45,6 +49,10 @@ __all__ = [
     "weighted_choice",
     "prob_or",
     "prob_and",
+    "pct_modifier",
+    "adjustment",
+    "dice_roll",
+    "final_chance",
     "PlayerState",
     "BaseState",
     "GameState",

--- a/playbalance/probability.py
+++ b/playbalance/probability.py
@@ -1,7 +1,7 @@
 """Generic probability utilities for the play-balance engine."""
 from __future__ import annotations
 
-from random import random
+from random import random, randint
 from typing import Dict, Sequence, TypeVar
 
 T = TypeVar("T")
@@ -53,4 +53,43 @@ def prob_and(probabilities: Sequence[float]) -> float:
     return clamp01(p)
 
 
-__all__ = ["clamp01", "roll", "weighted_choice", "prob_or", "prob_and"]
+def pct_modifier(chance: float, pct: float) -> float:
+    """Apply a percent modifier to ``chance`` as described in ``PBINI``."""
+
+    return (pct * chance) / 100.0
+
+
+def adjustment(chance: float, adjust: float) -> float:
+    """Add ``adjust`` to ``chance`` returning the new value."""
+
+    return chance + adjust
+
+
+def dice_roll(count: int, faces: int, base: int = 0) -> int:
+    """Return a roll of ``count`` dice with ``faces`` sides plus ``base``."""
+
+    return sum(randint(1, faces) for _ in range(count)) + base
+
+
+def final_chance(base: float, pct_mods: Sequence[float] = (), adjusts: Sequence[float] = ()) -> float:
+    """Combine ``base`` chance with percent modifiers and adjustments."""
+
+    chance = base
+    for pct in pct_mods:
+        chance = pct_modifier(chance, pct)
+    for adj in adjusts:
+        chance = adjustment(chance, adj)
+    return clamp01(chance)
+
+
+__all__ = [
+    "clamp01",
+    "roll",
+    "weighted_choice",
+    "prob_or",
+    "prob_and",
+    "pct_modifier",
+    "adjustment",
+    "dice_roll",
+    "final_chance",
+]

--- a/playbalance/ratings.py
+++ b/playbalance/ratings.py
@@ -7,6 +7,8 @@ fidelity.
 """
 from __future__ import annotations
 
+from typing import Any
+
 
 def clamp_rating(value: float, minimum: float = 0.0, maximum: float = 100.0) -> float:
     """Clamp ``value`` between ``minimum`` and ``maximum``."""
@@ -14,24 +16,69 @@ def clamp_rating(value: float, minimum: float = 0.0, maximum: float = 100.0) -> 
     return max(minimum, min(maximum, value))
 
 
-def combine_offense(contact: float, power: float, discipline: float = 50.0) -> float:
-    """Return a blended offensive rating on a ``0``-``100`` scale."""
+def _weights(cfg: Any | None, defaults: tuple[float, ...], names: tuple[str, ...]) -> tuple[float, ...]:
+    """Return tuple of weights pulling values from ``cfg`` when available."""
 
-    rating = (contact * 0.5) + (power * 0.4) + (discipline * 0.1)
+    if not cfg:
+        return defaults
+    return tuple(getattr(cfg, name, default) for name, default in zip(names, defaults))
+
+
+def combine_offense(
+    contact: float,
+    power: float,
+    discipline: float = 50.0,
+    cfg: Any | None = None,
+) -> float:
+    """Return a blended offensive rating on a ``0``-``100`` scale.
+
+    Weighting factors may be supplied in ``cfg`` using the attribute names
+    ``offenseContactWt``, ``offensePowerWt`` and ``offenseDisciplineWt``.
+    """
+
+    w_contact, w_power, w_disc = _weights(
+        cfg,
+        (0.5, 0.4, 0.1),
+        ("offenseContactWt", "offensePowerWt", "offenseDisciplineWt"),
+    )
+    rating = (contact * w_contact) + (power * w_power) + (discipline * w_disc)
     return clamp_rating(rating)
 
 
-def combine_slugging(power: float, discipline: float) -> float:
-    """Return a blended slugging rating on a ``0``-``100`` scale."""
+def combine_slugging(power: float, discipline: float, cfg: Any | None = None) -> float:
+    """Return a blended slugging rating on a ``0``-``100`` scale.
 
-    rating = (power * 0.8) + (discipline * 0.2)
+    Weighting attributes ``slugPowerWt`` and ``slugDisciplineWt`` may be present
+    on ``cfg`` to tweak the combination.
+    """
+
+    w_power, w_disc = _weights(
+        cfg,
+        (0.8, 0.2),
+        ("slugPowerWt", "slugDisciplineWt"),
+    )
+    rating = (power * w_power) + (discipline * w_disc)
     return clamp_rating(rating)
 
 
-def combine_defense(fielding: float, arm: float, range_: float = 50.0) -> float:
-    """Return a blended defensive rating on a ``0``-``100`` scale."""
+def combine_defense(
+    fielding: float,
+    arm: float,
+    range_: float = 50.0,
+    cfg: Any | None = None,
+) -> float:
+    """Return a blended defensive rating on a ``0``-``100`` scale.
 
-    rating = (fielding * 0.6) + (arm * 0.3) + (range_ * 0.1)
+    The configuration may provide weighting attributes ``defenseFieldingWt``,
+    ``defenseArmWt`` and ``defenseRangeWt``.
+    """
+
+    w_field, w_arm, w_range = _weights(
+        cfg,
+        (0.6, 0.3, 0.1),
+        ("defenseFieldingWt", "defenseArmWt", "defenseRangeWt"),
+    )
+    rating = (fielding * w_field) + (arm * w_arm) + (range_ * w_range)
     return clamp_rating(rating)
 
 

--- a/playbalance/state.py
+++ b/playbalance/state.py
@@ -7,11 +7,13 @@ from typing import Dict
 
 @dataclass
 class PlayerState:
-    """Minimal representation of an active player."""
+    """Representation of an active player with transient state."""
 
     name: str
     ratings: Dict[str, float] = field(default_factory=dict)
     position: str | None = None
+    fatigue: float = 0.0
+    stats: Dict[str, float] = field(default_factory=dict)
 
 
 @dataclass
@@ -46,6 +48,9 @@ class GameState:
     home_score: int = 0
     away_score: int = 0
     bases: BaseState = field(default_factory=BaseState)
+    pitch_count: int = 0
+    weather: Dict[str, float] = field(default_factory=dict)
+    park_factors: Dict[str, float] = field(default_factory=dict)
 
     def advance_inning(self) -> None:
         """Advance to the next half-inning and reset counters."""
@@ -63,6 +68,11 @@ class GameState:
             self.home_score += 1
         else:
             self.away_score += 1
+
+    def record_pitch(self) -> None:
+        """Increment the pitch counter."""
+
+        self.pitch_count += 1
 
 
 __all__ = ["PlayerState", "BaseState", "GameState"]

--- a/tests/test_playbalance_foundation.py
+++ b/tests/test_playbalance_foundation.py
@@ -1,5 +1,11 @@
 """Basic tests for the playbalance scaffolding."""
-from playbalance import load_config, load_benchmarks
+from playbalance import (
+    load_config,
+    load_benchmarks,
+    park_factors,
+    weather_profile,
+    league_averages,
+)
 
 
 def test_load_config_sections():
@@ -7,8 +13,17 @@ def test_load_config_sections():
     # The PBINI file is a single "PlayBalance" section with many entries.
     assert "PlayBalance" in cfg.sections
     assert cfg.get("PlayBalance", "speedBase") is not None
+    # Attribute access exposes the same value.
+    assert cfg.speedBase == cfg.sections["PlayBalance"].speedBase
 
 
 def test_load_benchmarks_has_values():
     benchmarks = load_benchmarks()
     assert benchmarks["pitches_put_in_play_pct"] == 0.175
+    # Helper slices of the benchmark data
+    pf = park_factors(benchmarks)
+    assert pf["overall"] == 100.0
+    weather = weather_profile(benchmarks)
+    assert weather["temperature"] == 75.0
+    avgs = league_averages(benchmarks)
+    assert avgs["exit_velocity"] == 88.5

--- a/tests/test_playbalance_utilities.py
+++ b/tests/test_playbalance_utilities.py
@@ -1,0 +1,48 @@
+from types import SimpleNamespace
+from random import seed
+
+from playbalance import (
+    combine_offense,
+    combine_slugging,
+    combine_defense,
+    pct_modifier,
+    adjustment,
+    dice_roll,
+    final_chance,
+    GameState,
+    PlayerState,
+)
+
+
+def test_rating_helpers_use_config():
+    cfg = SimpleNamespace(
+        offenseContactWt=1.0,
+        offensePowerWt=0.0,
+        offenseDisciplineWt=0.0,
+        slugPowerWt=0.5,
+        slugDisciplineWt=0.5,
+        defenseFieldingWt=0.7,
+        defenseArmWt=0.2,
+        defenseRangeWt=0.1,
+    )
+    assert combine_offense(80, 20, 40, cfg) == 80
+    assert combine_slugging(60, 40, cfg) == 50
+    assert combine_defense(70, 50, 40, cfg) == 63
+
+
+def test_probability_helpers():
+    assert pct_modifier(50, 50) == 25
+    assert adjustment(25, 10) == 35
+    seed(1)
+    assert dice_roll(2, 6) == 7
+    assert final_chance(0.5, pct_mods=[200], adjusts=[0.1]) == 1.0
+
+
+def test_state_tracking():
+    gs = GameState(weather={"temperature": 70.0}, park_factors={"overall": 100.0})
+    gs.record_pitch()
+    assert gs.pitch_count == 1
+    ps = PlayerState("Test")
+    ps.fatigue = 5.0
+    ps.stats["hr"] = 1
+    assert ps.stats["hr"] == 1


### PR DESCRIPTION
## Summary
- Map PBINI sections to dataclasses for strongly-typed PlayBalanceConfig
- Re-export benchmark helper slices for park, weather and league averages
- Extend ratings, probability and state utilities for richer PBINI-driven calculations
- Add tests covering config, benchmark helpers and utility modules

## Testing
- `pytest tests/test_playbalance_foundation.py tests/test_playbalance_utilities.py`
- `pytest` *(fails: 61 failed, 266 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0575fa58832e9beefa85f5e02f6f