### PR TITLE
Fix PlayBalance override merging

### DIFF
--- a/playbalance/config.py
+++ b/playbalance/config.py
@@ -74,13 +74,20 @@ def load_config(
             overrides = {}
 
         if isinstance(overrides, dict):
+            # Determine which section should receive flat overrides.  By
+            # convention the PBINI file uses a single "PlayBalance" section,
+            # but fall back to the first loaded section for flexibility.
+            default_section = "PlayBalance"
+            if default_section not in sections and sections:
+                default_section = next(iter(sections))
+
             for sect, values in overrides.items():
                 if isinstance(values, dict):
                     section_dict = sections.setdefault(sect, {})
                     section_dict.update(values)
                 else:
-                    # Allow flat overrides applied to a default section.
-                    section_dict = sections.setdefault("", {})
+                    # Allow flat overrides applied to the default section.
+                    section_dict = sections.setdefault(default_section, {})
                     section_dict[sect] = values
 
     return PlayBalanceConfig(sections)

--- a/tests/test_playbalance_foundation.py
+++ b/tests/test_playbalance_foundation.py
@@ -15,6 +15,8 @@ def test_load_config_sections():
     assert cfg.get("PlayBalance", "speedBase") is not None
     # Attribute access exposes the same value.
     assert cfg.speedBase == cfg.sections["PlayBalance"].speedBase
+    # JSON overrides should merge onto the PlayBalance section.
+    assert cfg.hbpBatterStepOutChance == 40
 
 
 def test_load_benchmarks_has_values():


### PR DESCRIPTION
## Summary
- ensure JSON overrides apply to PlayBalance section by default
- test that hbpBatterStepOutChance is overridden from JSON

## Testing
- `pytest`
- `pytest tests/test_playbalance_foundation.py tests/test_playbalance_utilities.py`

------
https://chatgpt.com/codex/tasks/task_e_68bf0a130fd8832ea4e153a9fe1afe5c