### PR TITLE
Implement offensive manager utilities

### DIFF
--- a/playbalance/__init__.py
+++ b/playbalance/__init__.py
@@ -45,6 +45,16 @@ from .defense import (  # noqa: F401
     outfielder_position,
     fielder_template,
 )
+from .offense import (  # noqa: F401
+    steal_chance,
+    maybe_attempt_steal,
+    hit_and_run_chance,
+    maybe_hit_and_run,
+    sacrifice_bunt_chance,
+    maybe_sacrifice_bunt,
+    squeeze_chance,
+    maybe_squeeze,
+)
 
 __all__ = [
     "PlayBalanceConfig",
@@ -77,6 +87,14 @@ __all__ = [
     "pitch_around_chance",
     "outfielder_position",
     "fielder_template",
+    "steal_chance",
+    "maybe_attempt_steal",
+    "hit_and_run_chance",
+    "maybe_hit_and_run",
+    "sacrifice_bunt_chance",
+    "maybe_sacrifice_bunt",
+    "squeeze_chance",
+    "maybe_squeeze",
     "PlayerState",
     "BaseState",
     "GameState",

--- a/playbalance/offense.py
+++ b/playbalance/offense.py
@@ -1,0 +1,199 @@
+"""Offensive manager calculations for the play-balance engine."""
+from __future__ import annotations
+
+from .config import PlayBalanceConfig
+from .probability import clamp01, roll
+
+
+def steal_chance(
+    cfg: PlayBalanceConfig,
+    *,
+    balls: int,
+    strikes: int,
+    runner_sp: float,
+    pitcher_hold: float,
+    pitcher_is_left: bool,
+    outs: int = 0,
+    runner_on: int = 1,
+    batter_ch: float = 0.0,
+    run_diff: int = 0,
+) -> float:
+    """Return probability that the runner attempts to steal a base.
+
+    The calculation mirrors a subset of the legacy PBINI formulas. Only the
+    most influential factors are considered which keeps the function compact yet
+    still allows unit tests to reason about monotonic behaviour.
+    """
+
+    count_key = f"stealChance{balls}{strikes}Count"
+    chance = getattr(cfg, count_key, 0) / 100.0
+
+    if runner_sp >= getattr(cfg, "stealChanceFastThresh", 0):
+        chance += getattr(cfg, "stealChanceFastAdjust", 0) / 100.0
+
+    if pitcher_hold <= getattr(cfg, "stealChanceMedHoldThresh", 0):
+        chance += getattr(cfg, "stealChanceMedHoldAdjust", 0) / 100.0
+
+    if not pitcher_is_left:
+        chance += getattr(cfg, "stealChancePitcherBackAdjust", 0) / 100.0
+
+    if (
+        outs == 1
+        and runner_on == 1
+        and batter_ch >= getattr(cfg, "stealChanceOnFirst01OutHighCHThresh", 101)
+    ):
+        chance += getattr(cfg, "stealChanceOnFirst01OutHighCHAdjust", 0) / 100.0
+
+    if run_diff <= getattr(cfg, "stealChanceWayBehindThresh", -999):
+        chance += getattr(cfg, "stealChanceWayBehindAdjust", 0) / 100.0
+
+    chance *= getattr(cfg, "offManStealChancePct", 100) / 100.0
+    return clamp01(chance)
+
+
+def maybe_attempt_steal(cfg: PlayBalanceConfig, **kwargs) -> bool:
+    """Return ``True`` when a steal should be attempted."""
+
+    return roll(steal_chance(cfg, **kwargs))
+
+
+def hit_and_run_chance(
+    cfg: PlayBalanceConfig,
+    *,
+    balls: int,
+    strikes: int,
+    runner_sp: float,
+    batter_ch: float,
+    batter_ph: float,
+    pitcher_wild: float = 50.0,
+    run_diff: int = 0,
+    runner_on_first: bool = True,
+) -> float:
+    """Return probability of calling a hit and run."""
+
+    if not runner_on_first:
+        return 0.0
+
+    count_key = f"hnrChance{balls}{strikes}Count"
+    chance = getattr(cfg, count_key, 0) / 100.0
+
+    if runner_sp >= getattr(cfg, "hnrChanceFastSPThresh", 0):
+        chance += getattr(cfg, "hnrChanceFastSPAdjust", 0) / 100.0
+
+    if batter_ch >= getattr(cfg, "hnrChanceHighCHThresh", 0):
+        chance += getattr(cfg, "hnrChanceHighCHAdjust", 0) / 100.0
+
+    if batter_ph <= getattr(cfg, "hnrChanceLowPHThresh", 100):
+        chance += getattr(cfg, "hnrChanceLowPHAdjust", 0) / 100.0
+
+    if pitcher_wild >= getattr(cfg, "hnrChancePitcherWildThresh", 101):
+        chance += getattr(cfg, "hnrChancePitcherWildAdjust", 0) / 100.0
+
+    if run_diff >= getattr(cfg, "hnrChanceAheadThresh", 999):
+        chance += getattr(cfg, "hnrChanceAheadAdjust", 0) / 100.0
+
+    chance *= getattr(cfg, "offManHNRChancePct", 100) / 100.0
+    return clamp01(chance)
+
+
+def maybe_hit_and_run(cfg: PlayBalanceConfig, **kwargs) -> bool:
+    """Return ``True`` when a hit and run should be attempted."""
+
+    return roll(hit_and_run_chance(cfg, **kwargs))
+
+
+def sacrifice_bunt_chance(
+    cfg: PlayBalanceConfig,
+    *,
+    batter_ch: float,
+    on_deck_ch: float,
+    on_deck_ph: float,
+    outs: int,
+    inning: int,
+    run_diff: int,
+    runner_on_first: bool,
+) -> float:
+    """Return probability of a sacrifice bunt."""
+
+    if not runner_on_first:
+        return 0.0
+
+    chance = getattr(cfg, "sacChanceBase", 0) / 100.0
+    if outs == 1:
+        chance += getattr(cfg, "sacChance1OutAdjust", 0) / 100.0
+
+    if inning >= 7 and abs(run_diff) <= 1:
+        chance += getattr(cfg, "sacChanceCLAdjust", 0) / 100.0
+        if (
+            outs == 1
+            and on_deck_ch >= getattr(cfg, "sacChanceCL1OutODHighCHThresh", 101)
+            and on_deck_ph >= getattr(cfg, "sacChanceCL1OutODHighPHThresh", 101)
+        ):
+            chance += getattr(cfg, "sacChanceCL1OutODHighAdjust", 0) / 100.0
+
+    chance *= getattr(cfg, "offManSacChancePct", 100) / 100.0
+    return clamp01(chance)
+
+
+def maybe_sacrifice_bunt(cfg: PlayBalanceConfig, **kwargs) -> bool:
+    """Return ``True`` when a sacrifice bunt should be attempted."""
+
+    return roll(sacrifice_bunt_chance(cfg, **kwargs))
+
+
+def squeeze_chance(
+    cfg: PlayBalanceConfig,
+    *,
+    kind: str,
+    balls: int,
+    strikes: int,
+    batter_ch: float,
+    batter_ph: float,
+    runner_on_third_sp: float,
+) -> float:
+    """Return probability for a squeeze play.
+
+    ``kind`` may be ``"suicide"`` or ``"safety"`` with the latter having a
+    reduced base probability.
+    """
+
+    count = balls + strikes
+    if count <= 1:
+        chance = getattr(cfg, "squeezeChanceLowCountAdjust", 0) / 100.0
+    elif count == 2:
+        chance = getattr(cfg, "squeezeChanceMedCountAdjust", 0) / 100.0
+    else:
+        chance = getattr(cfg, "squeezeChanceHighCountAdjust", 0) / 100.0
+
+    if runner_on_third_sp >= getattr(cfg, "squeezeChanceThirdFastSPThresh", 0):
+        chance += getattr(cfg, "squeezeChanceThirdFastAdjust", 0) / 100.0
+
+    max_ch = getattr(cfg, "squeezeChanceMaxCH", 100)
+    max_ph = getattr(cfg, "squeezeChanceMaxPH", 100)
+    chance *= min(batter_ch, max_ch) / max_ch
+    chance *= min(batter_ph, max_ph) / max_ph
+
+    chance *= getattr(cfg, "offManSqueezeChancePct", 100) / 100.0
+
+    if kind == "safety":
+        chance *= 0.5
+
+    return clamp01(chance)
+
+
+def maybe_squeeze(cfg: PlayBalanceConfig, *, kind: str, **kwargs) -> bool:
+    """Return ``True`` when a squeeze play should be attempted."""
+
+    return roll(squeeze_chance(cfg, kind=kind, **kwargs))
+
+
+__all__ = [
+    "steal_chance",
+    "maybe_attempt_steal",
+    "hit_and_run_chance",
+    "maybe_hit_and_run",
+    "sacrifice_bunt_chance",
+    "maybe_sacrifice_bunt",
+    "squeeze_chance",
+    "maybe_squeeze",
+]

--- a/tests/test_offense.py
+++ b/tests/test_offense.py
@@ -1,0 +1,156 @@
+from playbalance import (
+    load_config,
+    steal_chance,
+    maybe_attempt_steal,
+    hit_and_run_chance,
+    maybe_hit_and_run,
+    sacrifice_bunt_chance,
+    maybe_sacrifice_bunt,
+    squeeze_chance,
+    maybe_squeeze,
+)
+
+
+cfg = load_config()
+
+
+def test_steal_chance_increases_with_speed():
+    slow = steal_chance(
+        cfg,
+        balls=0,
+        strikes=0,
+        runner_sp=30,
+        pitcher_hold=50,
+        pitcher_is_left=True,
+    )
+    fast = steal_chance(
+        cfg,
+        balls=0,
+        strikes=0,
+        runner_sp=80,
+        pitcher_hold=50,
+        pitcher_is_left=True,
+    )
+    assert 0.0 <= slow <= fast <= 1.0
+
+
+def test_hit_and_run_requires_runner_on_first():
+    chance = hit_and_run_chance(
+        cfg,
+        balls=0,
+        strikes=0,
+        runner_sp=60,
+        batter_ch=60,
+        batter_ph=40,
+        runner_on_first=False,
+    )
+    assert chance == 0.0
+
+
+class DummyRoll:
+    def __init__(self, result: bool):
+        self.result = result
+
+    def __call__(self, chance: float) -> bool:  # pragma: no cover - simple stub
+        return self.result
+
+
+def test_decision_helpers(monkeypatch):
+    # Force a successful roll
+    monkeypatch.setattr("playbalance.offense.roll", DummyRoll(True))
+    assert maybe_attempt_steal(
+        cfg,
+        balls=0,
+        strikes=0,
+        runner_sp=80,
+        pitcher_hold=40,
+        pitcher_is_left=False,
+    )
+    assert maybe_hit_and_run(
+        cfg,
+        balls=0,
+        strikes=0,
+        runner_sp=80,
+        batter_ch=80,
+        batter_ph=20,
+    )
+    assert maybe_sacrifice_bunt(
+        cfg,
+        batter_ch=50,
+        on_deck_ch=60,
+        on_deck_ph=60,
+        outs=1,
+        inning=7,
+        run_diff=0,
+        runner_on_first=True,
+    )
+    assert maybe_squeeze(
+        cfg,
+        kind="suicide",
+        balls=0,
+        strikes=0,
+        batter_ch=50,
+        batter_ph=50,
+        runner_on_third_sp=60,
+    )
+    # Force a failed roll
+    monkeypatch.setattr("playbalance.offense.roll", DummyRoll(False))
+    assert not maybe_attempt_steal(
+        cfg,
+        balls=0,
+        strikes=0,
+        runner_sp=80,
+        pitcher_hold=40,
+        pitcher_is_left=False,
+    )
+    assert not maybe_hit_and_run(
+        cfg,
+        balls=0,
+        strikes=0,
+        runner_sp=80,
+        batter_ch=80,
+        batter_ph=20,
+    )
+    assert not maybe_sacrifice_bunt(
+        cfg,
+        batter_ch=50,
+        on_deck_ch=60,
+        on_deck_ph=60,
+        outs=1,
+        inning=7,
+        run_diff=0,
+        runner_on_first=True,
+    )
+    assert not maybe_squeeze(
+        cfg,
+        kind="suicide",
+        balls=0,
+        strikes=0,
+        batter_ch=50,
+        batter_ph=50,
+        runner_on_third_sp=60,
+    )
+
+
+def test_squeeze_safety_lower_than_suicide():
+    suicide = squeeze_chance(
+        cfg,
+        kind="suicide",
+        balls=0,
+        strikes=0,
+        batter_ch=60,
+        batter_ph=60,
+        runner_on_third_sp=60,
+    )
+    safety = squeeze_chance(
+        cfg,
+        kind="safety",
+        balls=0,
+        strikes=0,
+        batter_ch=60,
+        batter_ph=60,
+        runner_on_third_sp=60,
+    )
+    assert 0.0 <= safety <= suicide <= 1.0
+
+


### PR DESCRIPTION
## Summary
- add `playbalance.offense` with steal, hit-and-run, sacrifice bunt, and squeeze calculations plus decision helpers
- expose offensive utilities through the playbalance package
- test offensive probabilities and decision helpers

## Testing
- `pytest` *(fails: 59 failed, 280 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1bd8b960832e8e0ac503040505f9