### PR TITLE
Add offensive tactics tests

### DIFF
--- a/tests/test_offense.py
+++ b/tests/test_offense.py
@@ -154,3 +154,62 @@ def test_squeeze_safety_lower_than_suicide():
     assert 0.0 <= safety <= suicide <= 1.0
 
 
+def test_hit_and_run_chance_increases_with_modifiers():
+    """Fast runners and high-contact hitters raise H&R probability."""
+
+    low = hit_and_run_chance(
+        cfg,
+        balls=0,
+        strikes=0,
+        runner_sp=30,
+        batter_ch=50,
+        batter_ph=50,
+    )
+    high = hit_and_run_chance(
+        cfg,
+        balls=0,
+        strikes=0,
+        runner_sp=80,
+        batter_ch=80,
+        batter_ph=20,
+    )
+    assert 0.0 <= low <= high <= 1.0
+
+
+def test_sacrifice_bunt_situational_modifiers():
+    """Sacrifice chance depends on base state and game context."""
+
+    none = sacrifice_bunt_chance(
+        cfg,
+        batter_ch=50,
+        on_deck_ch=50,
+        on_deck_ph=50,
+        outs=0,
+        inning=1,
+        run_diff=0,
+        runner_on_first=False,
+    )
+    early = sacrifice_bunt_chance(
+        cfg,
+        batter_ch=50,
+        on_deck_ch=50,
+        on_deck_ph=50,
+        outs=0,
+        inning=1,
+        run_diff=2,
+        runner_on_first=True,
+    )
+    late = sacrifice_bunt_chance(
+        cfg,
+        batter_ch=50,
+        on_deck_ch=50,
+        on_deck_ph=50,
+        outs=0,
+        inning=8,
+        run_diff=0,
+        runner_on_first=True,
+    )
+    assert none == 0.0
+    assert 0.0 <= early <= late <= 1.0
+
+


### PR DESCRIPTION
## Summary
- Cover hit-and-run and sacrifice bunt chance modifiers
- Exercise decision helpers for offensive tactics

## Testing
- `pytest` *(fails: 60 failed, 281 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bf233197e8832e8837463b57ac3cb0