### PR TITLE
feat: add playbalance substitution utilities

### DIFF
--- a/playbalance/__init__.py
+++ b/playbalance/__init__.py
@@ -55,6 +55,16 @@ from .offense import (  # noqa: F401
     squeeze_chance,
     maybe_squeeze,
 )
+from .substitutions import (  # noqa: F401
+    Team,
+    pinch_hit,
+    pinch_run,
+    defensive_sub,
+    double_switch,
+    warm_reliever,
+    replace_pitcher,
+    cool_down,
+)
 
 __all__ = [
     "PlayBalanceConfig",
@@ -95,6 +105,14 @@ __all__ = [
     "maybe_sacrifice_bunt",
     "squeeze_chance",
     "maybe_squeeze",
+    "Team",
+    "pinch_hit",
+    "pinch_run",
+    "defensive_sub",
+    "double_switch",
+    "warm_reliever",
+    "replace_pitcher",
+    "cool_down",
     "PlayerState",
     "BaseState",
     "GameState",

--- a/playbalance/substitutions.py
+++ b/playbalance/substitutions.py
@@ -1,0 +1,168 @@
+"""Substitution utilities for the play-balance engine.
+
+These helpers implement simplified substitution logic including pinch hitting,
+bench running swaps, defensive replacements and basic bullpen management.
+The real simulation engine contains additional nuance; the goal here is to
+provide deterministic, easily-testable behaviour.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+from .ratings import combine_offense, combine_defense
+from .state import PlayerState
+
+
+@dataclass
+class Team:
+    """Minimal team container used by substitution helpers."""
+
+    lineup: List[PlayerState]
+    bench: List[PlayerState] = field(default_factory=list)
+    bullpen: List[PlayerState] = field(default_factory=list)
+    current_pitcher: PlayerState | None = None
+    warming: PlayerState | None = None
+    warmup_pitches: int = 0
+    toasted: List[PlayerState] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Rating helpers
+# ---------------------------------------------------------------------------
+
+def _off_rating(player: PlayerState, cfg) -> float:
+    r = player.ratings
+    return combine_offense(
+        r.get("contact", 50), r.get("power", 50), r.get("discipline", 50), cfg
+    )
+
+
+def _def_rating(player: PlayerState, cfg) -> float:
+    r = player.ratings
+    return combine_defense(
+        r.get("fielding", 50), r.get("arm", 50), r.get("range", 50), cfg
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bench substitutions
+# ---------------------------------------------------------------------------
+
+def pinch_hit(team: Team, index: int, cfg=None) -> PlayerState | None:
+    """Replace the lineup player at ``index`` with the best bench hitter."""
+
+    if not team.bench:
+        return None
+    current = team.lineup[index]
+    best = max(team.bench, key=lambda p: _off_rating(p, cfg))
+    if _off_rating(best, cfg) <= _off_rating(current, cfg):
+        return None
+    team.bench.remove(best)
+    team.bench.append(current)
+    team.lineup[index] = best
+    return best
+
+
+def pinch_run(team: Team, runner: PlayerState) -> PlayerState | None:
+    """Return a faster bench player to pinch run for ``runner`` if available."""
+
+    if not team.bench:
+        return None
+    best = max(team.bench, key=lambda p: p.ratings.get("speed", 0))
+    if best.ratings.get("speed", 0) <= runner.ratings.get("speed", 0):
+        return None
+    team.bench.remove(best)
+    team.bench.append(runner)
+    return best
+
+
+def defensive_sub(team: Team, index: int, cfg=None) -> PlayerState | None:
+    """Replace the lineup player at ``index`` with the best defender."""
+
+    if not team.bench:
+        return None
+    current = team.lineup[index]
+    best = max(team.bench, key=lambda p: _def_rating(p, cfg))
+    if _def_rating(best, cfg) <= _def_rating(current, cfg):
+        return None
+    team.bench.remove(best)
+    team.bench.append(current)
+    team.lineup[index] = best
+    return best
+
+
+def double_switch(
+    team: Team, bat_index: int, field_index: int, cfg=None
+) -> Tuple[PlayerState | None, PlayerState | None]:
+    """Perform a double switch returning the hitters inserted at each spot."""
+
+    hitter = pinch_hit(team, bat_index, cfg)
+    fielder = defensive_sub(team, field_index, cfg)
+    return hitter, fielder
+
+
+# ---------------------------------------------------------------------------
+# Pitcher management
+# ---------------------------------------------------------------------------
+
+def warm_reliever(
+    team: Team, reliever_index: int = 0, warmup_pitch_count: int = 8
+) -> bool:
+    """Increment warm-up pitches for the selected reliever.
+
+    Returns ``True`` once the reliever has thrown ``warmup_pitch_count`` pitches
+    and is considered ready.  Warming a new reliever toasts the previously
+    warmed pitcher if they were never used.
+    """
+
+    if reliever_index >= len(team.bullpen):
+        return False
+    reliever = team.bullpen[reliever_index]
+    if team.warming is not reliever:
+        if team.warming is not None:
+            team.toasted.append(team.warming)
+        team.warming = reliever
+        team.warmup_pitches = 0
+    team.warmup_pitches += 1
+    return team.warmup_pitches >= warmup_pitch_count
+
+
+def replace_pitcher(
+    team: Team, fatigue_thresh: float, warmup_pitch_count: int = 8
+) -> bool:
+    """Replace the current pitcher with the warmed reliever if needed."""
+
+    current = team.current_pitcher
+    if current is None or current.fatigue < fatigue_thresh:
+        return False
+    if team.warming is None or team.warmup_pitches < warmup_pitch_count:
+        return False
+    reliever = team.warming
+    team.bullpen.append(current)
+    team.bullpen.remove(reliever)
+    team.current_pitcher = reliever
+    team.warming = None
+    team.warmup_pitches = 0
+    return True
+
+
+def cool_down(team: Team) -> None:
+    """Mark any warmed reliever as toasted and reset warm-up state."""
+
+    if team.warming is not None:
+        team.toasted.append(team.warming)
+        team.warming = None
+        team.warmup_pitches = 0
+
+
+__all__ = [
+    "Team",
+    "pinch_hit",
+    "pinch_run",
+    "defensive_sub",
+    "double_switch",
+    "warm_reliever",
+    "replace_pitcher",
+    "cool_down",
+]

--- a/tests/test_substitutions_playbalance.py
+++ b/tests/test_substitutions_playbalance.py
@@ -1,0 +1,47 @@
+from playbalance.substitutions import (
+    Team,
+    pinch_hit,
+    pinch_run,
+    warm_reliever,
+    replace_pitcher,
+)
+from playbalance.state import PlayerState
+
+
+def make_player(name: str, fatigue: float = 0.0, **ratings: float) -> PlayerState:
+    return PlayerState(name=name, ratings=ratings, fatigue=fatigue)
+
+
+def test_pinch_hit_selects_best_bench_hitter():
+    starter = make_player("starter", contact=40, power=40)
+    bench1 = make_player("bench1", contact=50, power=50)
+    bench2 = make_player("bench2", contact=80, power=80)
+    team = Team(lineup=[starter], bench=[bench1, bench2])
+    chosen = pinch_hit(team, 0)
+    assert chosen is bench2
+    assert team.lineup[0] is bench2
+    assert starter in team.bench
+
+
+def test_pinch_run_prefers_fast_runner():
+    slow = make_player("slow", speed=40)
+    fast = make_player("fast", speed=80)
+    team = Team(lineup=[], bench=[fast])
+    chosen = pinch_run(team, slow)
+    assert chosen is fast
+    assert slow in team.bench
+
+
+def test_pitcher_warmup_and_replacement_with_toast():
+    current = make_player("sp", fatigue=80)
+    rp1 = make_player("rp1")
+    rp2 = make_player("rp2")
+    team = Team(lineup=[], bullpen=[rp1, rp2], current_pitcher=current)
+    # Warm first reliever but switch before usage, toasting the first
+    assert warm_reliever(team, 0, warmup_pitch_count=1)  # rp1 warmed
+    assert not team.toasted
+    assert warm_reliever(team, 1, warmup_pitch_count=1)  # rp1 toasted
+    assert rp1 in team.toasted
+    # Warm rp2 sufficiently and replace tired starter
+    assert replace_pitcher(team, fatigue_thresh=50, warmup_pitch_count=1)
+    assert team.current_pitcher is rp2


### PR DESCRIPTION
## Summary
- add substitution helpers for playbalance engine (pinch hit/run, defensive subs, double switch)
- implement bullpen warm-up and pitcher replacement logic with toast tracking
- cover substitution decisions and pitcher fatigue with new tests

## Testing
- `pytest`
- `pytest tests/test_substitutions_playbalance.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf3ad60304832e9f2423bbd963fcdd