### PR TITLE
Add basic physics helpers

### DIFF
--- a/playbalance/__init__.py
+++ b/playbalance/__init__.py
@@ -35,6 +35,11 @@ from .probability import (  # noqa: F401
     dice_roll,
     final_chance,
 )
+from .physics import (  # noqa: F401
+    exit_velocity,
+    pitch_movement,
+    pitcher_fatigue,
+)
 from .state import PlayerState, BaseState, GameState  # noqa: F401
 from .defense import (  # noqa: F401
     bunt_charge_chance,
@@ -90,6 +95,9 @@ __all__ = [
     "adjustment",
     "dice_roll",
     "final_chance",
+    "exit_velocity",
+    "pitch_movement",
+    "pitcher_fatigue",
     "bunt_charge_chance",
     "hold_runner_chance",
     "pickoff_chance",

--- a/playbalance/physics.py
+++ b/playbalance/physics.py
@@ -1,0 +1,99 @@
+"""Simplified physics helpers for the play-balance engine.
+
+Only a handful of calculations are implemented for now.  The goal is to
+expose deterministic formulas that unit tests can exercise while the rest of
+``PBINI.txt`` is gradually translated.  Functions here accept a
+:class:`PlayBalanceConfig` instance but fall back to sensible defaults when
+configuration entries are missing.
+"""
+from __future__ import annotations
+
+from random import Random
+from typing import Tuple
+
+from .config import PlayBalanceConfig
+
+
+def exit_velocity(
+    cfg: PlayBalanceConfig,
+    power: float,
+    *,
+    swing_type: str = "normal",
+) -> float:
+    """Return the exit velocity (mph) for a batted ball.
+
+    The calculation mirrors the simplified logic used in the legacy engine. A
+    base velocity is combined with a power based adjustment and finally scaled
+    depending on the swing type.
+    """
+
+    base = getattr(cfg, "exitVeloBase", 0.0)
+    ph_pct = getattr(cfg, "exitVeloPHPct", 0.0)
+    speed = base + ph_pct * power / 100.0
+
+    scale = {
+        "power": getattr(cfg, "exitVeloPowerPct", 100.0),
+        "contact": getattr(cfg, "exitVeloContactPct", 100.0),
+        "normal": getattr(cfg, "exitVeloNormalPct", 100.0),
+    }.get(swing_type, getattr(cfg, "exitVeloNormalPct", 100.0))
+
+    return speed * scale / 100.0
+
+
+def pitch_movement(
+    cfg: PlayBalanceConfig,
+    pitch_type: str,
+    *,
+    rand: float | None = None,
+    rng: Random | None = None,
+) -> Tuple[float, float]:
+    """Return horizontal and vertical break for ``pitch_type``.
+
+    Break values are derived from configuration entries
+    ``{pitch}BreakBaseWidth``/``Height`` and their ``Range`` counterparts.  A
+    single random value influences both axes which keeps the number of RNG calls
+    predictable for tests.
+    """
+
+    rng = rng or Random()
+    if rand is None:
+        rand = rng.random()
+
+    key = pitch_type.lower()
+    base_w = getattr(cfg, f"{key}BreakBaseWidth", 0.0)
+    base_h = getattr(cfg, f"{key}BreakBaseHeight", 0.0)
+    range_w = getattr(cfg, f"{key}BreakRangeWidth", 0.0)
+    range_h = getattr(cfg, f"{key}BreakRangeHeight", 0.0)
+
+    dx = base_w + rand * range_w
+    dy = base_h + rand * range_h
+    return dx, dy
+
+
+def pitcher_fatigue(
+    cfg: PlayBalanceConfig,
+    endurance: int,
+    pitches_thrown: int,
+) -> Tuple[int, str]:
+    """Return remaining pitches and fatigue state for a pitcher.
+
+    ``endurance`` represents the total number of pitches the pitcher can throw
+    when fully rested.  As pitches are thrown the remaining count decreases and
+    crosses the configured tired/exhausted thresholds.
+    """
+
+    remaining = max(0, endurance - pitches_thrown)
+    tired = getattr(cfg, "pitcherTiredThresh", 0)
+    exhausted = getattr(cfg, "pitcherExhaustedThresh", 0)
+
+    if remaining <= exhausted:
+        state = "exhausted"
+    elif remaining <= tired:
+        state = "tired"
+    else:
+        state = "fresh"
+
+    return remaining, state
+
+
+__all__ = ["exit_velocity", "pitch_movement", "pitcher_fatigue"]

--- a/tests/test_playbalance_physics.py
+++ b/tests/test_playbalance_physics.py
@@ -1,0 +1,37 @@
+from types import SimpleNamespace
+
+from playbalance import exit_velocity, pitch_movement, pitcher_fatigue
+
+
+def test_exit_velocity_scales_with_swing_type():
+    cfg = SimpleNamespace(
+        exitVeloBase=50.0,
+        exitVeloPHPct=1.0,
+        exitVeloPowerPct=120.0,
+        exitVeloNormalPct=100.0,
+        exitVeloContactPct=80.0,
+    )
+    power = exit_velocity(cfg, 60, swing_type="power")
+    contact = exit_velocity(cfg, 60, swing_type="contact")
+    assert power > contact
+
+
+def test_pitch_movement_uses_config_and_randomness():
+    cfg = SimpleNamespace(
+        fbBreakBaseWidth=1.0,
+        fbBreakBaseHeight=2.0,
+        fbBreakRangeWidth=2.0,
+        fbBreakRangeHeight=4.0,
+    )
+    dx, dy = pitch_movement(cfg, "fb", rand=0.5)
+    assert dx == 2.0 and dy == 4.0
+
+
+def test_pitcher_fatigue_thresholds():
+    cfg = SimpleNamespace(pitcherTiredThresh=20, pitcherExhaustedThresh=5)
+    remaining, state = pitcher_fatigue(cfg, 100, 0)
+    assert remaining == 100 and state == "fresh"
+    remaining, state = pitcher_fatigue(cfg, 100, 82)
+    assert remaining == 18 and state == "tired"
+    remaining, state = pitcher_fatigue(cfg, 100, 97)
+    assert remaining == 3 and state == "exhausted"


### PR DESCRIPTION
## Summary
- introduce simple exit velocity, pitch break, and fatigue calculations
- expose physics helpers through package API
- add unit tests covering swing scaling, movement and fatigue thresholds

## Testing
- `pytest tests/test_playbalance_physics.py`
- `pytest` *(fails: 60 failed, 287 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bf489c7714832e80df5453fd6b091a