### PR TITLE
Implement deterministic pitcher AI tests

### DIFF
--- a/tests/test_pitcher_ai.py
+++ b/tests/test_pitcher_ai.py
@@ -106,6 +106,9 @@ def test_pitch_objective_weights():
         pitchObj00CountEstablishWeight=1,
         pitchObj00CountOutsideWeight=2,
         pitchObj00CountBestWeight=3,
+        pitchObj00CountPlusWeight=0,
+        pitchObj00CountBestCenterWeight=0,
+        pitchObj00CountFastCenterWeight=0,
     )
     # Three calls using deterministic floats to select each objective based on
     # their relative weight: 1/6 establish, 2/6 outside, 3/6 best.
@@ -127,6 +130,7 @@ def test_pitch_variation_cached_per_game():
         pitchRatVariationFaces=6,
         pitchRatVariationBase=0,
         nonEstablishedPitchTypeAdjust=0,
+        primaryPitchTypeAdjust=0,
     )
     # Provide enough integers for two games. If variation was re-rolled every
     # pitch the RNG would be exhausted before the second game begins.


### PR DESCRIPTION
## Summary
- Clarify pitch objective weight test with explicit zeroing of unused weights
- Disable primary pitch adjustment in variation-caching test for deterministic behaviour

## Testing
- `pytest tests/test_pitcher_ai.py::test_pitch_objective_weights -q`
- `pytest tests/test_pitcher_ai.py::test_pitch_variation_cached_per_game -q`
- `pytest` *(fails: 57 failed, 304 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bf68b8e2f8832eac70b79f1c2c369f