### PR TITLE
feat: add weighted pitch objective selection

### DIFF
--- a/playbalance/pitcher_ai.py
+++ b/playbalance/pitcher_ai.py
@@ -115,9 +115,17 @@ def select_pitch(
     # Choose pitch with maximum adjusted rating.
     pitch = max(adjusted, key=adjusted.get)
 
-    # Determine objective weights and choose the strongest objective.
+    # Determine objective via weighted randomness using count specific weights.
     weights = objective_weights_by_count(cfg, balls, strikes)
-    objective = max(weights, key=weights.get)
+    total = sum(weights.values())
+    roll = rng.random() * total if total > 0 else 0.0
+    objective = "attack"
+    cumulative = 0.0
+    for obj, weight in weights.items():
+        cumulative += weight
+        if roll <= cumulative:
+            objective = obj
+            break
 
     location_map = {"attack": "zone", "chase": "edge", "waste": "ball"}
     location = location_map.get(objective, "zone")

--- a/tests/test_playbalance_pitcher_ai.py
+++ b/tests/test_playbalance_pitcher_ai.py
@@ -30,6 +30,14 @@ def test_pitch_rating_variation():
     assert low == pytest.approx(45.0)
 
 
+def test_pitch_rating_variation_clamped():
+    cfg = SimpleNamespace(pitchRatingVariationPct=10)
+    high = pitch_rating_variation(cfg, 100, ConstRandom(1.0))
+    low = pitch_rating_variation(cfg, 0, ConstRandom(0.0))
+    assert high == 100.0
+    assert low == 0.0
+
+
 def test_selection_adjustment_changes_choice():
     cfg = SimpleNamespace(pitchRatingVariationPct=0, pitchSelectionAdjust={"fb": 15})
     pitch_ratings = {"fb": 50, "sl": 60}
@@ -47,6 +55,18 @@ def test_objective_weights_determine_location():
     assert weights["chase"] == 2.0
     pitch, loc = select_pitch(cfg, {"fb": 50}, balls=0, strikes=0, rng=ConstRandom(0.5))
     assert pitch == "fb"
+    assert loc == "edge"
+
+
+def test_objective_weights_random_choice():
+    cfg = SimpleNamespace(
+        pitchRatingVariationPct=0,
+        pitchObjectiveWeights={"0-0": {"attack": 1.0, "chase": 1.0}},
+    )
+    pitch_ratings = {"fb": 50}
+    pitch, loc = select_pitch(cfg, pitch_ratings, balls=0, strikes=0, rng=ConstRandom(0.0))
+    assert loc == "zone"
+    pitch, loc = select_pitch(cfg, pitch_ratings, balls=0, strikes=0, rng=ConstRandom(0.9))
     assert loc == "edge"
 
 


### PR DESCRIPTION
## Summary
- apply weighted randomness to select pitch objectives
- expand pitcher AI tests for rating variation clamping and objective weighting behavior

## Testing
- `pytest tests/test_playbalance_pitcher_ai.py`
- `pytest` *(fails: tests/test_physics.py::test_pitch_aim_uses_control_box_dimensions[kn-kb-3-10] - AssertionError: assert 10 == 8)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6f657ad8832e85efccc946000c34