### PR TITLE
Add fielder ability calculations and tests

### DIFF
--- a/playbalance/__init__.py
+++ b/playbalance/__init__.py
@@ -60,6 +60,15 @@ from .defense import (  # noqa: F401
     outfielder_position,
     fielder_template,
 )
+from .fielder import (
+    reaction_delay,
+    catch_chance,
+    max_throw_distance,
+    throw_speed,
+    good_throw_chance,
+    wild_pitch_catch_chance,
+    should_chase_ball,
+)
 from .offense import (  # noqa: F401
     steal_chance,
     maybe_attempt_steal,
@@ -176,4 +185,12 @@ __all__ = [
     "PlayerState",
     "BaseState",
     "GameState",
+
+"reaction_delay",
+"catch_chance",
+"max_throw_distance",
+"throw_speed",
+"good_throw_chance",
+"wild_pitch_catch_chance",
+"should_chase_ball",
 ]

--- a/playbalance/fielder.py
+++ b/playbalance/fielder.py
@@ -1,0 +1,173 @@
+
+"""Fielder ability calculations for the play-balance engine.
+
+This module implements core formulas controlling how individual fielders
+react to batted balls, make catches and throws, and decide whether to chase
+balls.  The functions mirror the tuning parameters exposed in ``PBINI.txt``
+so unit tests can validate behaviour against the original game's logic.
+"""
+from __future__ import annotations
+
+from .config import PlayBalanceConfig
+from .probability import clamp01
+
+# ---------------------------------------------------------------------------
+# Helper utilities
+# ---------------------------------------------------------------------------
+
+POSITION_KEYS = {
+    "P": "Pitcher",
+    "C": "Catcher",
+    "1B": "FirstBase",
+    "2B": "SecondBase",
+    "3B": "ThirdBase",
+    "SS": "ShortStop",
+    "LF": "LeftField",
+    "CF": "CenterField",
+    "RF": "RightField",
+}
+
+
+def _pos_key(position: str) -> str:
+    """Return configuration suffix for ``position``."""
+
+    return POSITION_KEYS.get(position, position)
+
+
+# ---------------------------------------------------------------------------
+# Reaction time
+# ---------------------------------------------------------------------------
+
+def reaction_delay(cfg: PlayBalanceConfig, position: str, fa: float) -> float:
+    """Return the fielder reaction delay in seconds.
+
+    ``fa`` is the fielder's fielding ability rating.  Each position has a base
+    delay with a percentage modifier applied to the rating.  Higher fielding
+    ability generally reduces the delay (negative percentage).
+    """
+
+    key = _pos_key(position)
+    base = getattr(cfg, f"delayBase{key}", 0.0)
+    pct = getattr(cfg, f"delayFAPct{key}", 0.0)
+    return max(0.0, base + (pct * fa) / 100.0)
+
+
+# ---------------------------------------------------------------------------
+# Catch probability
+# ---------------------------------------------------------------------------
+
+def catch_chance(
+    cfg: PlayBalanceConfig,
+    position: str,
+    fa: float,
+    air_time: float,
+    distance: float,
+    diving: bool = False,
+    leaping: bool = False,
+) -> float:
+    """Return probability that the fielder makes the catch.
+
+    ``air_time`` is the time the ball spends in the air.  ``distance`` is the
+    distance from the fielder to the ball when the catch is attempted.  Short
+    throws within :attr:`automaticCatchDist` are always caught.
+    """
+
+    if distance <= getattr(cfg, "automaticCatchDist", 0.0):
+        return 1.0
+
+    chance = cfg.catchBaseChance + fa / max(cfg.catchFADiv, 1)
+    if diving:
+        chance += cfg.catchChanceDiving
+    if leaping:
+        chance += cfg.catchChanceLeaping
+    if air_time < 1.0:
+        chance += cfg.catchChanceLessThan1Sec
+        tenths = int((1.0 - air_time) * 10)
+        chance += tenths * cfg.catchChancePerTenth
+    adj_key = f"catchChance{_pos_key(position)}Adjust"
+    chance += getattr(cfg, adj_key, 0.0)
+    return clamp01(chance / 100.0)
+
+
+# ---------------------------------------------------------------------------
+# Throwing abilities
+# ---------------------------------------------------------------------------
+
+def max_throw_distance(cfg: PlayBalanceConfig, arm_strength: float) -> float:
+    """Return the maximum throwing distance in feet."""
+
+    return cfg.maxThrowDistBase + (cfg.maxThrowDistASPct * arm_strength) / 100.0
+
+
+def throw_speed(
+    cfg: PlayBalanceConfig,
+    distance: float,
+    arm_strength: float,
+    outfielder: bool = False,
+) -> float:
+    """Return the velocity in mph for a throw to ``distance`` feet."""
+
+    key = "OF" if outfielder else "IF"
+    base = getattr(cfg, f"throwSpeed{key}Base", 0.0)
+    dist_pct = getattr(cfg, f"throwSpeed{key}DistPct", 0.0)
+    as_pct = getattr(cfg, f"throwSpeed{key}ASPct", 0.0)
+    max_speed = getattr(cfg, f"throwSpeed{key}Max", 0.0)
+    speed = base + (dist_pct * distance) / 100.0 + (as_pct * arm_strength) / 100.0
+    return min(speed, max_speed)
+
+
+def good_throw_chance(
+    cfg: PlayBalanceConfig, position: str, fa: float
+) -> float:
+    """Return probability of making an accurate throw."""
+
+    chance = cfg.goodThrowBase + (cfg.goodThrowFAPct * fa) / 100.0
+    adj_key = f"goodThrowChance{_pos_key(position)}"
+    chance += getattr(cfg, adj_key, 0.0)
+    return clamp01(chance / 100.0)
+
+
+# ---------------------------------------------------------------------------
+# Special catches and chase decisions
+# ---------------------------------------------------------------------------
+
+def wild_pitch_catch_chance(
+    cfg: PlayBalanceConfig,
+    fa: float,
+    cross_body: bool = False,
+    high: bool = False,
+) -> float:
+    """Return probability the catcher snags a wild pitch."""
+
+    chance = cfg.wildCatchChanceBase + (cfg.wildCatchChanceFAPct * fa) / 100.0
+    if cross_body:
+        chance += cfg.wildCatchChanceOppMod
+    if high:
+        chance += cfg.wildCatchChanceHighMod
+    return clamp01(chance / 100.0)
+
+
+def should_chase_ball(cfg: PlayBalanceConfig, position: str, projected_dist: float) -> bool:
+    """Return whether the fielder should chase a batted ball.
+
+    ``projected_dist`` represents the distance to the ball when the fielder
+    would reach it (for infielders and pitchers) or the distance from home
+    plate at the interception point (for outfielders).
+    """
+
+    if position in {"LF", "CF", "RF"}:
+        return projected_dist >= cfg.outfieldMinChaseDist
+    if position == "P":
+        return projected_dist <= cfg.pitcherMaxChaseDist
+    return projected_dist <= cfg.infieldMaxChaseDist
+
+
+__all__ = [
+    "reaction_delay",
+    "catch_chance",
+    "max_throw_distance",
+    "throw_speed",
+    "good_throw_chance",
+    "wild_pitch_catch_chance",
+    "should_chase_ball",
+]

--- a/tests/test_playbalance_fielder_abilities.py
+++ b/tests/test_playbalance_fielder_abilities.py
@@ -1,0 +1,84 @@
+from types import SimpleNamespace
+import pytest
+
+from playbalance import (
+    reaction_delay,
+    catch_chance,
+    max_throw_distance,
+    throw_speed,
+    good_throw_chance,
+    wild_pitch_catch_chance,
+    should_chase_ball,
+)
+
+
+def make_cfg(**kwargs):
+    return SimpleNamespace(**kwargs)
+
+
+def test_reaction_delay():
+    cfg = make_cfg(delayBaseCatcher=12, delayFAPctCatcher=-4)
+    assert reaction_delay(cfg, "C", 50) == 10.0
+
+
+def test_catch_chance_adjustments():
+    cfg = make_cfg(
+        catchBaseChance=90,
+        catchFADiv=7,
+        catchChanceDiving=-40,
+        catchChanceLeaping=-15,
+        catchChanceLessThan1Sec=-10,
+        catchChancePerTenth=-1,
+        catchChanceThirdBaseAdjust=0,
+        automaticCatchDist=15,
+    )
+    # Diving 3B with 0.5s hang time and 20ft distance
+    prob = catch_chance(cfg, "3B", fa=50, air_time=0.5, distance=20, diving=True)
+    assert prob == pytest.approx(0.4214286, rel=1e-6)
+
+
+def test_throwing_metrics():
+    cfg = make_cfg(
+        maxThrowDistBase=190,
+        maxThrowDistASPct=100,
+        throwSpeedIFBase=52,
+        throwSpeedIFDistPct=3,
+        throwSpeedIFASPct=0,
+        throwSpeedIFMax=92,
+        throwSpeedOFBase=52,
+        throwSpeedOFDistPct=3,
+        throwSpeedOFASPct=0,
+        throwSpeedOFMax=92,
+    )
+    assert max_throw_distance(cfg, 50) == 240
+    assert throw_speed(cfg, 150, 60) == pytest.approx(56.5)
+    # Large distance capped at max speed for outfielders
+    assert throw_speed(cfg, 2000, 60, outfielder=True) == 92
+
+
+def test_throw_accuracy_and_wild_pitch():
+    cfg = make_cfg(
+        goodThrowBase=63,
+        goodThrowFAPct=40,
+        goodThrowChanceCenterField=-10,
+        wildCatchChanceBase=85,
+        wildCatchChanceFAPct=50,
+        wildCatchChanceOppMod=-10,
+        wildCatchChanceHighMod=-5,
+    )
+    # CF accuracy
+    assert good_throw_chance(cfg, "CF", 80) == pytest.approx(0.85)
+    # Wild pitch catch chance with cross-body adjustment
+    assert wild_pitch_catch_chance(cfg, 20, cross_body=True) == pytest.approx(0.85)
+
+
+def test_chase_decisions():
+    cfg = make_cfg(
+        infieldMaxChaseDist=50,
+        pitcherMaxChaseDist=90,
+        outfieldMinChaseDist=150,
+    )
+    assert should_chase_ball(cfg, "SS", 40) is True
+    assert should_chase_ball(cfg, "P", 100) is False
+    assert should_chase_ball(cfg, "CF", 120) is False
+    assert should_chase_ball(cfg, "LF", 200) is True


### PR DESCRIPTION
## Summary
- implement fielder ability formulas for reaction delay, catching, throwing and chase logic
- expose fielder utilities in playbalance package
- add tests covering catch probability, throws and chase decisions

## Testing
- `pytest tests/test_playbalance_fielder_abilities.py -q`
- `pytest -q` *(fails: 58 failed, 312 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7ceda148832ea5028c9c047eca5b