### PR TITLE
Clamp fielder ability inputs and validate against PBINI

### DIFF
--- a/data/news_feed.txt
+++ b/data/news_feed.txt
@@ -44,3 +44,13 @@
 [2025-09-08 00:02:44] Generated regular season schedule with 162 games
 [2025-09-08 00:02:44] Generated regular season schedule with 162 games
 [2025-09-08 00:02:44] No unsigned players available
+[2025-09-09 01:30:52] Simulated a regular season day; 1 days until Midseason
+[2025-09-09 01:30:52] Simulated a regular season day; 0 days until Midseason
+[2025-09-09 01:30:52] Simulated week; 0 days until Midseason
+[2025-09-09 01:30:52] Simulated month; 0 days until Midseason
+[2025-09-09 01:30:52] Season advanced to Preseason
+[2025-09-09 01:30:52] No unsigned players available
+[2025-09-09 01:30:52] Training camp completed; players marked ready
+[2025-09-09 01:30:52] Generated regular season schedule with 162 games
+[2025-09-09 01:30:52] Generated regular season schedule with 162 games
+[2025-09-09 01:30:52] No unsigned players available

--- a/playbalance/fielder.py
+++ b/playbalance/fielder.py
@@ -46,6 +46,7 @@ def reaction_delay(cfg: PlayBalanceConfig, position: str, fa: float) -> float:
     ability generally reduces the delay (negative percentage).
     """
 
+    fa = max(0.0, fa)
     key = _pos_key(position)
     base = getattr(cfg, f"delayBase{key}", 0.0)
     pct = getattr(cfg, f"delayFAPct{key}", 0.0)
@@ -72,6 +73,9 @@ def catch_chance(
     throws within :attr:`automaticCatchDist` are always caught.
     """
 
+    fa = max(0.0, fa)
+    air_time = max(0.0, air_time)
+    distance = max(0.0, distance)
     if distance <= getattr(cfg, "automaticCatchDist", 0.0):
         return 1.0
 
@@ -96,6 +100,7 @@ def catch_chance(
 def max_throw_distance(cfg: PlayBalanceConfig, arm_strength: float) -> float:
     """Return the maximum throwing distance in feet."""
 
+    arm_strength = max(0.0, arm_strength)
     return cfg.maxThrowDistBase + (cfg.maxThrowDistASPct * arm_strength) / 100.0
 
 
@@ -107,6 +112,8 @@ def throw_speed(
 ) -> float:
     """Return the velocity in mph for a throw to ``distance`` feet."""
 
+    distance = max(0.0, distance)
+    arm_strength = max(0.0, arm_strength)
     key = "OF" if outfielder else "IF"
     base = getattr(cfg, f"throwSpeed{key}Base", 0.0)
     dist_pct = getattr(cfg, f"throwSpeed{key}DistPct", 0.0)
@@ -121,6 +128,7 @@ def good_throw_chance(
 ) -> float:
     """Return probability of making an accurate throw."""
 
+    fa = max(0.0, fa)
     chance = cfg.goodThrowBase + (cfg.goodThrowFAPct * fa) / 100.0
     adj_key = f"goodThrowChance{_pos_key(position)}"
     chance += getattr(cfg, adj_key, 0.0)
@@ -139,6 +147,7 @@ def wild_pitch_catch_chance(
 ) -> float:
     """Return probability the catcher snags a wild pitch."""
 
+    fa = max(0.0, fa)
     chance = cfg.wildCatchChanceBase + (cfg.wildCatchChanceFAPct * fa) / 100.0
     if cross_body:
         chance += cfg.wildCatchChanceOppMod
@@ -155,6 +164,7 @@ def should_chase_ball(cfg: PlayBalanceConfig, position: str, projected_dist: flo
     plate at the interception point (for outfielders).
     """
 
+    projected_dist = max(0.0, projected_dist)
     if position in {"LF", "CF", "RF"}:
         return projected_dist >= cfg.outfieldMinChaseDist
     if position == "P":

--- a/tests/test_playbalance_fielder_abilities.py
+++ b/tests/test_playbalance_fielder_abilities.py
@@ -1,7 +1,7 @@
-from types import SimpleNamespace
 import pytest
 
 from playbalance import (
+    load_config,
     reaction_delay,
     catch_chance,
     max_throw_distance,
@@ -12,72 +12,38 @@ from playbalance import (
 )
 
 
-def make_cfg(**kwargs):
-    return SimpleNamespace(**kwargs)
+@pytest.fixture(scope="module")
+def cfg():
+    """Return a PlayBalanceConfig loaded from the project's PBINI file."""
+
+    return load_config()
 
 
-def test_reaction_delay():
-    cfg = make_cfg(delayBaseCatcher=12, delayFAPctCatcher=-4)
+def test_reaction_delay(cfg):
     assert reaction_delay(cfg, "C", 50) == 10.0
 
 
-def test_catch_chance_adjustments():
-    cfg = make_cfg(
-        catchBaseChance=90,
-        catchFADiv=7,
-        catchChanceDiving=-40,
-        catchChanceLeaping=-15,
-        catchChanceLessThan1Sec=-10,
-        catchChancePerTenth=-1,
-        catchChanceThirdBaseAdjust=0,
-        automaticCatchDist=15,
-    )
+def test_catch_chance_adjustments(cfg):
     # Diving 3B with 0.5s hang time and 20ft distance
     prob = catch_chance(cfg, "3B", fa=50, air_time=0.5, distance=20, diving=True)
     assert prob == pytest.approx(0.4214286, rel=1e-6)
 
 
-def test_throwing_metrics():
-    cfg = make_cfg(
-        maxThrowDistBase=190,
-        maxThrowDistASPct=100,
-        throwSpeedIFBase=52,
-        throwSpeedIFDistPct=3,
-        throwSpeedIFASPct=0,
-        throwSpeedIFMax=92,
-        throwSpeedOFBase=52,
-        throwSpeedOFDistPct=3,
-        throwSpeedOFASPct=0,
-        throwSpeedOFMax=92,
-    )
+def test_throwing_metrics(cfg):
     assert max_throw_distance(cfg, 50) == 240
     assert throw_speed(cfg, 150, 60) == pytest.approx(56.5)
     # Large distance capped at max speed for outfielders
-    assert throw_speed(cfg, 2000, 60, outfielder=True) == 92
+    assert throw_speed(cfg, 2000, 60, outfielder=True) == cfg.throwSpeedOFMax
 
 
-def test_throw_accuracy_and_wild_pitch():
-    cfg = make_cfg(
-        goodThrowBase=63,
-        goodThrowFAPct=40,
-        goodThrowChanceCenterField=-10,
-        wildCatchChanceBase=85,
-        wildCatchChanceFAPct=50,
-        wildCatchChanceOppMod=-10,
-        wildCatchChanceHighMod=-5,
-    )
+def test_throw_accuracy_and_wild_pitch(cfg):
     # CF accuracy
     assert good_throw_chance(cfg, "CF", 80) == pytest.approx(0.85)
     # Wild pitch catch chance with cross-body adjustment
     assert wild_pitch_catch_chance(cfg, 20, cross_body=True) == pytest.approx(0.85)
 
 
-def test_chase_decisions():
-    cfg = make_cfg(
-        infieldMaxChaseDist=50,
-        pitcherMaxChaseDist=90,
-        outfieldMinChaseDist=150,
-    )
+def test_chase_decisions(cfg):
     assert should_chase_ball(cfg, "SS", 40) is True
     assert should_chase_ball(cfg, "P", 100) is False
     assert should_chase_ball(cfg, "CF", 120) is False


### PR DESCRIPTION
## Summary
- Guard fielder ability calculations against negative inputs for realistic reaction, catch, throw, wild pitch and chase evaluations
- Load real PBINI configuration in fielder ability tests to confirm catch/throw probabilities and distances

## Testing
- `pytest` *(fails: 57 failed, 313 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7f973bdc832e895ab798f03ab021