### PR TITLE
Implement baserunning long lead and pickoff scare logic

### DIFF
--- a/playbalance/__init__.py
+++ b/playbalance/__init__.py
@@ -69,6 +69,7 @@ from .fielder import (
     wild_pitch_catch_chance,
     should_chase_ball,
 )
+from .baserunning import lead_level, pickoff_scare  # noqa: F401
 from .offense import (  # noqa: F401
     steal_chance,
     maybe_attempt_steal,
@@ -152,6 +153,8 @@ __all__ = [
     "pitch_around_chance",
     "outfielder_position",
     "fielder_template",
+    "lead_level",
+    "pickoff_scare",
     "steal_chance",
     "maybe_attempt_steal",
     "hit_and_run_chance",

--- a/playbalance/baserunning.py
+++ b/playbalance/baserunning.py
@@ -1,0 +1,40 @@
+"""Baserunning helpers for the play-balance engine."""
+from __future__ import annotations
+
+from random import Random
+
+from .config import PlayBalanceConfig
+
+
+def lead_level(cfg: PlayBalanceConfig, runner_sp: float) -> int:
+    """Return lead level (0 or 2) based on runner speed.
+
+    Runners take a long lead only when their speed rating meets or exceeds
+    ``cfg.longLeadSpeed``.
+    """
+
+    return 2 if runner_sp >= getattr(cfg, "longLeadSpeed", 0) else 0
+
+
+def pickoff_scare(
+    cfg: PlayBalanceConfig,
+    runner_sp: float,
+    lead: int,
+    rng: Random | None = None,
+) -> int:
+    """Return adjusted lead after a pickoff attempt.
+
+    When a pickoff throw nearly succeeds and the runner's speed is at or
+    below ``cfg.pickoffScareSpeed`` there is a 10% chance the runner retreats
+    to a short lead.
+    """
+
+    if rng is None:
+        rng = Random()
+    if lead > 0 and runner_sp <= getattr(cfg, "pickoffScareSpeed", 0):
+        if rng.random() < 0.1:
+            return 0
+    return lead
+
+
+__all__ = ["lead_level", "pickoff_scare"]

--- a/tests/test_playbalance_baserunning.py
+++ b/tests/test_playbalance_baserunning.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+from random import Random
+
+from playbalance import lead_level, pickoff_scare
+
+
+class ConstRandom(Random):
+    """Random generator returning a constant value from ``random``."""
+
+    def __init__(self, value: float):
+        super().__init__()
+        self.value = value
+
+    def random(self) -> float:  # type: ignore[override]
+        return self.value
+
+
+def test_long_lead_threshold():
+    cfg = SimpleNamespace(longLeadSpeed=60)
+    assert lead_level(cfg, 70) == 2
+    assert lead_level(cfg, 59) == 0
+
+
+def test_pickoff_scare_behavior():
+    cfg = SimpleNamespace(pickoffScareSpeed=60)
+    # Slow runner can be scared back on low roll
+    scared = pickoff_scare(cfg, 50, 2, rng=ConstRandom(0.05))
+    assert scared == 0
+    # Fast runner ignores scare
+    not_scared = pickoff_scare(cfg, 80, 2, rng=ConstRandom(0.05))
+    assert not_scared == 2
+    # Slow runner with high roll stays aggressive
+    no_event = pickoff_scare(cfg, 50, 2, rng=ConstRandom(0.2))
+    assert no_event == 2


### PR DESCRIPTION
## Summary
- add baserunning helpers to calculate long leads and pickoff scare reactions
- export new helpers from playbalance package
- cover baserunning logic with unit tests

## Testing
- `pytest` *(fails: 56 failed, 325 passed, 3 skipped)*
- `pytest tests/test_playbalance_baserunning.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf9404a5f4832e92cb594e982553d5