### PR TITLE
Add season simulation helpers and integration tests

### DIFF
--- a/logic/season_simulator.py
+++ b/logic/season_simulator.py
@@ -160,4 +160,45 @@ class SeasonSimulator:
         return home.runs, away.runs, html
 
 
-__all__ = ["SeasonSimulator"]
+def simulate_day(sim: "SeasonSimulator") -> None:
+    """Simulate games for a single scheduled day.
+
+    The provided :class:`SeasonSimulator` instance maintains its internal
+    state, allowing repeated calls to advance the schedule incrementally.
+    """
+
+    sim.simulate_next_day()
+
+
+def simulate_week(sim: "SeasonSimulator") -> None:
+    """Simulate up to seven days of games."""
+
+    for _ in range(7):
+        if sim._index >= len(sim.dates):
+            break
+        sim.simulate_next_day()
+
+
+def simulate_month(sim: "SeasonSimulator") -> None:
+    """Simulate up to thirty days of games."""
+
+    for _ in range(30):
+        if sim._index >= len(sim.dates):
+            break
+        sim.simulate_next_day()
+
+
+def simulate_season(sim: "SeasonSimulator") -> None:
+    """Simulate the remaining days on the schedule."""
+
+    while sim._index < len(sim.dates):
+        sim.simulate_next_day()
+
+
+__all__ = [
+    "SeasonSimulator",
+    "simulate_day",
+    "simulate_week",
+    "simulate_month",
+    "simulate_season",
+]

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -2530,12 +2530,45 @@ def save_boxscore_html(game_type: str, html: str, game_id: str | None = None) ->
     return str(path)
 
 
+def simulate_game(
+    home: TeamState,
+    away: TeamState,
+    config: PlayBalanceConfig,
+    rng: random.Random | None = None,
+    *,
+    innings: int = 9,
+) -> GameSimulation:
+    """Run a full game simulation and return the engine.
+
+    This convenience wrapper composes the various subsystems into a
+    pitch-by-pitch loop.  The provided ``home`` and ``away`` team states
+    are mutated with the results and the resulting :class:`GameSimulation`
+    instance is returned for further inspection.
+
+    Parameters
+    ----------
+    home, away:
+        Team states representing each club.
+    config:
+        Play balance configuration controlling behaviour of the simulation.
+    rng:
+        Optional random number generator to use for deterministic tests.
+    innings:
+        Number of innings to play.  Games may extend if tied.
+    """
+
+    sim = GameSimulation(home, away, config, rng)
+    sim.simulate_game(innings=innings)
+    return sim
+
+
 __all__ = [
     "BatterState",
     "PitcherState",
     "FieldingState",
     "TeamState",
     "GameSimulation",
+    "simulate_game",
     "generate_boxscore",
     "render_boxscore_html",
     "save_boxscore_html",

--- a/tests/test_simulation_spans.py
+++ b/tests/test_simulation_spans.py
@@ -1,0 +1,133 @@
+import random
+
+from logic.season_simulator import (
+    SeasonSimulator,
+    simulate_day,
+    simulate_week,
+    simulate_month,
+    simulate_season,
+)
+from logic.simulation import TeamState, simulate_game
+from models.player import Player
+from models.pitcher import Pitcher
+from tests.util.pbini_factory import load_config
+
+
+def make_player(pid: str) -> Player:
+    return Player(
+        player_id=pid,
+        first_name="F" + pid,
+        last_name="L" + pid,
+        birthdate="2000-01-01",
+        height=72,
+        weight=180,
+        bats="R",
+        primary_position="1B",
+        other_positions=[],
+        gf=50,
+        ch=50,
+        ph=50,
+        sp=50,
+        pl=0,
+        vl=0,
+        sc=0,
+        fa=0,
+        arm=0,
+    )
+
+
+def make_pitcher(pid: str) -> Pitcher:
+    return Pitcher(
+        player_id=pid,
+        first_name="PF" + pid,
+        last_name="PL" + pid,
+        birthdate="2000-01-01",
+        height=72,
+        weight=180,
+        bats="R",
+        primary_position="P",
+        other_positions=[],
+        gf=50,
+        endurance=50,
+        control=50,
+        movement=50,
+        hold_runner=50,
+        fb=50,
+        cu=0,
+        cb=0,
+        sl=0,
+        si=0,
+        scb=0,
+        kn=0,
+        arm=50,
+        fa=50,
+        role="SP",
+    )
+
+
+def _build_game_cb(cfg, teams):
+    def _cb(home_id: str, away_id: str):
+        home_info = teams[home_id]
+        away_info = teams[away_id]
+        home = TeamState(list(home_info["lineup"]), list(home_info["bench"]), list(home_info["pitchers"]))
+        away = TeamState(list(away_info["lineup"]), list(away_info["bench"]), list(away_info["pitchers"]))
+        simulate_game(home, away, cfg, random.Random(0), innings=1)
+        return home.runs, away.runs
+
+    return _cb
+
+
+def test_span_helpers_accumulate_stats():
+    cfg = load_config()
+    h_lineup = [make_player("h1")]
+    a_lineup = [make_player("a1")]
+    h_pitchers = [make_pitcher("hp")]
+    a_pitchers = [make_pitcher("ap")]
+    teams = {
+        "H": {"lineup": h_lineup, "bench": [], "pitchers": h_pitchers},
+        "A": {"lineup": a_lineup, "bench": [], "pitchers": a_pitchers},
+    }
+    schedule = [
+        {"date": "2024-04-01", "home": "H", "away": "A"},
+        {"date": "2024-04-02", "home": "A", "away": "H"},
+        {"date": "2024-04-03", "home": "H", "away": "A"},
+        {"date": "2024-04-04", "home": "A", "away": "H"},
+    ]
+    sim = SeasonSimulator(schedule, simulate_game=_build_game_cb(cfg, teams))
+
+    simulate_day(sim)
+    pa_after_day = h_lineup[0].season_stats.get("pa", 0)
+    assert pa_after_day > 0
+
+    simulate_week(sim)
+    pa_after_week = h_lineup[0].season_stats.get("pa", 0)
+    assert pa_after_week > pa_after_day
+
+    simulate_month(sim)
+    assert h_lineup[0].season_stats.get("pa", 0) == pa_after_week
+
+    simulate_season(sim)
+    assert h_lineup[0].season_stats.get("pa", 0) == pa_after_week
+
+
+def test_simulate_season_runs_all_games():
+    cfg = load_config()
+    h_lineup = [make_player("hh1")]
+    a_lineup = [make_player("aa1")]
+    h_pitchers = [make_pitcher("hhp")]
+    a_pitchers = [make_pitcher("aap")]
+    teams = {
+        "H": {"lineup": h_lineup, "bench": [], "pitchers": h_pitchers},
+        "A": {"lineup": a_lineup, "bench": [], "pitchers": a_pitchers},
+    }
+    schedule = [
+        {"date": "2024-04-01", "home": "H", "away": "A"},
+        {"date": "2024-04-02", "home": "A", "away": "H"},
+        {"date": "2024-04-03", "home": "H", "away": "A"},
+        {"date": "2024-04-04", "home": "A", "away": "H"},
+    ]
+    sim = SeasonSimulator(schedule, simulate_game=_build_game_cb(cfg, teams))
+
+    simulate_season(sim)
+    assert sim._index == len(sim.dates)
+    assert h_lineup[0].season_stats.get("pa", 0) > 0


### PR DESCRIPTION
## Summary
- expose a convenience `simulate_game` wrapper for pitch-by-pitch simulations
- add span helpers to `SeasonSimulator` for day, week, month, and season
- add integration tests exercising new helpers and stat accumulation

## Testing
- `pytest tests/test_simulation_spans.py -q`
- `pytest -q` *(fails: AttributeError: type object 'object' has no attribute 'new', ValueError: Team DRO does not have enough position players, AssertionError, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c0143e8e08832ea56f54b4b78d1872