### PR TITLE
Integrate real player data into play-balance sims

### DIFF
--- a/playbalance/player_loader.py
+++ b/playbalance/player_loader.py
@@ -1,0 +1,93 @@
+"""Utilities for loading player ratings from CSV data."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Mapping
+import csv
+
+from .ratings import clamp_rating
+
+
+@dataclass
+class Player:
+    """Lightweight representation of a player with mapped ratings."""
+
+    player_id: str
+    name: str
+    is_pitcher: bool
+    ratings: Dict[str, float]
+
+
+def _to_rating(value: str | float) -> float:
+    """Convert ``value`` to a 0-100 rating."""
+
+    try:
+        return clamp_rating(float(value))
+    except (TypeError, ValueError):
+        return 50.0
+
+
+def load_players(path: str | Path) -> Dict[str, Player]:
+    """Load players from ``path`` returning a mapping by ``player_id``.
+
+    The CSV is expected to contain the fields used by the internal play-balance
+    schema.  Pitching ratings map ``fb`` and ``sl`` to ``fastball`` and
+    ``slider`` respectively along with ``control`` and ``movement``.  Batting
+    ratings map ``ch`` to ``contact`` and ``pl`` to ``discipline``.
+    """
+
+    path = Path(path)
+    players: Dict[str, Player] = {}
+    with path.open(newline="") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            pid = row.get("player_id")
+            if not pid:
+                continue
+            is_pitcher = row.get("is_pitcher", "0") == "1"
+            name = f"{row.get('first_name','')} {row.get('last_name','')}".strip()
+            ratings: Dict[str, float] = {}
+            if is_pitcher:
+                ratings["fastball"] = _to_rating(row.get("fb", 50))
+                ratings["slider"] = _to_rating(row.get("sl", 50))
+                ratings["control"] = _to_rating(row.get("control", 50))
+                ratings["movement"] = _to_rating(row.get("movement", 50))
+            else:
+                ratings["contact"] = _to_rating(row.get("ch", 50))
+                ratings["discipline"] = _to_rating(row.get("pl", 50))
+            players[pid] = Player(pid, name, is_pitcher, ratings)
+    return players
+
+
+def load_lineup(path: str | Path, players: Mapping[str, Player]) -> list[Player]:
+    """Return batting order from ``path`` using ``players`` mapping."""
+
+    path = Path(path)
+    lineup: list[Player] = []
+    with path.open(newline="") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            pid = row.get("player_id")
+            if pid and pid in players:
+                lineup.append(players[pid])
+    return lineup
+
+
+def load_pitching_staff(path: str | Path, players: Mapping[str, Player]) -> list[Player]:
+    """Return pitching staff from roster ``path`` using ``players`` mapping."""
+
+    path = Path(path)
+    staff: list[Player] = []
+    with path.open(newline="") as fh:
+        reader = csv.reader(fh)
+        for row in reader:
+            if not row:
+                continue
+            pid = row[0]
+            if pid in players and players[pid].is_pitcher:
+                staff.append(players[pid])
+    return staff
+
+
+__all__ = ["Player", "load_players", "load_lineup", "load_pitching_staff"]

--- a/tests/test_roster_integration.py
+++ b/tests/test_roster_integration.py
@@ -1,0 +1,45 @@
+import math
+
+from playbalance.config import load_config
+from playbalance.benchmarks import load_benchmarks, league_average
+from playbalance.player_loader import load_players
+from playbalance.orchestrator import Team, simulate_games
+
+
+def test_real_player_data_influences_results():
+    players = load_players("data/players.csv")
+    batters = [p for p in players.values() if not p.is_pitcher]
+    batters.sort(key=lambda p: p.ratings.get("discipline", 50.0))
+    low_lineup = batters[:9]
+    high_lineup = batters[-9:]
+    pitchers = [p for p in players.values() if p.is_pitcher][:5]
+    team_low = Team(low_lineup, pitchers)
+    team_high = Team(high_lineup, pitchers)
+
+    cfg = load_config()
+    benchmarks = load_benchmarks()
+    benchmarks.update(
+        {
+            "avg_bb_pct": 0.08,
+            "avg_k_pct": 0.22,
+            "avg_babip": 0.3,
+            "avg_sba_per_pa": 0.02,
+            "avg_sb_pct": 0.75,
+            "avg_pitches_per_pa": 4.0,
+        }
+    )
+    stats_low = simulate_games(cfg, benchmarks, 200, team_low, team_low, rng_seed=1)
+    stats_mixed = simulate_games(cfg, benchmarks, 200, team_high, team_low, rng_seed=1)
+
+    bb_low = stats_low.bb / stats_low.pa
+    bb_mixed = stats_mixed.bb / stats_mixed.pa
+    k_low = stats_low.k / stats_low.pa
+    k_mixed = stats_mixed.k / stats_mixed.pa
+
+    assert bb_mixed > bb_low
+    assert k_mixed < k_low
+
+    league_bb = league_average(benchmarks, "bb_pct")
+    league_k = league_average(benchmarks, "k_pct")
+    assert math.isclose(bb_mixed, league_bb, abs_tol=0.05)
+    assert math.isclose(k_mixed, league_k, abs_tol=0.05)


### PR DESCRIPTION
## Summary
- Load players, lineups and pitching staffs from CSV to drive simulations
- Map raw player fields to play-balance ratings and wire into orchestrator
- Allow simulations to iterate through actual batting orders and pitchers
- Add integration test checking roster differences affect aggregate stats

## Testing
- `pytest tests/test_roster_integration.py`
- `pytest` *(fails: simulate_season missing args, insufficient team data, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c065881e1c832eb5758bf6906e3f18