### PR TITLE
Fix standalone execution for playbalance simulation script

### DIFF
--- a/scripts/playbalance_simulate.py
+++ b/scripts/playbalance_simulate.py
@@ -18,6 +18,10 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import sys
+
+# Allow running the script without installing the package
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from playbalance.benchmarks import load_benchmarks, league_average
 from playbalance.config import load_config


### PR DESCRIPTION
## Summary
- ensure `scripts/playbalance_simulate.py` adds repository root to `sys.path`
- allow running playbalance simulations without installing the package

## Testing
- `pytest` *(fails: 59 failed, 324 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e79a0cc0832e98af825172c7139b