### PR TITLE
Fix PBINI path resolution in play-balance config

### DIFF
--- a/playbalance/config.py
+++ b/playbalance/config.py
@@ -58,16 +58,35 @@ class PlayBalanceConfig:
 
 
 def load_config(
-    pbini_path: str | Path = Path("logic/PBINI.txt"),
-    overrides_path: str | Path = Path("data/playbalance_overrides.json"),
+    pbini_path: str | Path | None = None,
+    overrides_path: str | Path | None = None,
 ) -> PlayBalanceConfig:
-    """Load configuration from ``pbini_path`` and optional JSON overrides."""
+    """Load configuration from ``pbini_path`` and optional JSON overrides.
+
+    Paths default to locations relative to the project root allowing the
+    configuration to be loaded even when the current working directory is
+    different from the repository location.
+    """
+
+    base_dir = Path(__file__).resolve().parents[1]
+    if pbini_path is None:
+        pbini_path = base_dir / "logic" / "PBINI.txt"
+    else:
+        pbini_path = Path(pbini_path)
+        if not pbini_path.is_absolute():
+            pbini_path = base_dir / pbini_path
 
     sections = load_pbini(pbini_path)
     # Preserve the original keys to ensure coverage after overrides are merged.
     pbini_keys = {sect: set(vals.keys()) for sect, vals in sections.items()}
 
-    overrides_path = Path(overrides_path)
+    if overrides_path is None:
+        overrides_path = base_dir / "data" / "playbalance_overrides.json"
+    else:
+        overrides_path = Path(overrides_path)
+        if not overrides_path.is_absolute():
+            overrides_path = base_dir / overrides_path
+
     if overrides_path.exists():
         try:
             with overrides_path.open("r", encoding="utf-8") as fh:

--- a/tests/test_playbalance_config_paths.py
+++ b/tests/test_playbalance_config_paths.py
@@ -1,0 +1,9 @@
+from playbalance.config import load_config
+
+
+def test_load_config_outside_repo(monkeypatch, tmp_path):
+    """``load_config`` should locate PBINI.txt relative to the project root."""
+
+    monkeypatch.chdir(tmp_path)
+    cfg = load_config()
+    assert "PlayBalance" in cfg.sections


### PR DESCRIPTION
## Summary
- resolve PBINI.txt path relative to project root for play-balance config
- add regression test ensuring load_config works from any working directory

## Testing
- `pytest` (fails: assert 3 == 11, ValueError: Team DRO does not have eno..., and others)


------
https://chatgpt.com/codex/tasks/task_e_68c1f07c4618832e83705121cef4aa52