### PR TITLE
Fix path resolution for play-balance data files

### DIFF
--- a/playbalance/benchmarks.py
+++ b/playbalance/benchmarks.py
@@ -11,7 +11,8 @@ from typing import Dict
 import csv
 
 
-BENCHMARK_CSV = Path("data/MLB_avg/mlb_league_benchmarks_2025_filled.csv")
+BASE_DIR = Path(__file__).resolve().parents[1]
+BENCHMARK_CSV = BASE_DIR / "data" / "MLB_avg" / "mlb_league_benchmarks_2025_filled.csv"
 
 
 def load_benchmarks(path: str | Path = BENCHMARK_CSV) -> Dict[str, float]:
@@ -23,6 +24,8 @@ def load_benchmarks(path: str | Path = BENCHMARK_CSV) -> Dict[str, float]:
         CSV file with two columns: ``metric_key`` and ``value``.
     """
     path = Path(path)
+    if not path.is_absolute():
+        path = BASE_DIR / path
     benchmarks: Dict[str, float] = {}
     with path.open(newline="") as fh:
         reader = csv.DictReader(fh)

--- a/playbalance/orchestrator.py
+++ b/playbalance/orchestrator.py
@@ -14,6 +14,7 @@ benchmarks.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Dict, Iterable, Mapping
 import argparse
 import random
@@ -24,6 +25,9 @@ from .pitcher_ai import select_pitch
 from .batter_ai import StrikeZoneGrid, look_for_zone
 from .benchmarks import load_benchmarks, league_average
 from .player_loader import Player, load_lineup, load_pitching_staff, load_players
+
+
+BASE_DIR = Path(__file__).resolve().parents[1]
 
 
 @dataclass
@@ -76,16 +80,17 @@ def _load_default_teams() -> tuple[Team, Team]:
     helpers usable in tests.
     """
 
-    players = load_players("data/players.csv")
-    home_lineup = load_lineup("data/lineups/ARG_vs_rhp.csv", players)
-    away_lineup = load_lineup("data/lineups/ARG_vs_rhp.csv", players)
+    data_dir = BASE_DIR / "data"
+    players = load_players(data_dir / "players.csv")
+    home_lineup = load_lineup(data_dir / "lineups/ARG_vs_rhp.csv", players)
+    away_lineup = load_lineup(data_dir / "lineups/ARG_vs_rhp.csv", players)
     if not home_lineup:
         home_lineup = [p for p in players.values() if not p.is_pitcher][:9]
     if not away_lineup:
         away_lineup = [p for p in players.values() if not p.is_pitcher][9:18]
 
-    home_pitchers = load_pitching_staff("data/rosters/ABU.csv", players)
-    away_pitchers = load_pitching_staff("data/rosters/BCH.csv", players)
+    home_pitchers = load_pitching_staff(data_dir / "rosters/ABU.csv", players)
+    away_pitchers = load_pitching_staff(data_dir / "rosters/BCH.csv", players)
     if not home_pitchers:
         home_pitchers = [p for p in players.values() if p.is_pitcher][:5]
     if not away_pitchers:

--- a/tests/test_playbalance_orchestrator.py
+++ b/tests/test_playbalance_orchestrator.py
@@ -24,3 +24,11 @@ def test_season_stats_align_with_benchmarks():
     assert abs(babip - league_average(benchmarks, "babip")) < 0.03
     assert abs(sba_rate - league_average(benchmarks, "sba_per_pa")) < 0.01
     assert abs(sb_pct - league_average(benchmarks, "sb_pct")) < 0.1
+
+
+def test_simulation_runs_outside_repo(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cfg = load_config()
+    benchmarks = load_benchmarks()
+    res = simulate_season(cfg, benchmarks, games=1, rng_seed=1)
+    assert res.pa > 0


### PR DESCRIPTION
## Summary
- Resolve benchmark CSV path relative to project root
- Load default team data using absolute paths
- Add regression test ensuring simulations run from any working directory

## Testing
- `pytest` *(fails: 59 failed, 326 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68c1f32c5800832e916677dac1a8e95e