### PR TITLE
Gracefully handle missing playbalance roster files

### DIFF
--- a/tests/test_playbalance_player_loader_missing.py
+++ b/tests/test_playbalance_player_loader_missing.py
@@ -1,0 +1,15 @@
+import pathlib
+
+from playbalance.player_loader import load_lineup, load_pitching_staff
+
+
+def test_load_lineup_missing_file(tmp_path):
+    players = {}
+    missing_path = tmp_path / "missing_lineup.csv"
+    assert load_lineup(missing_path, players) == []
+
+
+def test_load_pitching_staff_missing_file(tmp_path):
+    players = {}
+    missing_path = tmp_path / "missing_roster.csv"
+    assert load_pitching_staff(missing_path, players) == []


### PR DESCRIPTION
## Summary
- Avoid crashing when default lineups or rosters are absent by catching `FileNotFoundError` in player loader helpers
- Add regression tests covering missing lineup and roster CSV files

## Testing
- `python scripts/playbalance_simulate.py season`
- `pytest tests/test_playbalance_player_loader_missing.py -q`
- `pytest -q` *(fails: 59 failed, 328 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fde4e68c832eb5c75d1018c6dfdc