### PR TITLE
Fix benchmark lookup when CSV lacks avg_ prefix

### DIFF
--- a/playbalance/benchmarks.py
+++ b/playbalance/benchmarks.py
@@ -102,8 +102,10 @@ def league_averages(benchmarks: Dict[str, float]) -> Dict[str, float]:
 
 def league_average(benchmarks: Dict[str, float], metric: str, default: float = 0.0) -> float:
     """Return league average for ``metric`` or ``default`` when missing."""
-    # Thin wrapper around ``benchmarks.get`` that adds the ``avg_`` prefix.
-    return benchmarks.get(f"avg_{metric}", default)
+    # Some benchmark CSVs include metrics without the ``avg_`` prefix.  The
+    # lookup first attempts to find the prefixed version and then falls back to
+    # the unprefixed key to support both formats.
+    return benchmarks.get(f"avg_{metric}", benchmarks.get(metric, default))
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- ensure league_average falls back to unprefixed benchmark keys

## Testing
- `pytest`
- `python scripts/playbalance_simulate.py season --games 1`

------
https://chatgpt.com/codex/tasks/task_e_68c1ffe3e714832eb2a4da84af68ef28