### PR TITLE
Use pipe separator for other positions

### DIFF
--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -640,7 +640,7 @@ class MainWindow(QMainWindow):
                 pid = row.get("player_id", "").strip()
                 players[pid] = {
                     "primary": row.get("primary_position", "").strip(),
-                    "others": row.get("other_positions", "").split("/")
+                    "others": row.get("other_positions", "").split("|")
                     if row.get("other_positions")
                     else [],
                     "is_pitcher": row.get("is_pitcher") == "1",

--- a/ui/lineup_editor.py
+++ b/ui/lineup_editor.py
@@ -210,7 +210,11 @@ class LineupEditor(QDialog):
                     player_id = str(row.get("player_id", "")).strip()
                     name = f"{row.get('first_name', '').strip()} {row.get('last_name', '').strip()}"
                     primary = row.get("primary_position", "").strip()
-                    others = row.get("other_positions", "").strip().split("/") if row.get("other_positions") else []
+                    others = (
+                        row.get("other_positions", "").strip().split("|")
+                        if row.get("other_positions")
+                        else []
+                    )
                     is_pitcher = row.get("is_pitcher") == "1"
                     players[player_id] = {
                         "name": f"{name} ({primary})",


### PR DESCRIPTION
## Summary
- parse `other_positions` using `|` delimiter in `admin_dashboard.set_all_lineups`
- parse `other_positions` using `|` delimiter in `lineup_editor.load_players_dict`

## Testing
- `pytest` *(fails: 62 failed, 325 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c206dbe0fc832e943640c5e62cfaeb