### PR TITLE
Ensure ACT roster covers all positions

### DIFF
--- a/logic/league_creator.py
+++ b/logic/league_creator.py
@@ -124,6 +124,28 @@ def _purge_old_league(base_dir: Path) -> None:
             item.unlink()
 
 
+def _ensure_act_positions(players: List[dict]) -> None:
+    """Ensure the active roster has coverage for all positions.
+
+    Parameters
+    ----------
+    players:
+        List of player dictionaries representing the ACT roster.
+
+    Raises
+    ------
+    ValueError
+        If any required position is missing from the roster.
+    """
+    required = {"P", "C", "1B", "2B", "3B", "SS", "LF", "CF", "RF"}
+    positions = {p.get("primary_position") for p in players}
+    missing = required - positions
+    if missing:
+        raise ValueError(
+            "ACT roster missing positions: " + ", ".join(sorted(missing))
+        )
+
+
 def create_league(base_dir: str | Path, divisions: Dict[str, List[Tuple[str, str]]], league_name: str):
     base_dir = Path(base_dir)
     base_dir.mkdir(parents=True, exist_ok=True)
@@ -183,6 +205,7 @@ def create_league(base_dir: str | Path, divisions: Dict[str, List[Tuple[str, str
             )
 
             act_players = generate_roster(11, 14, (21, 38), ensure_positions=True)
+            _ensure_act_positions(act_players)
             aaa_players = generate_roster(7, 8, (21, 38))
             low_players = generate_roster(5, 5, (18, 21))
 

--- a/tests/test_league_creator.py
+++ b/tests/test_league_creator.py
@@ -6,6 +6,7 @@ from models.pitcher import Pitcher
 from logic.player_generator import reset_name_cache
 from utils.team_loader import load_teams
 import random
+import pytest
 
 
 def test_create_league_generates_files(tmp_path):
@@ -180,3 +181,17 @@ def test_create_league_purges_old_files_but_keeps_avatars(tmp_path):
     assert not old_file.exists()
     assert not old_dir.exists()
     assert avatar.exists()
+
+
+def test_create_league_requires_all_positions(tmp_path, monkeypatch):
+    def fake_generate_player(is_pitcher=False, age_range=None, primary_position=None, **kwargs):
+        return {
+            "player_id": "p1",
+            "primary_position": "P" if is_pitcher else "1B",
+        }
+
+    monkeypatch.setattr("logic.league_creator.generate_player", fake_generate_player)
+    divisions = {"East": [("CityA", "Cats")]}
+
+    with pytest.raises(ValueError):
+        create_league(str(tmp_path), divisions, "Test League")


### PR DESCRIPTION
## Summary
- verify active roster includes every fielding position when generating a league
- add regression test for active roster position coverage

## Testing
- `pytest` (fails: tests failing: 62)
- `pytest tests/test_league_creator.py::test_create_league_requires_all_positions -q`


------
https://chatgpt.com/codex/tasks/task_e_68c210ee7ebc832e919a187d5662f0c0