### PR TITLE
Add swing and contact tracking for play-balance simulation

### DIFF
--- a/playbalance/state.py
+++ b/playbalance/state.py
@@ -17,6 +17,41 @@ class PlayerState:
 
 
 @dataclass
+class PitcherState:
+    """Tracks pitch-level statistics for a pitcher."""
+
+    zone_pitches: int = 0
+    zone_swings: int = 0
+    zone_contacts: int = 0
+    o_zone_swings: int = 0
+    o_zone_contacts: int = 0
+
+    def record_pitch(self, *, in_zone: bool, swung: bool, contact: bool) -> None:
+        """Record a pitch outcome.
+
+        Parameters
+        ----------
+        in_zone:
+            Whether the pitch was in the strike zone.
+        swung:
+            Whether the batter offered at the pitch.
+        contact:
+            True if the swing resulted in contact.
+        """
+
+        if in_zone:
+            self.zone_pitches += 1
+            if swung:
+                self.zone_swings += 1
+                if contact:
+                    self.zone_contacts += 1
+        elif swung:
+            self.o_zone_swings += 1
+            if contact:
+                self.o_zone_contacts += 1
+
+
+@dataclass
 class BaseState:
     """Tracks which bases currently have runners."""
 
@@ -75,4 +110,4 @@ class GameState:
         self.pitch_count += 1
 
 
-__all__ = ["PlayerState", "BaseState", "GameState"]
+__all__ = ["PlayerState", "PitcherState", "BaseState", "GameState"]

--- a/tests/test_playbalance_pitcher_state.py
+++ b/tests/test_playbalance_pitcher_state.py
@@ -1,0 +1,12 @@
+from playbalance.state import PitcherState
+
+
+def test_pitcher_state_records_zone_and_contact():
+    ps = PitcherState()
+    ps.record_pitch(in_zone=True, swung=True, contact=True)
+    ps.record_pitch(in_zone=False, swung=True, contact=False)
+    assert ps.zone_pitches == 1
+    assert ps.zone_swings == 1
+    assert ps.zone_contacts == 1
+    assert ps.o_zone_swings == 1
+    assert ps.o_zone_contacts == 0


### PR DESCRIPTION
## Summary
- add `PitcherState` in play-balance engine to track strike-zone pitches, swings, and contact
- drop prior strike-zone tracking from `GameSimulation` to focus on play-balance implementation
- cover pitch tracking with a dedicated unit test

## Testing
- `pytest tests/test_playbalance_pitcher_state.py::test_pitcher_state_records_zone_and_contact -q`
- `pytest -q` *(fails: numerous unrelated tests)*


------
https://chatgpt.com/codex/tasks/task_e_68c2fc4b161c832eacb5fceaddd910a7