### PR TITLE
Add chunksize to playbalance simulation pool

### DIFF
--- a/scripts/playbalance_simulate.py
+++ b/scripts/playbalance_simulate.py
@@ -181,10 +181,11 @@ def main(argv: list[str] | None = None) -> int:
         for g, s in zip(schedule, seeds)
     ]
 
+    chunksize = max(1, len(jobs) // (mp.cpu_count() * 4))
     totals: Counter[str] = Counter()
     with mp.Pool(initializer=_init_worker, initargs=(base_states, cfg)) as pool:
         for stats in tqdm(
-            pool.imap_unordered(_simulate_game, jobs),
+            pool.imap_unordered(_simulate_game, jobs, chunksize=chunksize),
             total=len(jobs),
             desc="Simulating games",
             disable=args.no_progress,


### PR DESCRIPTION
## Summary
- Compute dynamic chunksize for multiprocessing pool
- Pass chunksize to `imap_unordered` while preserving progress bar total

## Testing
- `pytest` *(fails: 62 failed, 327 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c301760434832e89a64a0041aad469