### PR TITLE
Make stat persistence optional in GameSimulation

### DIFF
--- a/scripts/playbalance_simulate.py
+++ b/scripts/playbalance_simulate.py
@@ -154,7 +154,7 @@ def _simulate_game(args: tuple[str, str, int]) -> np.ndarray:
     home = clone_team_state(home_id)
     away = clone_team_state(away_id)
     sim = GameSimulation(home, away, CFG, FastRNG(seed))
-    sim.simulate_game()
+    sim.simulate_game(persist_stats=False)
     totals = np.zeros(len(STAT_KEYS), dtype=np.int64)
 
     for team in (home, away):


### PR DESCRIPTION
## Summary
- add `persist_stats` flag to `GameSimulation.simulate_game`
- bypass stat saving in bulk `playbalance_simulate` runs

## Testing
- `pytest` *(fails: Team ABU does not have enough position players, test_walk_records_stats, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c382da1f0c832ebb3b7c1560fc70b3