### PR TITLE
route playbalance simulation via wrapper module

### DIFF
--- a/playbalance/orchestrator.py
+++ b/playbalance/orchestrator.py
@@ -25,7 +25,7 @@ import os
 import random
 
 from logic.schedule_generator import generate_mlb_schedule
-from logic.simulation import (
+from .simulation import (
     FieldingState,
     GameSimulation,
     PitcherState,

--- a/playbalance/simulation.py
+++ b/playbalance/simulation.py
@@ -1,0 +1,33 @@
+"""Compatibility layer exposing simulation primitives for the play-balance engine.
+
+This module provides a thin wrapper around the full-featured simulation
+implementation in :mod:`logic.simulation`.  Importing through this module
+allows the rest of the ``playbalance`` package to depend solely on the
+``playbalance`` namespace while a dedicated simulation engine is developed.
+"""
+from __future__ import annotations
+
+from logic.simulation import (
+    FieldingState as _FieldingState,
+    GameSimulation as _GameSimulation,
+    PitcherState as _PitcherState,
+    TeamState as _TeamState,
+    generate_boxscore as _generate_boxscore,
+)
+
+# Re-export the simulation classes so callers can import them from
+# ``playbalance.simulation`` without touching the legacy ``logic`` package.
+FieldingState = _FieldingState
+PitcherState = _PitcherState
+TeamState = _TeamState
+GameSimulation = _GameSimulation
+
+generate_boxscore = _generate_boxscore
+
+__all__ = [
+    "FieldingState",
+    "PitcherState",
+    "TeamState",
+    "GameSimulation",
+    "generate_boxscore",
+]

--- a/scripts/playbalance_simulate.py
+++ b/scripts/playbalance_simulate.py
@@ -37,7 +37,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from playbalance.benchmarks import load_benchmarks, league_average
 from logic.schedule_generator import generate_mlb_schedule
 from logic.sim_config import load_tuned_playbalance_config
-from logic.simulation import FieldingState, GameSimulation, PitcherState, TeamState
+from playbalance.simulation import FieldingState, GameSimulation, PitcherState, TeamState
 from utils.lineup_loader import build_default_game_state
 from utils.team_loader import load_teams
 


### PR DESCRIPTION
## Summary
- expose a `playbalance.simulation` module that re-exports the existing simulation engine
- update orchestrator and simulation script to import GameSimulation and state classes from `playbalance.simulation`

## Testing
- `pytest` *(fails: ValueError: Team ABU does not have enough position players)*

------
https://chatgpt.com/codex/tasks/task_e_68c3a0c38d7c832e9dea6729f78e91f3