### PR TITLE
Track strike zone pitch metrics

### DIFF
--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -1129,8 +1129,15 @@ class GameSimulation:
                 pitcher_state,
                 start_pitches,
             ):
+                pitcher_state.record_pitch(
+                    in_zone=dist <= 3, swung=True, contact=False
+                )
                 pitcher_state.outs += outs
                 return outs + outs_from_pick
+
+            pitcher_state.record_pitch(
+                in_zone=dist <= 3, swung=swing, contact=contact > 0
+            )
 
             if swing:
                 self.infield_fly = False

--- a/playbalance/state.py
+++ b/playbalance/state.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, Any
 
 
 @dataclass
@@ -20,6 +20,39 @@ class PlayerState:
 class PitcherState:
     """Tracks pitch-level statistics for a pitcher."""
 
+    player: Any | None = None
+    g: int = 0
+    gs: int = 0
+    gf: int = 0
+    outs: int = 0
+    r: int = 0
+    er: int = 0
+    h: int = 0
+    hr: int = 0
+    b1: int = 0
+    b2: int = 0
+    b3: int = 0
+    bb: int = 0
+    ibb: int = 0
+    so: int = 0
+    so_looking: int = 0
+    so_swinging: int = 0
+    hbp: int = 0
+    bf: int = 0
+    pitches_thrown: int = 0
+    balls_thrown: int = 0
+    strikes_thrown: int = 0
+    first_pitch_strikes: int = 0
+    pk: int = 0
+    pocs: int = 0
+    bk: int = 0
+    gb: int = 0
+    ld: int = 0
+    fb: int = 0
+    toast: float = 0.0
+    consecutive_hits: int = 0
+    consecutive_baserunners: int = 0
+    allowed_hr: bool = False
     zone_pitches: int = 0
     zone_swings: int = 0
     zone_contacts: int = 0

--- a/tests/test_pitch_zone_counters.py
+++ b/tests/test_pitch_zone_counters.py
@@ -1,0 +1,16 @@
+from playbalance.state import PitcherState
+
+
+def test_pitch_zone_counter_sequence():
+    ps = PitcherState()
+    ps.record_pitch(in_zone=True, swung=False, contact=False)
+    ps.record_pitch(in_zone=True, swung=True, contact=True)
+    ps.record_pitch(in_zone=False, swung=True, contact=False)
+    ps.record_pitch(in_zone=False, swung=True, contact=True)
+    ps.record_pitch(in_zone=False, swung=False, contact=False)
+
+    assert ps.zone_pitches == 2
+    assert ps.zone_swings == 1
+    assert ps.zone_contacts == 1
+    assert ps.o_zone_swings == 2
+    assert ps.o_zone_contacts == 1


### PR DESCRIPTION
## Summary
- track strike zone and swing/contact info for each pitch
- expose zone and out-of-zone counters on PitcherState
- add tests covering pitch zone counter behavior

## Testing
- `pytest tests/test_playbalance_pitcher_state.py tests/test_pitch_zone_counters.py tests/test_pitching_stats_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68c3a4e0a12c832ebc0ee4d70819c5be