### PR TITLE
Add save and inherited runner tracking to PitcherState

### DIFF
--- a/playbalance/state.py
+++ b/playbalance/state.py
@@ -29,6 +29,12 @@ class PitcherState:
     g: int = 0
     gs: int = 0
     gf: int = 0
+    sv: int = 0
+    svo: int = 0
+    hld: int = 0
+    bs: int = 0
+    ir: int = 0
+    irs: int = 0
     outs: int = 0
     r: int = 0
     er: int = 0
@@ -59,6 +65,7 @@ class PitcherState:
     consecutive_hits: int = 0
     consecutive_baserunners: int = 0
     allowed_hr: bool = False
+    in_save_situation: bool = False
     zone_pitches: int = 0
     zone_swings: int = 0
     zone_contacts: int = 0

--- a/tests/test_playbalance_pitcher_state.py
+++ b/tests/test_playbalance_pitcher_state.py
@@ -10,3 +10,14 @@ def test_pitcher_state_records_zone_and_contact():
     assert ps.zone_contacts == 1
     assert ps.o_zone_swings == 1
     assert ps.o_zone_contacts == 0
+
+
+def test_pitcher_state_defaults():
+    ps = PitcherState()
+    assert ps.ir == 0
+    assert ps.irs == 0
+    assert ps.svo == 0
+    assert ps.sv == 0
+    assert ps.hld == 0
+    assert ps.bs == 0
+    assert not ps.in_save_situation


### PR DESCRIPTION
## Summary
- add missing save and inherited runner attributes to `PitcherState`
- add test for default `PitcherState` values

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68c429eb04dc832eb0a71910ae5296af