### PR TITLE
refactor: centralize pitch rating constant

### DIFF
--- a/playbalance/batter_ai.py
+++ b/playbalance/batter_ai.py
@@ -16,6 +16,7 @@ from models.player import Player
 from models.pitcher import Pitcher
 from .playbalance_config import PlayBalanceConfig
 from .probability import clamp01, roll
+from .constants import PITCH_RATINGS
 
 
 # ---------------------------------------------------------------------------
@@ -224,7 +225,7 @@ class BatterAI:
             self._primary_cache = {}
         pid = pitcher.player_id
         if pid not in self._primary_cache:
-            ratings = {p: getattr(pitcher, p) for p in _PITCH_RATINGS}
+            ratings = {p: getattr(pitcher, p) for p in PITCH_RATINGS}
             primary = max(ratings.items(), key=lambda kv: kv[1])[0]
             self._primary_cache[pid] = primary
         return self._primary_cache[pid]
@@ -234,7 +235,7 @@ class BatterAI:
             self._best_cache = {}
         pid = pitcher.player_id
         if pid not in self._best_cache:
-            ratings = {p: getattr(pitcher, p) for p in _PITCH_RATINGS}
+            ratings = {p: getattr(pitcher, p) for p in PITCH_RATINGS}
             best = max(ratings.items(), key=lambda kv: kv[1])[0]
             self._best_cache[pid] = best
         return self._best_cache[pid]

--- a/playbalance/constants.py
+++ b/playbalance/constants.py
@@ -1,0 +1,5 @@
+"""Shared constants for play-balance modules."""
+
+PITCH_RATINGS = ["fb", "sl", "cu", "cb", "si", "scb", "kn"]
+
+__all__ = ["PITCH_RATINGS"]

--- a/playbalance/pitcher_ai.py
+++ b/playbalance/pitcher_ai.py
@@ -17,6 +17,7 @@ import random
 
 from models.pitcher import Pitcher
 from .playbalance_config import PlayBalanceConfig
+from .constants import PITCH_RATINGS
 
 
 # ---------------------------------------------------------------------------
@@ -161,13 +162,13 @@ class PitcherAI:
     def _primary_pitch(self, pitcher: Pitcher) -> str:
         pid = pitcher.player_id
         if pid not in self._primary_cache:
-            ratings = {p: getattr(pitcher, p) for p in _PITCH_RATINGS}
+            ratings = {p: getattr(pitcher, p) for p in PITCH_RATINGS}
             primary = max(ratings.items(), key=lambda kv: kv[1])[0]
             self._primary_cache[pid] = primary
         return self._primary_cache[pid]
 
     def select_pitch(self, pitcher: Pitcher, *, balls: int = 0, strikes: int = 0) -> Tuple[str, str]:
-        available = {p: getattr(pitcher, p) for p in _PITCH_RATINGS if getattr(pitcher, p) > 0}
+        available = {p: getattr(pitcher, p) for p in PITCH_RATINGS if getattr(pitcher, p) > 0}
         if not available:
             raise ValueError("Pitcher has no available pitch types")
 
@@ -199,7 +200,7 @@ class PitcherAI:
                 score += primary_adjust
             scored[name] = score
 
-        pitch_type = max(scored.items(), key=lambda kv: (kv[1], -_PITCH_RATINGS.index(kv[0])))[0]
+        pitch_type = max(scored.items(), key=lambda kv: (kv[1], -PITCH_RATINGS.index(kv[0])))[0]
         established.add(pitch_type)
 
         prefix = f"pitchObj{balls}{strikes}Count"

--- a/playbalance/simulation.py
+++ b/playbalance/simulation.py
@@ -33,7 +33,7 @@ from .stats import (
     compute_team_rates,
 )
 
-_PITCH_RATINGS = ["fb", "sl", "cu", "cb", "si", "scb", "kn"]
+from .constants import PITCH_RATINGS
 
 
 @dataclass(slots=True)
@@ -254,7 +254,7 @@ class GameSimulation:
             co_mult = self.config.get("effCOPct", 100) / 100.0
             mo_mult = self.config.get("effMOPct", 100) / 100.0
         scaled = replace(pitcher)
-        for attr in _PITCH_RATINGS:
+        for attr in PITCH_RATINGS:
             setattr(scaled, attr, int(getattr(pitcher, attr) * pitch_mult))
         scaled.arm = int(pitcher.arm * as_mult)
         scaled.control = int(pitcher.control * co_mult)


### PR DESCRIPTION
## Summary
- centralize list of pitch rating attributes in `PITCH_RATINGS`
- use shared constant across pitcher, batter, and simulation modules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4376d9f60832e93d442501f13c5f5