### PR TITLE
Fix ball bounce surface argument

### DIFF
--- a/playbalance/simulation.py
+++ b/playbalance/simulation.py
@@ -1799,7 +1799,7 @@ class GameSimulation:
         bounce_vert, bounce_horiz = self.physics.ball_bounce(
             bat_speed / 2.0,
             bat_speed / 2.0,
-            self.surface,
+            surface=self.surface,
             wet=self.wet,
             temperature=self.temperature,
         )
@@ -1917,7 +1917,7 @@ class GameSimulation:
                 _, bounce_dist = self.physics.ball_bounce(
                     spd / 2.0,
                     spd / 2.0,
-                    self.surface,
+                    surface=self.surface,
                     wet=self.wet,
                     temperature=self.temperature,
                 )
@@ -1948,7 +1948,7 @@ class GameSimulation:
                 _, bounce_dist = self.physics.ball_bounce(
                     spd / 2.0,
                     spd / 2.0,
-                    self.surface,
+                    surface=self.surface,
                     wet=self.wet,
                     temperature=self.temperature,
                 )


### PR DESCRIPTION
## Summary
- ensure Physics.ball_bounce is called with `surface` as a keyword argument to match signature

## Testing
- `pytest` *(fails: 73 failed, 323 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c43f366204832eb17af68152a1f9a8