### PR TITLE
Track batter misreads in BatterAI

### DIFF
--- a/playbalance/batter_ai.py
+++ b/playbalance/batter_ai.py
@@ -219,6 +219,7 @@ class BatterAI:
     _primary_cache: Dict[str, str] = None  # type: ignore[assignment]
     _best_cache: Dict[str, str] = None  # type: ignore[assignment]
     last_decision: Tuple[bool, float] | None = None
+    last_misread: bool = False
 
     def _primary_pitch(self, pitcher: Pitcher) -> str:
         if self._primary_cache is None:
@@ -282,6 +283,9 @@ class BatterAI:
 
         if look_for and not pitch_match:
             contact_quality -= getattr(self.config, "lookMismatchPenalty", 0) / 100.0
+            self.last_misread = True
+        else:
+            self.last_misread = False
 
         id_base = getattr(self.config, "idRatingBase", 0)
         id_scale = getattr(self.config, "idRatingEaseScale", 1.0)


### PR DESCRIPTION
## Summary
- ensure `BatterAI` exposes `last_misread`
- mark `last_misread` when the batter looks for the wrong pitch

## Testing
- `pytest` *(fails: 72 failed, 324 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c4405624b0832e84b940998b2a13ae