### PR TITLE
Adjust batted ball distribution based on player attributes

### DIFF
--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -148,6 +148,10 @@ _DEFAULTS: Dict[str, Any] = {
     "groundBallBaseRate": 44,
     "flyBallBaseRate": 35,
     "lineDriveBaseRate": 21,
+    # Weighting factors for batter/pitcher influence on batted ball types
+    "bipPowerWeight": 0.2,
+    "bipLaunchWeight": 0.2,
+    "bipMovementWeight": 0.2,
     # League average strike percentage
     "leagueStrikePct": _LEAGUE_STRIKE_PCT,
     # Hit type distribution reflecting recent MLB averages
@@ -740,6 +744,21 @@ class PlayBalanceConfig:
     def line_drive_base_rate(self) -> int:
         """Baseline percentage of batted balls that are line drives."""
         return int(self.lineDriveBaseRate)
+
+    @property
+    def bip_power_weight(self) -> float:
+        """Weight for batter power influence on batted ball distribution."""
+        return float(self.bipPowerWeight)
+
+    @property
+    def bip_launch_weight(self) -> float:
+        """Weight for batter launch tendency influence."""
+        return float(self.bipLaunchWeight)
+
+    @property
+    def bip_movement_weight(self) -> float:
+        """Weight for pitcher movement influence on batted ball distribution."""
+        return float(self.bipMovementWeight)
 
     @property
     def hit_prob_base(self) -> float:

--- a/tests/test_bip_attribute_variation.py
+++ b/tests/test_bip_attribute_variation.py
@@ -1,0 +1,48 @@
+import random
+
+from playbalance.simulation import BatterState, GameSimulation, TeamState
+from playbalance.state import PitcherState
+from playbalance.playbalance_config import PlayBalanceConfig
+from tests.test_physics import make_player, make_pitcher
+
+
+def _simulate_counts(batter, pitcher, cfg):
+    """Helper to simulate a large number of swings and return type counts."""
+    defense = TeamState(lineup=[make_player("d")], bench=[], pitchers=[pitcher])
+    offense = TeamState(lineup=[batter], bench=[], pitchers=[make_pitcher("op")])
+    sim = GameSimulation(defense, offense, cfg, random.Random(0))
+    b_state = BatterState(batter)
+    p_state = PitcherState()
+    p_state.player = pitcher
+    counts = {"ground": 0, "line": 0, "fly": 0}
+    for _ in range(3000):
+        sim._swing_result(batter, pitcher, defense, b_state, p_state, pitch_speed=90)
+        counts[sim.last_batted_ball_type] += 1
+    return counts
+
+
+def test_batter_attributes_shift_distribution():
+    cfg = PlayBalanceConfig.from_dict({})
+    slugger = make_player("slug", ph=80)
+    slugger.gf = 80
+    slap = make_player("slap", ph=20)
+    slap.gf = 20
+    pitcher = make_pitcher("p")
+    slug_counts = _simulate_counts(slugger, pitcher, cfg)
+    slap_counts = _simulate_counts(slap, pitcher, cfg)
+    assert slug_counts["fly"] > slap_counts["fly"]
+    assert slug_counts["ground"] < slap_counts["ground"]
+
+
+def test_pitcher_movement_shift_distribution():
+    cfg = PlayBalanceConfig.from_dict({})
+    batter = make_player("b")
+    ground_pitcher = make_pitcher("g")
+    ground_pitcher.movement = 80
+    fly_pitcher = make_pitcher("f")
+    fly_pitcher.movement = 20
+    ground_counts = _simulate_counts(batter, ground_pitcher, cfg)
+    fly_counts = _simulate_counts(batter, fly_pitcher, cfg)
+    assert ground_counts["ground"] > fly_counts["ground"]
+    assert ground_counts["fly"] < fly_counts["fly"]
+

--- a/tests/test_ground_fly_distribution.py
+++ b/tests/test_ground_fly_distribution.py
@@ -46,14 +46,14 @@ def test_ground_air_distribution():
     assert air / total == pytest.approx(expected_air, abs=0.02)
 
 
-def test_vert_angle_gf_pct_shifts_distribution():
-    cfg0 = PlayBalanceConfig.from_dict({"vertAngleGFPct": 0})
-    cfg10 = PlayBalanceConfig.from_dict({"vertAngleGFPct": 10})
+def test_launch_weight_shifts_distribution():
+    cfg0 = PlayBalanceConfig.from_dict({"bipLaunchWeight": 0})
+    cfg40 = PlayBalanceConfig.from_dict({"bipLaunchWeight": 0.4})
 
     def run(cfg):
         rng = random.Random(0)
         batter = make_player("b")
-        batter.gf = 0
+        batter.gf = 80
         pitcher = make_pitcher("p")
         defense = TeamState(lineup=[make_player("d")], bench=[], pitchers=[pitcher])
         offense = TeamState(lineup=[batter], bench=[], pitchers=[make_pitcher("op")])
@@ -73,6 +73,6 @@ def test_vert_angle_gf_pct_shifts_distribution():
         return ground, air
 
     ground0, air0 = run(cfg0)
-    ground10, air10 = run(cfg10)
-    assert ground10 < ground0
-    assert air10 > air0
+    ground40, air40 = run(cfg40)
+    assert ground40 < ground0
+    assert air40 > air0


### PR DESCRIPTION
## Summary
- weigh ground/line/fly ball mix using batter power/launch tendencies and pitcher movement
- expose tuning weights in `PlayBalanceConfig`
- test that hitter and pitcher attributes and config weights influence batted ball distribution

## Testing
- `pytest` (fails: Team ABU does not have enough ...)
- `pytest tests/test_bip_attribute_variation.py tests/test_bip_type_distribution.py tests/test_ground_fly_distribution.py tests/test_line_drive_distribution.py`


------
https://chatgpt.com/codex/tasks/task_e_68c46b661ccc832eba2e4a48019e361c