### PR TITLE
Manage window top-most behavior via helper

### DIFF
--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -38,6 +38,7 @@ from PyQt6.QtWidgets import (
 )
 
 from .components import Card, NavButton, section_title
+from ui.window_utils import ensure_on_top, show_on_top
 from .theme import _toggle_theme
 from .team_entry_dialog import TeamEntryDialog
 from .exhibition_game_dialog import ExhibitionGameDialog
@@ -419,7 +420,7 @@ class MainWindow(QMainWindow):
         layout.addWidget(trade_list)
         layout.addLayout(btn_layout)
         dialog.setLayout(layout)
-        dialog.exec()
+        show_on_top(dialog)
 
     def generate_team_logos(self) -> None:
         teams = load_teams("data/teams.csv")
@@ -537,7 +538,7 @@ class MainWindow(QMainWindow):
         cancel_btn.clicked.connect(dialog.reject)
 
         dialog.setLayout(layout)
-        dialog.exec()
+        show_on_top(dialog)
 
     def open_edit_user(self) -> None:
         dialog = QDialog(self)
@@ -611,7 +612,7 @@ class MainWindow(QMainWindow):
         cancel_btn.clicked.connect(dialog.reject)
 
         dialog.setLayout(layout)
-        dialog.exec()
+        show_on_top(dialog)
 
     def open_team_dashboard(self) -> None:
         teams = load_teams(get_base_dir() / "data" / "teams.csv")
@@ -624,7 +625,7 @@ class MainWindow(QMainWindow):
         )
         if ok and team_id:
             dashboard = OwnerDashboard(team_id)
-            dashboard.show()
+            show_on_top(dashboard)
             self.team_dashboards.append(dashboard)
 
     def set_all_lineups(self) -> None:
@@ -755,6 +756,7 @@ class MainWindow(QMainWindow):
             return
 
         dialog = TeamEntryDialog(divisions, teams_per_div, self)
+        ensure_on_top(dialog)
         if dialog.exec() != QDialog.DialogCode.Accepted:
             return
 

--- a/ui/login_window.py
+++ b/ui/login_window.py
@@ -15,6 +15,7 @@ import bcrypt
 
 from utils.path_utils import get_base_dir
 from ui.theme import DARK_QSS
+from ui.window_utils import show_on_top
 
 # Determine the path to the users file in a cross-platform way
 USER_FILE = get_base_dir() / "data" / "users.txt"
@@ -115,7 +116,7 @@ class LoginWindow(QWidget):
         if app:
             app.setStyleSheet(DARK_QSS)
 
-        self.dashboard.show()
+        show_on_top(self.dashboard)
 
         # Keep the splash screen visible while the dashboard is open so it
         # behaves the same way it does when the login window is shown.  This

--- a/ui/owner_dashboard.py
+++ b/ui/owner_dashboard.py
@@ -47,6 +47,7 @@ from utils.free_agent_finder import find_free_agents
 from utils.pitcher_role import get_role
 from utils.team_loader import load_teams
 from utils.path_utils import get_base_dir
+from ui.window_utils import show_on_top
 
 
 class OwnerDashboard(QMainWindow):
@@ -192,25 +193,25 @@ class OwnerDashboard(QMainWindow):
 
     # ---------- Actions used by pages ----------
     def open_lineup_editor(self) -> None:
-        LineupEditor(self.team_id).exec()
+        show_on_top(LineupEditor(self.team_id))
 
     def open_pitching_editor(self) -> None:
-        PitchingEditor(self.team_id).exec()
+        show_on_top(PitchingEditor(self.team_id))
 
     def open_position_players_dialog(self) -> None:
-        PositionPlayersDialog(self.players, self.roster).exec()
+        show_on_top(PositionPlayersDialog(self.players, self.roster))
 
     def open_pitchers_dialog(self) -> None:
-        PitchersDialog(self.players, self.roster).exec()
+        show_on_top(PitchersDialog(self.players, self.roster))
 
     def open_reassign_players_dialog(self) -> None:
-        ReassignPlayersDialog(self.players, self.roster, self).exec()
+        show_on_top(ReassignPlayersDialog(self.players, self.roster, self))
 
     def open_transactions_page(self) -> None:
-        TransactionsWindow().exec()
+        show_on_top(TransactionsWindow())
 
     def open_trade_dialog(self) -> None:
-        TradeDialog(self.team_id, self).exec()
+        show_on_top(TradeDialog(self.team_id, self))
 
     def sign_free_agent(self) -> None:
         try:
@@ -225,16 +226,16 @@ class OwnerDashboard(QMainWindow):
             QMessageBox.critical(self, "Error", f"Failed to sign free agent: {e}")
 
     def open_standings_window(self) -> None:
-        StandingsWindow(self).exec()
+        show_on_top(StandingsWindow(self))
 
     def open_schedule_window(self) -> None:
-        ScheduleWindow(self).exec()
+        show_on_top(ScheduleWindow(self))
 
     def open_team_schedule_window(self) -> None:
         if not getattr(self, "team_id", None):
             QMessageBox.warning(self, "Error", "Team information not available.")
             return
-        TeamScheduleWindow(self.team_id, self).exec()
+        show_on_top(TeamScheduleWindow(self.team_id, self))
 
     def open_team_stats_window(self) -> None:
         if not getattr(self, "team", None):
@@ -242,7 +243,7 @@ class OwnerDashboard(QMainWindow):
             return
         w = TeamStatsWindow(self.team, self.players, self.roster, self)
         w.tabs.setCurrentIndex(2)
-        w.exec()
+        show_on_top(w)
 
     def open_player_stats_window(self) -> None:
         if not getattr(self, "team", None):
@@ -250,14 +251,14 @@ class OwnerDashboard(QMainWindow):
             return
         w = TeamStatsWindow(self.team, self.players, self.roster, self)
         w.tabs.setCurrentIndex(0)
-        w.exec()
+        show_on_top(w)
 
     def open_league_stats_window(self) -> None:
         teams = load_teams()
-        LeagueStatsWindow(teams, self.players.values(), self).exec()
+        show_on_top(LeagueStatsWindow(teams, self.players.values(), self))
 
     def open_league_leaders_window(self) -> None:
-        LeagueLeadersWindow(self.players.values(), self).exec()
+        show_on_top(LeagueLeadersWindow(self.players.values(), self))
 
     # ---------- Utilities ----------
     def calculate_age(self, birthdate_str: str):

--- a/ui/splash_screen.py
+++ b/ui/splash_screen.py
@@ -1,9 +1,10 @@
 from PyQt6.QtWidgets import QWidget, QLabel, QPushButton, QVBoxLayout
 from PyQt6.QtGui import QPixmap, QFont
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import Qt, QEvent
 
 from ui.login_window import LoginWindow
 from utils.path_utils import get_base_dir
+from ui.window_utils import show_on_top, set_all_on_top
 
 class SplashScreen(QWidget):
     """Initial splash screen displaying the NexGen logo and start button."""
@@ -44,9 +45,9 @@ class SplashScreen(QWidget):
         self.login_button.setEnabled(False)
 
         self.login_window = LoginWindow(self)
-        # Ensure the login window (certificate selector) isn't hidden behind
-        # other applications by forcing it to the foreground.
-        self.login_window.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint)
-        self.login_window.show()
-        self.login_window.raise_()
-        self.login_window.activateWindow()
+        show_on_top(self.login_window)
+
+    def changeEvent(self, event):
+        if event.type() == QEvent.Type.WindowStateChange:
+            set_all_on_top(not self.isMinimized())
+        super().changeEvent(event)

--- a/ui/window_utils.py
+++ b/ui/window_utils.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+"""Utilities for managing top-most behaviour of Qt windows."""
+
+import weakref
+
+from PyQt6.QtCore import Qt
+
+# Track windows that should follow the splash screen's top-most state
+_tracked_windows: "weakref.WeakSet" = weakref.WeakSet()
+
+
+def _apply_flag(window, enable: bool) -> None:
+    """Apply or remove the WindowStaysOnTopHint flag for *window*."""
+    flags = window.windowFlags()
+    if enable:
+        window.setWindowFlags(flags | Qt.WindowType.WindowStaysOnTopHint)
+    else:
+        window.setWindowFlags(flags & ~Qt.WindowType.WindowStaysOnTopHint)
+    # Re-show to ensure the new flags take effect
+    window.show()
+
+
+def ensure_on_top(window) -> None:
+    """Ensure *window* stays on top and register it for global toggling."""
+    _tracked_windows.add(window)
+    _apply_flag(window, True)
+
+
+def remove_on_top(window) -> None:
+    """Remove the on-top hint for *window* and stop tracking it."""
+    _apply_flag(window, False)
+    try:
+        _tracked_windows.remove(window)
+    except KeyError:
+        pass
+
+
+def set_all_on_top(enable: bool) -> None:
+    """Toggle the on-top flag for all tracked windows."""
+    for win in list(_tracked_windows):
+        _apply_flag(win, enable)
+
+
+def show_on_top(window):
+    """Show a window while ensuring it stays on top.
+
+    If the window has an ``exec`` method (e.g. dialogs), it will be invoked and
+    the result returned. Otherwise ``show`` is called.
+    """
+    ensure_on_top(window)
+    if hasattr(window, "exec"):
+        return window.exec()
+    window.show()
+    window.raise_()
+    window.activateWindow()
+    return None


### PR DESCRIPTION
## Summary
- Add `window_utils` module to track windows and toggle `Qt.WindowStaysOnTopHint`
- Use helper when opening LoginWindow, dashboards, and dialogs
- Splash screen listens for minimize/restore to update tracked windows

## Testing
- `pytest` *(fails: AttributeError, ValueError, AssertionError; 70 failed, 329 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c46c65e858832ea4f860a5ed416c93