### PR TITLE
Unify team and player stats access

### DIFF
--- a/tests/test_schedule_windows.py
+++ b/tests/test_schedule_windows.py
@@ -281,9 +281,10 @@ def test_owner_dashboard_stats_windows(monkeypatch):
 
     dash = owner_dashboard.OwnerDashboard('X')
     dash.open_team_stats_window()
-    dash.open_player_stats_window()
+    dash.open_team_stats_window(tab="batting")
+    dash.open_team_stats_window(tab="pitching")
 
-    assert called == [2, 0]
+    assert called == [2, 0, 1]
 
 
 def test_team_schedule_window_no_entries(monkeypatch, tmp_path):

--- a/ui/owner_dashboard.py
+++ b/ui/owner_dashboard.py
@@ -249,20 +249,14 @@ class OwnerDashboard(QMainWindow):
             return
         show_on_top(TeamScheduleWindow(self.team_id, self))
 
-    def open_team_stats_window(self) -> None:
+    def open_team_stats_window(self, tab: str = "team") -> None:
+        """Open the team statistics window with the specified default tab."""
         if not getattr(self, "team", None):
             QMessageBox.warning(self, "Error", "Team information not available.")
             return
         w = TeamStatsWindow(self.team, self.players, self.roster, self)
-        w.tabs.setCurrentIndex(2)
-        show_on_top(w)
-
-    def open_player_stats_window(self) -> None:
-        if not getattr(self, "team", None):
-            QMessageBox.warning(self, "Error", "Team information not available.")
-            return
-        w = TeamStatsWindow(self.team, self.players, self.roster, self)
-        w.tabs.setCurrentIndex(0)
+        index_map = {"batting": 0, "pitching": 1, "team": 2}
+        w.tabs.setCurrentIndex(index_map.get(tab.lower(), 2))
         show_on_top(w)
 
     def open_league_stats_window(self) -> None:

--- a/ui/team_page.py
+++ b/ui/team_page.py
@@ -17,13 +17,9 @@ class TeamPage(QWidget):
         btn_sched.clicked.connect(dashboard.open_team_schedule_window)
         card.layout().addWidget(btn_sched)
 
-        btn_team_stats = QPushButton("Team Stats", objectName="Primary")
-        btn_team_stats.clicked.connect(dashboard.open_team_stats_window)
-        card.layout().addWidget(btn_team_stats)
-
-        btn_player_stats = QPushButton("Player Stats", objectName="Primary")
-        btn_player_stats.clicked.connect(dashboard.open_player_stats_window)
-        card.layout().addWidget(btn_player_stats)
+        btn_stats = QPushButton("Team & Player Stats", objectName="Primary")
+        btn_stats.clicked.connect(dashboard.open_team_stats_window)
+        card.layout().addWidget(btn_stats)
 
         card.layout().addStretch()
         layout.addWidget(card)


### PR DESCRIPTION
## Summary
- Replace separate team and player stats buttons with one "Team & Player Stats" button
- Allow specifying default tab when opening TeamStatsWindow
- Update tests for unified stats window behavior

## Testing
- `pytest` *(fails: Team DRO does not have enough position players, pinch hitters, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c471bc97bc832e919ecf3fcb1a41de