### PR TITLE
feat: tune zone and out swing scales

### DIFF
--- a/playbalance/batter_ai.py
+++ b/playbalance/batter_ai.py
@@ -316,6 +316,10 @@ class BatterAI:
         }[pitch_kind]
         base = getattr(self.config, prob_key, 0.0)
         base *= getattr(self.config, "swingProbScale", 1.0)
+        in_zone = pitch_kind in {"sure strike", "close strike"}
+        zone_scale = getattr(self.config, "zSwingProbScale", 1.0)
+        o_zone_scale = getattr(self.config, "oSwingProbScale", 1.0)
+        base *= zone_scale if in_zone else o_zone_scale
         swing_chance = base
 
         # Count-based adjustment allows tuning per ball-strike count.

--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -224,6 +224,9 @@ _DEFAULTS: Dict[str, Any] = {
     "swingProbSureBall": 0.05,
     # Global swing probability scaling factor
     "swingProbScale": 0.9,
+    # Separate scaling factors for pitches in and out of the zone
+    "zSwingProbScale": 1.0,
+    "oSwingProbScale": 1.0,
     # Count and location adjustments to swing probability
     "swingProb00CountAdjust": 0,
     "swingProb01CountAdjust": 0,

--- a/playbalance/sim_config.py
+++ b/playbalance/sim_config.py
@@ -37,10 +37,18 @@ def apply_league_benchmarks(
     pitches_per_pa = benchmarks["pitches_per_pa"]
     cfg.swingProbScale = round(4.0 / pitches_per_pa, 2) if pitches_per_pa else 1.0
 
-    swing_pct = benchmarks.get("swing_pct")
-    zone_pct = benchmarks.get("zone_pct")
     z_swing_pct = benchmarks.get("z_swing_pct")
     o_swing_pct = benchmarks.get("o_swing_pct")
+    if None not in (z_swing_pct, o_swing_pct):
+        base_z = (cfg.swingProbSureStrike + cfg.swingProbCloseStrike) / 2
+        base_o = (cfg.swingProbCloseBall + cfg.swingProbSureBall) / 2
+        base_z *= cfg.swingProbScale
+        base_o *= cfg.swingProbScale
+        cfg.zSwingProbScale = round(z_swing_pct / base_z, 2) if base_z else 1.0
+        cfg.oSwingProbScale = round(o_swing_pct / base_o, 2) if base_o else 1.0
+
+    swing_pct = benchmarks.get("swing_pct")
+    zone_pct = benchmarks.get("zone_pct")
     z_contact_pct = benchmarks.get("z_contact_pct")
     o_contact_pct = benchmarks.get("o_contact_pct")
     swstr_pct = benchmarks.get("swstr_pct")

--- a/tests/test_o_swing_zone_pct.py
+++ b/tests/test_o_swing_zone_pct.py
@@ -13,4 +13,5 @@ def test_o_swing_and_zone_pct():
     rates = compute_pitching_rates(ps)
     assert ps.o_zone_pitches == 2
     assert rates["ozone_swing_pct"] == approx(1 / 2)
+    assert rates["z_swing_pct"] == approx(0)
     assert rates["zone_pct"] == approx(1 / 3)


### PR DESCRIPTION
## Summary
- add distinct swing probability scales for pitches in and out of the zone
- tune zone/out-of-zone swing scales from league benchmarks
- use zone/out-of-zone scaling when batters choose to swing
- add coverage for zone and out-of-zone swing percentages

## Testing
- `pytest` *(fails: schedule window, season simulator, simulation, standings window, swing and miss rate, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c4c4606b4c832ea2e6c1bc776be55f