### PR TITLE
Adjust PBINI swing probabilities for realistic swing rates

### DIFF
--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -218,10 +218,10 @@ _DEFAULTS: Dict[str, Any] = {
     "closeStrikeDist": 5,
     "closeBallDist": 4,
     # Baseline swing probabilities reflecting MLB averages
-    "swingProbSureStrike": 0.75,
-    "swingProbCloseStrike": 0.5,
-    "swingProbCloseBall": 0.2,
-    "swingProbSureBall": 0.05,
+    "swingProbSureStrike": 0.66,
+    "swingProbCloseStrike": 0.46,
+    "swingProbCloseBall": 0.51,
+    "swingProbSureBall": 0.13,
     # Global swing probability scaling factor
     "swingProbScale": 0.9,
     # Separate scaling factors for pitches in and out of the zone

--- a/tests/test_league_swing_pct.py
+++ b/tests/test_league_swing_pct.py
@@ -11,8 +11,6 @@ from tests.util.pbini_factory import make_cfg
 def test_league_wide_swing_percentage():
     cfg = make_cfg(idRatingBase=50)
     cfg.values["swingProbScale"] = 1.0
-    cfg.values["zSwingProbScale"] = 1.04
-    cfg.values["oSwingProbScale"] = 2.56
     ai = BatterAI(cfg)
     batter = make_player("B", ch=50)
     pitcher = make_pitcher("P", movement=50)

--- a/tests/util/pbini_factory.py
+++ b/tests/util/pbini_factory.py
@@ -19,10 +19,10 @@ def make_cfg(**entries: int) -> PlayBalanceConfig:
         "hit2BProb": 0,
         "hit3BProb": 0,
         "hitHRProb": 0,
-        "swingProbSureStrike": 0.75,
-        "swingProbCloseStrike": 0.5,
-        "swingProbCloseBall": 0.35,
-        "swingProbSureBall": 0.1,
+        "swingProbSureStrike": 0.66,
+        "swingProbCloseStrike": 0.46,
+        "swingProbCloseBall": 0.51,
+        "swingProbSureBall": 0.13,
     }
     base_entries.update(entries)
     return PlayBalanceConfig.from_dict({"PlayBalance": base_entries})
@@ -46,10 +46,10 @@ def load_config(path: Path | None = None) -> PlayBalanceConfig:
             "hit2BProb": 0,
             "hit3BProb": 0,
             "hitHRProb": 0,
-            "swingProbSureStrike": 0.75,
-            "swingProbCloseStrike": 0.5,
-            "swingProbCloseBall": 0.35,
-            "swingProbSureBall": 0.1,
+            "swingProbSureStrike": 0.66,
+            "swingProbCloseStrike": 0.46,
+            "swingProbCloseBall": 0.51,
+            "swingProbSureBall": 0.13,
         }
     )
     # The real configuration contains pitch objective weights which would


### PR DESCRIPTION
## Summary
- shift swing behavior by increasing default out-of-zone swing probabilities and moderating in-zone swings in PBINI defaults
- keep swing probability scaling neutral and update test config to rely on new PBINI values

## Testing
- `pytest` *(fails: tests/test_simulation.py::test_pinch_hitter_not_used, tests/test_simulation.py::test_steal_attempt_success, tests/test_simulation.py::test_steal_attempt_failure, tests/test_simulation.py::test_catcher_reaction_delay_affects_steal, tests/test_simulation.py::test_hit_and_run_count_adjust, tests/test_simulation.py::test_pitch_out_count_adjust, tests/test_simulation.py::test_starter_replaced_when_toast, tests/test_simulation.py::test_run_tracking_and_boxscore, tests/test_simulation.py::test_walk_records_stats, tests/test_simulation.py::test_swing_and_miss_records_strikeout, tests/test_simulation.py::test_pitch_control_affects_location, tests/test_simulation.py::test_fielding_stats_tracking, tests/test_simulation_averages.py::test_simulated_averages_close_to_mlb, tests/test_simulation_foul_balls.py::test_fouls_increase_pitches_reduce_strikeouts, tests/test_simulation_foul_balls.py::test_foul_pitch_distribution, tests/test_stadium_dimensions.py::test_custom_stadium_affects_hit_value, tests/test_standings_window.py::test_standings_action_opens_dialog, tests/test_swing_and_miss_rate.py::test_swstr_and_bip_rates, tests/test_swing_and_miss_rate.py::test_swing_rates_match_modern_game; etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c4c6ea2670832e957acf3ed130eaf6