### PR TITLE
feat: increase swings on close balls as strike count rises

### DIFF
--- a/docs/simulation_engine.md
+++ b/docs/simulation_engine.md
@@ -41,8 +41,9 @@ A collection of focused modules encapsulate specific decision making:
 
 - `PitcherAI` selects pitches and objectives using configurable weights and
   tracks which pitches have been established【F:playbalance/pitcher_ai.py†L1-L33】【F:playbalance/pitcher_ai.py†L48-L60】.
-- `BatterAI` applies count-based adjustments to swing decisions and computes the
-  contact quality of a swing【F:playbalance/batter_ai.py†L1-L39】【F:playbalance/batter_ai.py†L58-L70】.
+- `BatterAI` applies count-based adjustments to swing decisions—including a
+  strike-sensitive bonus for close balls—and computes the contact quality of a
+  swing【F:playbalance/batter_ai.py†L1-L39】【F:playbalance/batter_ai.py†L58-L70】.
 - `SubstitutionManager` evaluates pinch hitting, defensive replacements and
   bullpen usage using ratings derived from player attributes and configuration
   chances【F:playbalance/substitution_manager.py†L1-L108】.

--- a/playbalance/batter_ai.py
+++ b/playbalance/batter_ai.py
@@ -326,6 +326,13 @@ class BatterAI:
         count_key = f"swingProb{balls}{strikes}CountAdjust"
         swing_chance += getattr(self.config, count_key, 0) / 100.0
 
+        # Strike-sensitive bonus for pitches just off the plate.
+        if pitch_kind == "close ball":
+            swing_chance += strikes * getattr(
+                self.config, "closeBallStrikeBonus", 0
+            ) / 100.0
+            swing_chance = clamp01(swing_chance)
+
         # Discipline pushes aggressiveness in the expected direction.
         if pitch_kind in {"sure strike", "close strike"}:
             swing_chance += (discipline - 0.5) * 0.2

--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -227,6 +227,8 @@ _DEFAULTS: Dict[str, Any] = {
     # Separate scaling factors for pitches in and out of the zone
     "zSwingProbScale": 1.0,
     "oSwingProbScale": 1.0,
+    # Bonus applied to close-ball swing probability per strike
+    "closeBallStrikeBonus": 0,
     # Count and location adjustments to swing probability
     "swingProb00CountAdjust": 0,
     "swingProb01CountAdjust": 0,

--- a/tests/test_close_ball_strike_bias.py
+++ b/tests/test_close_ball_strike_bias.py
@@ -1,0 +1,38 @@
+from playbalance.batter_ai import BatterAI
+from tests.util.pbini_factory import make_cfg
+from tests.test_simulation import make_player, make_pitcher
+
+
+def test_close_ball_strike_bias():
+    cfg = make_cfg(closeBallStrikeBonus=5, swingProbScale=1.0)
+    ai0 = BatterAI(cfg)
+    ai2 = BatterAI(cfg)
+    batter = make_player("b1")
+    pitcher = make_pitcher("p1")
+
+    samples = [i / 1000 for i in range(1000)]
+    swings0 = 0
+    swings2 = 0
+    for rv in samples:
+        swing0, _ = ai0.decide_swing(
+            batter,
+            pitcher,
+            pitch_type="fb",
+            balls=0,
+            strikes=0,
+            dist=4,
+            random_value=rv,
+        )
+        swing2, _ = ai2.decide_swing(
+            batter,
+            pitcher,
+            pitch_type="fb",
+            balls=0,
+            strikes=2,
+            dist=4,
+            random_value=rv,
+        )
+        swings0 += int(swing0)
+        swings2 += int(swing2)
+
+    assert swings2 > swings0


### PR DESCRIPTION
## Summary
- add strike-count bonus to BatterAI swing probability on close balls
- expose `closeBallStrikeBonus` configuration default and document behaviour
- describe strike-sensitive swings in simulation engine docs
- test that close-ball swing frequency rises with more strikes

## Testing
- `pytest` *(fails: assert 1 == 0, assert 2 == 1, etc.)*
- `pytest tests/test_close_ball_strike_bias.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4cd200dc4832e81e7c59552a89151