### PR TITLE
Preserve abbreviations for pitcher ratings

### DIFF
--- a/ui/player_profile_dialog.py
+++ b/ui/player_profile_dialog.py
@@ -245,11 +245,12 @@ class PlayerProfileDialog(QDialog):
         group = QGroupBox(title)
         grid = QGridLayout()
         for col, (key, val) in enumerate(data.items()):
-            grid.addWidget(
-                QLabel(str(key).replace("_", " ").title()),
-                0,
-                col,
-            )
+            label = str(key)
+            if label.isupper():
+                label_text = label
+            else:
+                label_text = label.replace("_", " ").title()
+            grid.addWidget(QLabel(label_text), 0, col)
             grid.addWidget(QLabel(self._format_stat(val)), 1, col)
         group.setLayout(grid)
         return group


### PR DESCRIPTION
## Summary
- ensure pitcher player profiles display rating abbreviations (EN, CO, MO, HR) in uppercase

## Testing
- `pytest` (fails: assert 1 == 0, etc.)
- `flake8 ui/player_profile_dialog.py` (command not found; attempted install failed)


------
https://chatgpt.com/codex/tasks/task_e_68c4d03dcddc832ebc71c847a71e73ba