### PR TITLE
Tune swing probability scaling

### DIFF
--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -223,10 +223,10 @@ _DEFAULTS: Dict[str, Any] = {
     "swingProbCloseBall": 0.51,
     "swingProbSureBall": 0.13,
     # Global swing probability scaling factor
-    "swingProbScale": 0.9,
+    "swingProbScale": 1.1,
     # Separate scaling factors for pitches in and out of the zone
-    "zSwingProbScale": 1.0,
-    "oSwingProbScale": 1.0,
+    "zSwingProbScale": 0.85,
+    "oSwingProbScale": 2.7,
     # Bonus applied to close-ball swing probability per strike
     "closeBallStrikeBonus": 0,
     # Count and location adjustments to swing probability


### PR DESCRIPTION
## Summary
- boost global swing probability scaling to raise overall swing rate
- lower zone swing scale to align with MLB zone swing frequency
- raise out-of-zone swing scale toward MLB's O-Swing rate

## Testing
- `pytest` *(fails: ValueError: Team ABU does not have enough position players, AssertionError, etc.; 79 failed, 326 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d4f0d098832ea3a5230d021f8a08