### PR TITLE
Tune contact and misread parameters

### DIFF
--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -297,13 +297,13 @@ _DEFAULTS: Dict[str, Any] = {
     "disciplineRating31CountAdjust": 5,
     "disciplineRating32CountAdjust": 15,
     # Baseline contact chance when the batter misreads the pitch
-    "minMisreadContact": 0.3,
+    "minMisreadContact": 0.5,
     # Final contact multiplier applied to swing decisions
     # Lowered to reintroduce swing-and-miss outcomes while keeping run scoring in line
-    "contactQualityScale": 1.2,
+    "contactQualityScale": 1.5,
     # Scaling factors for batter skills impacting contact quality
-    "contactAbilityScale": 0.3,
-    "contactDisciplineScale": 0.2,
+    "contactAbilityScale": 0.4,
+    "contactDisciplineScale": 0.3,
     # Check-swing tuning ---------------------------------------------------
     "checkChanceBasePower": 150,
     "checkChanceBaseNormal": 250,


### PR DESCRIPTION
## Summary
- Increase minimum contact when batter misreads the pitch
- Boost contact quality, ability, and discipline scaling factors

## Testing
- `pytest` *(fails: 80 failed, 325 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d6196ad8832eaea77ec2ba16ba07