### PR TITLE
Improve double play conversion probability

### DIFF
--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -191,7 +191,7 @@ _DEFAULTS: Dict[str, Any] = {
     "ballInPlayPitchPct": 17,
     "ballInPlayOuts": 0,
     # Probability that a ground ball with a force at second becomes a double play
-    "doublePlayProb": 0.35,
+    "doublePlayProb": 0.60,
     # Baseline aggression for runners attempting extra bases
     "baserunningAggression": 0.35,
     # Hit by pitch avoidance ----------------------------------------


### PR DESCRIPTION
## Summary
- raise infield double play probability from 0.35 to 0.60

## Testing
- `pytest` *(fails: 81 failed, 324 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d72d3a08832ea813f1f4871caf26