### PR TITLE
Adjust swing probability scaling

### DIFF
--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -223,10 +223,10 @@ _DEFAULTS: Dict[str, Any] = {
     "swingProbCloseBall": 0.51,
     "swingProbSureBall": 0.13,
     # Global swing probability scaling factor
-    "swingProbScale": 1.1,
+    "swingProbScale": 1.2,
     # Separate scaling factors for pitches in and out of the zone
-    "zSwingProbScale": 0.85,
-    "oSwingProbScale": 2.7,
+    "zSwingProbScale": 0.8,
+    "oSwingProbScale": 3.0,
     # Bonus applied to close-ball swing probability per strike
     "closeBallStrikeBonus": 0,
     # Count and location adjustments to swing probability


### PR DESCRIPTION
## Summary
- tune swing probability scaling to encourage earlier swings

## Testing
- `python -m pytest -q` *(fails: AttributeError, AssertionError and TypeError; 84 failed, 321 passed, 3 skipped)*
- `python scripts/playbalance_simulate.py --games 1 --seed 1 --no-progress` *(fails: NumPy is required to run this script)*

------
https://chatgpt.com/codex/tasks/task_e_68c4dd010638832eb834f9f3fcdc05eb