### PR TITLE
Tune ball in play pitch rate

### DIFF
--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -16,7 +16,7 @@ _OVERRIDE_PATH = DATA_DIR / "playbalance_overrides.json"
 # MLB averages used to derive strike-based foul rates from all pitches.
 # These baseline percentages are tuned to yield roughly four pitches per
 # plate appearance, matching modern MLB norms.
-_FOUL_PITCH_BASE_PCT = 15  # Percent of all pitches that are fouls
+_FOUL_PITCH_BASE_PCT = 16  # Percent of all pitches that are fouls
 _LEAGUE_STRIKE_PCT = 65.3  # Percent of all pitches that are strikes
 
 # Default values for PlayBalance configuration entries used throughout the
@@ -848,7 +848,7 @@ class PlayBalanceConfig:
 if _benchmarks:
     _DEFAULTS["ballInPlayPitchPct"] = int(
         round(_benchmarks.get("pitches_put_in_play_pct", 0.175) * 100)
-    )
+    ) - 1
     _DEFAULTS["targetPitchesPerPA"] = _benchmarks.get("pitches_per_pa", 4.0)
     dp_pct = _benchmarks.get("bip_double_play_pct", 0.028)
     gb_pct = _benchmarks.get("bip_gb_pct", 0.44)

--- a/playbalance/sim_config.py
+++ b/playbalance/sim_config.py
@@ -33,7 +33,7 @@ def apply_league_benchmarks(
     # Base hit probability derived directly from league BABIP
     cfg.hitProbBase = benchmarks["babip"] / (1 - hr_rate)
     pip_pct = benchmarks["pitches_put_in_play_pct"]
-    cfg.ballInPlayPitchPct = int(round(pip_pct * 100))
+    cfg.ballInPlayPitchPct = int(round(pip_pct * 100)) - 1
     pitches_per_pa = benchmarks["pitches_per_pa"]
     cfg.swingProbScale = round(4.0 / pitches_per_pa, 2) if pitches_per_pa else 1.0
 

--- a/tests/test_bip_distribution.py
+++ b/tests/test_bip_distribution.py
@@ -20,9 +20,9 @@ def test_bip_distribution():
 
     foul_pitch_pct = PB_CFG.foulPitchBasePct / 100.0
     bip_pitch_pct = PB_CFG.ballInPlayPitchPct / 100.0
-    # Verify configured baselines roughly match MLB averages (~18% each)
-    assert foul_pitch_pct == pytest.approx(0.18, abs=0.01)
-    assert bip_pitch_pct == pytest.approx(0.18, abs=0.01)
+    # Verify configured baselines roughly match MLB averages
+    assert foul_pitch_pct == pytest.approx(0.16, abs=0.01)
+    assert bip_pitch_pct == pytest.approx(0.17, abs=0.01)
     contact_rate = foul_pitch_pct + bip_pitch_pct
     prob = GameSimulation._foul_probability(sim_stub, batter, pitcher)
     expected_foul_pct = contact_rate * prob

--- a/tests/test_league_benchmarks.py
+++ b/tests/test_league_benchmarks.py
@@ -17,7 +17,7 @@ def test_apply_league_benchmarks():
     }
     apply_league_benchmarks(cfg, benchmarks)
     assert cfg.hitProbBase == pytest.approx(0.291 / 0.95, abs=0.0001)
-    assert cfg.ballInPlayPitchPct == 18
+    assert cfg.ballInPlayPitchPct == 17
     assert cfg.swingProbScale == pytest.approx(1.04, abs=0.001)
     assert cfg.groundOutProb == pytest.approx(0.767, abs=0.001)
     assert cfg.lineOutProb == pytest.approx(0.323, abs=0.001)

--- a/tests/test_playbalance_config.py
+++ b/tests/test_playbalance_config.py
@@ -21,7 +21,7 @@ def test_playbalance_config_defaults():
     assert cfg.ground_ball_base_rate == 44
     assert cfg.fly_ball_base_rate == 35
     assert cfg.hit_prob_base == pytest.approx(0.12)
-    assert cfg.foulPitchBasePct == 15
+    assert cfg.foulPitchBasePct == 16
     assert cfg.foulStrikeBasePct == 31
     assert cfg.foulContactTrendPct == 2.0
     assert cfg.minMisreadContact == 0.3


### PR DESCRIPTION
## Summary
- Lower ball in play pitch percentage by one point and bump league foul pitch baseline to 16%
- Update benchmark application and tests for new distributions

## Testing
- `pytest` *(fails: Team DRO does not have enough position players, etc.)*
- `python scripts/simulate_season_avg.py --disable-tqdm --seed 0` *(fails: Team DRO does not have enough position players)*
- `python - <<'PY' ...` *(shows foul_pct≈0.161, bip_pct≈0.170)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ddff573c832e88e6d6594b49e2c9