### PR TITLE
Reduce baseline grounder rate

### DIFF
--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -145,7 +145,7 @@ _DEFAULTS: Dict[str, Any] = {
     "vertAngleGFPct": 0,
     "sprayAnglePLPct": 0,
     # Baseline batted ball type distribution (ground/line/fly)
-    "groundBallBaseRate": 44,
+    "groundBallBaseRate": 41,
     "flyBallBaseRate": 35,
     "lineDriveBaseRate": 21,
     # Weighting factors for batter/pitcher influence on batted ball types

--- a/tests/test_playbalance_config.py
+++ b/tests/test_playbalance_config.py
@@ -18,7 +18,7 @@ def test_playbalance_config_defaults():
     assert cfg.exit_velo_contact_pct == 100
     assert cfg.vert_angle_gf_pct == 0
     assert cfg.spray_angle_pl_pct == 0
-    assert cfg.ground_ball_base_rate == 44
+    assert cfg.ground_ball_base_rate == 41
     assert cfg.fly_ball_base_rate == 35
     assert cfg.hit_prob_base == pytest.approx(0.12)
     assert cfg.foulPitchBasePct == 16


### PR DESCRIPTION
## Summary
- Lower groundBallBaseRate default to tone down grounders
- Align groundBallBaseRate default test with new value

## Testing
- `pytest` *(fails: ValueError: Team ABU does not have enough position players, etc.)*
- `PYTHONPATH=. python scripts/playbalance_simulate.py --games 20 --seed 1 --no-progress` *(fails: RuntimeError: NumPy is required to run this script)*
- `python - <<'PY' ...` *(BIP GB% 0.4232)*

------
https://chatgpt.com/codex/tasks/task_e_68c4df7ad3b8832e804c70824f7d6a6b