### PR TITLE
Increase fly ball base rate

### DIFF
--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -146,7 +146,7 @@ _DEFAULTS: Dict[str, Any] = {
     "sprayAnglePLPct": 0,
     # Baseline batted ball type distribution (ground/line/fly)
     "groundBallBaseRate": 41,
-    "flyBallBaseRate": 35,
+    "flyBallBaseRate": 38,
     "lineDriveBaseRate": 21,
     # Weighting factors for batter/pitcher influence on batted ball types
     "bipPowerWeight": 0.2,


### PR DESCRIPTION
## Summary
- raise flyBallBaseRate baseline to encourage ~35% league fly-ball rate

## Testing
- `pytest` *(fails: 83 failed, 322 passed, 3 skipped)*
- `python scripts/playbalance_simulate.py` *(fails: NumPy is required)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e1634d1c832e9aedfd04bf371d68