### PR TITLE
Tune line drive base rate

### DIFF
--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -147,7 +147,7 @@ _DEFAULTS: Dict[str, Any] = {
     # Baseline batted ball type distribution (ground/line/fly)
     "groundBallBaseRate": 41,
     "flyBallBaseRate": 38,
-    "lineDriveBaseRate": 21,
+    "lineDriveBaseRate": 20,
     # Weighting factors for batter/pitcher influence on batted ball types
     "bipPowerWeight": 0.2,
     "bipLaunchWeight": 0.2,


### PR DESCRIPTION
## Summary
- reduce baseline line drive rate for batted balls

## Testing
- `pytest` *(fails: assert mismatches, missing roster data etc.)*
- `PYTHONPATH=. python - <<'PY'
... simulation snippet ...
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c4e2473928832ea1a7cf94a71ed13a