### PR TITLE
Reduce default strike rate for more walks

### DIFF
--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -17,7 +17,7 @@ _OVERRIDE_PATH = DATA_DIR / "playbalance_overrides.json"
 # These baseline percentages are tuned to yield roughly four pitches per
 # plate appearance, matching modern MLB norms.
 _FOUL_PITCH_BASE_PCT = 16  # Percent of all pitches that are fouls
-_LEAGUE_STRIKE_PCT = 65.3  # Percent of all pitches that are strikes
+_LEAGUE_STRIKE_PCT = 64.7  # Percent of all pitches that are strikes
 
 # Default values for PlayBalance configuration entries used throughout the
 # simplified game playbalance.  Missing keys will fall back to these values when


### PR DESCRIPTION
## Summary
- Lower league strike percentage to 64.7 to permit slightly more balls and walks

## Testing
- `pytest` *(fails: missing team data, multiple assertions)*
- `python scripts/playbalance_simulate.py --games 10 --seed 1` *(fails: NumPy is required)*


------
https://chatgpt.com/codex/tasks/task_e_68c5620ca95c832e85203296d6d2f4b3