### PR TITLE
Adjust hit distributions to reduce slugging

### DIFF
--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -139,7 +139,7 @@ _DEFAULTS: Dict[str, Any] = {
     # Exit velocity and launch characteristics
     "exitVeloBase": 0,
     "exitVeloPHPct": 0,
-    "exitVeloPowerPct": 85,
+    "exitVeloPowerPct": 83,
     "exitVeloNormalPct": 85,
     "exitVeloContactPct": 100,
     "vertAngleGFPct": 0,
@@ -155,10 +155,10 @@ _DEFAULTS: Dict[str, Any] = {
     # League average strike percentage
     "leagueStrikePct": _LEAGUE_STRIKE_PCT,
     # Hit type distribution reflecting recent MLB averages
-    "hit1BProb": 65,
+    "hit1BProb": 66,
     "hit2BProb": 20,
     "hit3BProb": 2,
-    "hitHRProb": 13,
+    "hitHRProb": 12,
     # Hit probability tuning ----------------------------------------
     # Baseline additive hit probability tuned for a lower league-wide average
     # to curb excessive offense after other modifiers.


### PR DESCRIPTION
## Summary
- Slightly reduce power exit velocity to limit long drives
- Increase single probability and reduce home run probability for more balanced hits

## Testing
- `python -m playbalance.orchestrator --games 10 --seed 1` *(fails: Team ABU does not have enough position players)*
- `python - <<'PY'
ba=0.245
hit1=66
hit2=20
hit3=2
hitHR=12
avg_bases_per_hit=(hit1+2*hit2+3*hit3+4*hitHR)/100
slg=ba*avg_bases_per_hit
print({'avg_bases_per_hit':avg_bases_per_hit,'slugging':round(slg,3)})
PY`
- `pytest -q` *(fails: multiple errors including missing player data)*

------
https://chatgpt.com/codex/tasks/task_e_68c5630867a4832ebf833f565329954a