### PR TITLE
Increase out-of-zone swing aggressiveness

### DIFF
--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -220,13 +220,13 @@ _DEFAULTS: Dict[str, Any] = {
     # Baseline swing probabilities reflecting MLB averages
     "swingProbSureStrike": 0.66,
     "swingProbCloseStrike": 0.46,
-    "swingProbCloseBall": 0.51,
-    "swingProbSureBall": 0.13,
+    "swingProbCloseBall": 0.56,
+    "swingProbSureBall": 0.18,
     # Global swing probability scaling factor
     "swingProbScale": 1.2,
     # Separate scaling factors for pitches in and out of the zone
     "zSwingProbScale": 0.8,
-    "oSwingProbScale": 3.0,
+    "oSwingProbScale": 3.6,
     # Bonus applied to close-ball swing probability per strike
     "closeBallStrikeBonus": 0,
     # Count and location adjustments to swing probability

--- a/tests/util/pbini_factory.py
+++ b/tests/util/pbini_factory.py
@@ -21,8 +21,8 @@ def make_cfg(**entries: int) -> PlayBalanceConfig:
         "hitHRProb": 0,
         "swingProbSureStrike": 0.66,
         "swingProbCloseStrike": 0.46,
-        "swingProbCloseBall": 0.51,
-        "swingProbSureBall": 0.13,
+        "swingProbCloseBall": 0.56,
+        "swingProbSureBall": 0.18,
     }
     base_entries.update(entries)
     return PlayBalanceConfig.from_dict({"PlayBalance": base_entries})
@@ -48,8 +48,8 @@ def load_config(path: Path | None = None) -> PlayBalanceConfig:
             "hitHRProb": 0,
             "swingProbSureStrike": 0.66,
             "swingProbCloseStrike": 0.46,
-            "swingProbCloseBall": 0.51,
-            "swingProbSureBall": 0.13,
+            "swingProbCloseBall": 0.56,
+            "swingProbSureBall": 0.18,
         }
     )
     # The real configuration contains pitch objective weights which would


### PR DESCRIPTION
## Summary
- raise swing probabilities for sure balls and close balls
- boost global out-of-zone swing scale so hitters chase more often
- align test configuration with updated swing values

## Testing
- `pytest` *(fails: TrackingBatterAI.decide_swing missing, multiple failures)*
- `python scripts/playbalance_simulate.py --games 20 --seed 1` *(fails: ModuleNotFoundError: No module named 'tqdm')*


------
https://chatgpt.com/codex/tasks/task_e_68c566727cac832eb6094d9d0bb8aa92