### PR TITLE
Adjust swing probability scaling for MLB alignment

### DIFF
--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -223,10 +223,10 @@ _DEFAULTS: Dict[str, Any] = {
     "swingProbCloseBall": 0.56,
     "swingProbSureBall": 0.18,
     # Global swing probability scaling factor
-    "swingProbScale": 1.2,
+    "swingProbScale": 1.25,
     # Separate scaling factors for pitches in and out of the zone
-    "zSwingProbScale": 0.82,
-    "oSwingProbScale": 0.72,
+    "zSwingProbScale": 0.79,
+    "oSwingProbScale": 0.69,
     # Bonus applied to close-ball swing probability per strike
     "closeBallStrikeBonus": 0,
     # Count and location adjustments to swing probability

--- a/tests/test_league_swing_pct.py
+++ b/tests/test_league_swing_pct.py
@@ -10,9 +10,9 @@ from tests.util.pbini_factory import make_cfg
 
 def test_league_wide_swing_percentage():
     cfg = make_cfg(idRatingBase=50)
-    cfg.values["swingProbScale"] = 1.2
-    cfg.values["zSwingProbScale"] = 0.82
-    cfg.values["oSwingProbScale"] = 0.72
+    cfg.values["swingProbScale"] = 1.25
+    cfg.values["zSwingProbScale"] = 0.79
+    cfg.values["oSwingProbScale"] = 0.69
     ai = BatterAI(cfg)
     batter = make_player("B", ch=50)
     pitcher = make_pitcher("P", movement=50)

--- a/tests/test_swing_and_miss_rate.py
+++ b/tests/test_swing_and_miss_rate.py
@@ -57,8 +57,8 @@ def test_swstr_and_bip_rates():
 
 def test_swing_rates_match_modern_game():
     cfg = make_cfg(idRatingBase=50)
-    cfg.values["zSwingProbScale"] = 0.82
-    cfg.values["oSwingProbScale"] = 0.45
+    cfg.values["zSwingProbScale"] = 0.79
+    cfg.values["oSwingProbScale"] = 0.43
     ai = BatterAI(cfg)
     batter = make_player("B", ch=50)
     pitcher = make_pitcher("P", movement=50)


### PR DESCRIPTION
## Summary
- raise global `swingProbScale` to 1.25
- retune `zSwingProbScale` and `oSwingProbScale` to preserve MLB swing benchmarks
- update swing percentage tests to new scaling factors

## Testing
- `pytest` *(fails: Team DRO does not have enough po..., etc.)*
- `python scripts/playbalance_simulate.py` *(fails: ModuleNotFoundError: No module named 'tqdm')*


------
https://chatgpt.com/codex/tasks/task_e_68c569554964832e9284d4eaee0122bb