### PR TITLE
Adjust contact and movement factors

### DIFF
--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -164,11 +164,11 @@ _DEFAULTS: Dict[str, Any] = {
     # to curb excessive offense after other modifiers.
     "hitProbBase": 0.045,
     # Boost contact to raise overall zone contact rate closer to MLB levels
-    "contactFactorBase": 1.5,
+    "contactFactorBase": 1.4,
     # Lower divisor so contact-heavy hitters see a larger boost
     # from their ``CH`` rating in hit probability calculations.
     "contactFactorDiv": 200,
-    "movementFactorMin": 0.2,
+    "movementFactorMin": 0.18,
     "movementImpactScale": 0.6,
     # Cap on final hit probability to prevent excessive offense
     "hitProbCap": 0.80,


### PR DESCRIPTION
## Summary
- Reduce contactFactorBase in play-balance config to temper contact rates
- Lower movementFactorMin to keep balance after contact tweak

## Testing
- `pytest` *(fails: 78 failed, 327 passed, 3 skipped)*
- `python scripts/playbalance_simulate.py --games 10 --seed 1` *(missing dependency: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_68c56cb0679c832e9239d88d9877f44e