### PR TITLE
Tune contact factor for swing logic

### DIFF
--- a/playbalance/batter_ai.py
+++ b/playbalance/batter_ai.py
@@ -353,6 +353,11 @@ class BatterAI:
             batter_contact = getattr(batter, "ch", 50)
             pitch_quality = getattr(pitcher, pitch_type, getattr(pitcher, "movement", 50))
             miss_chance = (pitch_quality - batter_contact + 50) / 200.0
+            contact_factor = (
+                self.config.contact_factor_base
+                + (batter_contact - 50) / self.config.contact_factor_div
+            )
+            miss_chance /= contact_factor
             miss_chance = max(0.05, min(0.95, miss_chance))
             rv_contact = rv if check_random is None else check_random
             if rv_contact < miss_chance:

--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -164,7 +164,7 @@ _DEFAULTS: Dict[str, Any] = {
     # to curb excessive offense after other modifiers.
     "hitProbBase": 0.045,
     # Boost contact to raise overall zone contact rate closer to MLB levels
-    "contactFactorBase": 1.4,
+    "contactFactorBase": 1.48,
     # Lower divisor so contact-heavy hitters see a larger boost
     # from their ``CH`` rating in hit probability calculations.
     "contactFactorDiv": 200,

--- a/tests/test_swing_and_miss_rate.py
+++ b/tests/test_swing_and_miss_rate.py
@@ -51,8 +51,8 @@ def test_swstr_and_bip_rates():
         if swing and contact:
             contacts += 1
     rates = compute_pitching_rates(ps)
-    assert rates["swstr_pct"] == pytest.approx(0.165, abs=0.02)
-    assert contacts / pitches == pytest.approx(0.495, abs=0.03)
+    assert rates["swstr_pct"] == pytest.approx(0.116, abs=0.02)
+    assert contacts / pitches == pytest.approx(0.53, abs=0.03)
 
 
 def test_swing_rates_match_modern_game():


### PR DESCRIPTION
## Summary
- scale miss chance by configurable contact factor for more realistic contact rates
- raise default contactFactorBase to 1.48 to target ~76% league contact
- adjust swing-and-miss test expectations for new contact baseline

## Testing
- `python - <<'PY'
from playbalance.simulation import GameSimulation, TeamState
from tests.test_simulation import make_player, make_pitcher
from tests.util.pbini_factory import load_config
from scripts.simulate_season_avg import clone_team_state
import random

cfg = load_config()
cfg.values['contactFactorBase'] = 1.48
cfg.values['contactFactorDiv'] = 200
cfg.values['movementFactorMin'] = 0.18

lineup = [make_player(f'b{i}', ch=50) for i in range(9)]
pitchers = [make_pitcher('p', movement=50)]
team_base = TeamState(lineup=lineup, bench=[], pitchers=pitchers)

rng = random.Random(0)
zone_swings = zone_contacts = o_zone_swings = o_zone_contacts = 0
for g in range(20):
    home = clone_team_state(team_base)
    away = clone_team_state(team_base)
    sim = GameSimulation(home, away, cfg, rng)
    sim.simulate_game()
    for ps in list(home.pitcher_stats.values()) + list(away.pitcher_stats.values()):
        zone_swings += ps.zone_swings
        zone_contacts += ps.zone_contacts
        o_zone_swings += ps.o_zone_swings
        o_zone_contacts += ps.o_zone_contacts
swings = zone_swings + o_zone_swings
contacts = zone_contacts + o_zone_contacts
print('contact_pct', contacts / swings if swings else 0)
PY`
- `pytest tests/test_swing_and_miss_rate.py::test_swstr_and_bip_rates -q`
- `pytest -q` (fails: ValueError: Team ABU does not have enough position players, AttributeError: type object 'object' has no attribute 'new', and others)


------
https://chatgpt.com/codex/tasks/task_e_68c56da7adb0832ea47632ff93a1faa7