### PR TITLE
Tune swing/contact for strikeout rate

### DIFF
--- a/playbalance/sim_config.py
+++ b/playbalance/sim_config.py
@@ -132,10 +132,19 @@ def load_tuned_playbalance_config(
 
     apply_league_benchmarks(cfg, benchmarks, cfg.babip_scale)
 
+    # Apply swing-rate and contact-factor adjustments to curb excessive
+    # strikeouts observed in full season simulations.  Slightly reducing swing
+    # aggression on balls and boosting the contact factor nudges the engine
+    # towards league-average strikeout rates.
+    cfg.zSwingProbScale *= 0.98
+    cfg.oSwingProbScale *= 0.92
+    cfg.contactFactorBase = round(cfg.contactFactorBase * 1.05, 2)
+    cfg.contactFactorDiv = int(cfg.contactFactorDiv * 0.9)
+
     # Boost batter pitch recognition to curb excessive strikeouts seen in
     # season simulations. Increasing the ease scale makes identifying pitches
     # easier which leads to more contact and fewer swinging strikes.
-    cfg.idRatingEaseScale = 2.5
+    cfg.idRatingEaseScale = 3.0
 
     mlb_averages = {stat: float(val) for stat, val in row.items() if stat}
     return cfg, mlb_averages


### PR DESCRIPTION
## Summary
- adjust swing-rate scales and contact factors to rein in strikeouts
- boost pitch recognition ease for batters when strikeouts stay high

## Testing
- `python scripts/playbalance_simulate.py --games 5 --seed 1` *(fails: No module named 'tqdm')*
- `pip install tqdm` *(fails: Could not find a version that satisfies the requirement tqdm)*
- `pytest` *(fails: 76 failed, 329 passed, 3 skipped in 6.32s)*

------
https://chatgpt.com/codex/tasks/task_e_68c56f9c8568832ebcbba09bf38ec54d