### PR TITLE
Tune strike and swing parameters for better walk rates

### DIFF
--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -17,7 +17,9 @@ _OVERRIDE_PATH = DATA_DIR / "playbalance_overrides.json"
 # These baseline percentages are tuned to yield roughly four pitches per
 # plate appearance, matching modern MLB norms.
 _FOUL_PITCH_BASE_PCT = 16  # Percent of all pitches that are fouls
-_LEAGUE_STRIKE_PCT = 64.7  # Percent of all pitches that are strikes
+# Percent of all pitches that are strikes.
+# Slightly reduced to encourage a few more walks across simulations.
+_LEAGUE_STRIKE_PCT = 63.8
 
 # Default values for PlayBalance configuration entries used throughout the
 # simplified game playbalance.  Missing keys will fall back to these values when
@@ -224,7 +226,8 @@ _DEFAULTS: Dict[str, Any] = {
     "swingProbCloseBall": 0.56,
     "swingProbSureBall": 0.18,
     # Global swing probability scaling factor
-    "swingProbScale": 1.25,
+    # Modest reduction to raise walk frequency when strike percentage is low
+    "swingProbScale": 1.22,
     # Separate scaling factors for pitches in and out of the zone
     "zSwingProbScale": 0.79,
     "oSwingProbScale": 0.69,


### PR DESCRIPTION
## Summary
- Lower leagueStrikePct baseline to reduce strike frequency
- Slightly drop swingProbScale so batters take more pitches

## Testing
- `pytest` *(fails: Team DRO does not have enough position players)*
- `python -m playbalance.orchestrator --games 50 --seed 1` *(fails: Team ABU does not have enough position players)*

------
https://chatgpt.com/codex/tasks/task_e_68c570780794832e8dee778829a7c908