### PR TITLE
Tune steal aggressiveness

### DIFF
--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -197,7 +197,7 @@ _DEFAULTS: Dict[str, Any] = {
     # Probability that a ground ball with a force at second becomes a double play
     "doublePlayProb": 0.70,
     # Baseline aggression for runners attempting extra bases
-    "baserunningAggression": 0.40,
+    "baserunningAggression": 0.50,
     # Hit by pitch avoidance ----------------------------------------
     "hbpBatterStepOutChance": 18,
     "hbpBaseChance": 0.0,
@@ -351,7 +351,7 @@ _DEFAULTS: Dict[str, Any] = {
     "stealChance30Count": 15,
     "stealChance31Count": 15,
     "stealChance32Count": 20,
-    "offManStealChancePct": 67,
+    "offManStealChancePct": 80,
     "stealSuccessTagOutPct": 25,
     "stealSuccessSafePct": 75,
     "stealChanceVerySlowThresh": 13,


### PR DESCRIPTION
## Summary
- Increase baseline baserunning aggression
- Raise off-man steal chance to encourage more stolen base attempts

## Testing
- `pytest` *(fails: 77 failed, 328 passed, 3 skipped)*
- `PYTHONPATH=. python /tmp/playbalance_simulate_nopy.py` *(fails: Team DRO does not have enough position players)*

------
https://chatgpt.com/codex/tasks/task_e_68c57304f1cc832e83605c7d1b3e8f5f