### PR TITLE
Add option to skip benchmark tuning in playbalance simulations

### DIFF
--- a/scripts/playbalance_simulate.py
+++ b/scripts/playbalance_simulate.py
@@ -281,7 +281,7 @@ def main(argv: list[str] | None = None) -> int:
     configure_perf_tuning()
 
     benchmarks = load_benchmarks()
-    cfg, _ = load_tuned_playbalance_config()
+    cfg, _ = load_tuned_playbalance_config(apply_benchmarks=False)
 
     team_ids = [t.team_id for t in load_teams("data/teams.csv")]
     base_states = {tid: pickle.dumps(build_default_game_state(tid)) for tid in team_ids}


### PR DESCRIPTION
## Summary
- add `apply_benchmarks` flag to `load_tuned_playbalance_config`
- make benchmark tuning optional in simulation script to respect user config

## Testing
- `pytest` *(fails: 77 failed, 328 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c577112468832e9361095b178f52ce