### PR TITLE
Adjust hit probability baseline scaling

### DIFF
--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -162,9 +162,11 @@ _DEFAULTS: Dict[str, Any] = {
     "hit3BProb": 2,
     "hitHRProb": 12,
     # Hit probability tuning ----------------------------------------
-    # Baseline additive hit probability tuned for a lower league-wide average
-    # to curb excessive offense after other modifiers.
-    "hitProbBase": 0.045,
+    # Baseline hit probability value scaled down when accessed via
+    # :pyattr:`hit_prob_base`.  The property multiplies the stored value by
+    # ``0.1`` so a default of ``1.2`` yields an effective additive term of
+    # ``0.12`` in the simulation.
+    "hitProbBase": 1.2,
     # Boost contact to raise overall zone contact rate closer to MLB levels
     "contactFactorBase": 1.48,
     # Lower divisor so contact-heavy hitters see a larger boost
@@ -799,7 +801,7 @@ class PlayBalanceConfig:
     @property
     def hit_prob_base(self) -> float:
         """Baseline additive probability for a ball in play to become a hit."""
-        return float(self.hitProbBase)
+        return float(self.hitProbBase) * 0.1
 
     @property
     def contact_factor_base(self) -> float:

--- a/playbalance/sim_config.py
+++ b/playbalance/sim_config.py
@@ -31,9 +31,11 @@ def apply_league_benchmarks(
         default) ``cfg.babip_scale`` is used.
     """
 
-    hr_rate = cfg.hitHRProb / 100
-    # Base hit probability derived directly from league BABIP
-    cfg.hitProbBase = benchmarks["babip"] / (1 - hr_rate)
+    # Base hit probability derived from league BABIP.  ``hitProbBase`` is
+    # scaled down in :mod:`playbalance.simulation` so multiply the MLB BABIP
+    # by ``1.5`` to produce a small additive term in the final hit probability
+    # calculation.
+    cfg.hitProbBase = benchmarks["babip"] * 1.5
     pip_pct = benchmarks["pitches_put_in_play_pct"]
     cfg.ballInPlayPitchPct = int(round(pip_pct * 100)) - 1
     pitches_per_pa = benchmarks["pitches_per_pa"]

--- a/playbalance/simulation.py
+++ b/playbalance/simulation.py
@@ -1780,7 +1780,7 @@ class GameSimulation:
                     * contact_factor
                     * movement_factor
                 )
-                + self.config.hit_prob_base,
+                + self.config.hit_prob_base,  # value scaled in PlayBalanceConfig
             ),
         )
         # Modify hit probability based on current defensive alignment.

--- a/tests/test_league_benchmarks.py
+++ b/tests/test_league_benchmarks.py
@@ -16,7 +16,7 @@ def test_apply_league_benchmarks():
         "bip_ld_pct": 0.21,
     }
     apply_league_benchmarks(cfg, benchmarks)
-    assert cfg.hitProbBase == pytest.approx(0.291 / 0.95, abs=0.0001)
+    assert cfg.hitProbBase == pytest.approx(0.291 * 1.5, abs=0.0001)
     assert cfg.ballInPlayPitchPct == 17
     assert cfg.swingProbScale == pytest.approx(1.04, abs=0.001)
     assert cfg.groundOutProb == pytest.approx(0.920, abs=0.001)


### PR DESCRIPTION
## Summary
- Scale `hitProbBase` via `PlayBalanceConfig` so the simulation uses a smaller additive baseline
- Derive tuned `hitProbBase` from MLB BABIP in `apply_league_benchmarks`
- Align league benchmark test with new hit probability scaling

## Testing
- `pytest` *(fails: Team DRO does not have enough position players, assert 0 == 1, etc.)*
- `python scripts/playbalance_simulate.py --games 1` *(failed: No module named 'tqdm')*


------
https://chatgpt.com/codex/tasks/task_e_68c577fe272c832ebbdb64c11dbe3c8d