### PR TITLE
feat: make swing scaling configurable

### DIFF
--- a/playbalance/playbalance_config.py
+++ b/playbalance/playbalance_config.py
@@ -234,6 +234,9 @@ _DEFAULTS: Dict[str, Any] = {
     # Separate scaling factors for pitches in and out of the zone
     "zSwingProbScale": 0.79,
     "oSwingProbScale": 0.69,
+    # Additional tuning applied after benchmark adjustments
+    "extraZSwingScale": 0.98,
+    "extraOSwingScale": 0.92,
     # Bonus applied to close-ball swing probability per strike
     "closeBallStrikeBonus": 0,
     # Count and location adjustments to swing probability
@@ -832,6 +835,26 @@ class PlayBalanceConfig:
     def babip_scale(self, value: float) -> None:
         """Set scaling factor for outs on balls in play."""
         self.babipScale = value
+
+    @property
+    def extra_z_swing_scale(self) -> float:
+        """Additional scaling applied to zone swing probability."""
+        return float(self.extraZSwingScale)
+
+    @extra_z_swing_scale.setter
+    def extra_z_swing_scale(self, value: float) -> None:
+        """Set additional scaling for zone swing probability."""
+        self.extraZSwingScale = value
+
+    @property
+    def extra_o_swing_scale(self) -> float:
+        """Additional scaling applied to out-of-zone swing probability."""
+        return float(self.extraOSwingScale)
+
+    @extra_o_swing_scale.setter
+    def extra_o_swing_scale(self, value: float) -> None:
+        """Set additional scaling for out-of-zone swing probability."""
+        self.extraOSwingScale = value
 
     # ------------------------------------------------------------------
     # Mapping style helpers

--- a/playbalance/sim_config.py
+++ b/playbalance/sim_config.py
@@ -50,6 +50,12 @@ def apply_league_benchmarks(
         base_o *= cfg.swingProbScale
         cfg.zSwingProbScale = round(z_swing_pct / base_z, 2) if base_z else 1.0
         cfg.oSwingProbScale = round(o_swing_pct / base_o, 2) if base_o else 1.0
+        cfg.zSwingProbScale = round(
+            cfg.zSwingProbScale * cfg.extra_z_swing_scale, 2
+        )
+        cfg.oSwingProbScale = round(
+            cfg.oSwingProbScale * cfg.extra_o_swing_scale, 2
+        )
 
     swing_pct = benchmarks.get("swing_pct")
     zone_pct = benchmarks.get("zone_pct")
@@ -141,12 +147,9 @@ def load_tuned_playbalance_config(
 
         apply_league_benchmarks(cfg, benchmarks, cfg.babip_scale)
 
-        # Apply swing-rate and contact-factor adjustments to curb excessive
-        # strikeouts observed in full season simulations.  Slightly reducing swing
-        # aggression on balls and boosting the contact factor nudges the engine
-        # towards league-average strikeout rates.
-        cfg.zSwingProbScale *= 0.98
-        cfg.oSwingProbScale *= 0.92
+        # Apply contact-factor adjustments to curb excessive strikeouts observed
+        # in full season simulations. Slightly boosting the contact factor nudges
+        # the engine toward league-average strikeout rates.
         cfg.contactFactorBase = round(cfg.contactFactorBase * 1.05, 2)
         cfg.contactFactorDiv = int(cfg.contactFactorDiv * 0.9)
 


### PR DESCRIPTION
## Summary
- expose extraZSwingScale and extraOSwingScale to tune swing aggression
- apply extra swing scaling in `apply_league_benchmarks`
- document new configuration fields

## Testing
- `pytest` *(fails: 76 failed, 329 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c57b186418832ea8d93d65a7b52201