### PR TITLE
Convert fielding slop timing from frames to seconds

### DIFF
--- a/playbalance/fielding_ai.py
+++ b/playbalance/fielding_ai.py
@@ -188,23 +188,17 @@ class FieldingAI:
     def should_relay_throw(self, fielder_time: float, runner_time: float) -> bool:
         """Return ``True`` if a relay throw should be attempted."""
 
-        return (
-            fielder_time + self.config.generalSlop + self.config.relaySlop
-            <= runner_time
-        )
+        slop = (self.config.generalSlop + self.config.relaySlop) / 60
+        return fielder_time + slop <= runner_time
 
     def should_tag_runner(self, fielder_time: float, runner_time: float) -> bool:
         """Return ``True`` if a tag play beats the runner."""
 
-        return (
-            fielder_time + self.config.generalSlop + self.config.tagTimeSlop
-            <= runner_time
-        )
+        slop = (self.config.generalSlop + self.config.tagTimeSlop) / 60
+        return fielder_time + slop <= runner_time
 
     def should_run_to_bag(self, fielder_time: float, runner_time: float) -> bool:
         """Return ``True`` if the fielder can reach the bag in time."""
 
-        return (
-            fielder_time + self.config.generalSlop + self.config.stepOnBagSlop
-            <= runner_time
-        )
+        slop = (self.config.generalSlop + self.config.stepOnBagSlop) / 60
+        return fielder_time + slop <= runner_time

--- a/tests/test_fielding_ai.py
+++ b/tests/test_fielding_ai.py
@@ -20,34 +20,34 @@ def test_catch_slop_changes_decision():
 def test_relay_slop_affects_choice():
     cfg = PlayBalanceConfig()
     ai = FieldingAI(cfg)
-    assert not ai.should_relay_throw(fielder_time=10, runner_time=30)
+    assert not ai.should_relay_throw(fielder_time=1.0, runner_time=1.1)
 
     cfg = PlayBalanceConfig()
     cfg.relaySlop = -10
     ai = FieldingAI(cfg)
-    assert ai.should_relay_throw(fielder_time=10, runner_time=30)
+    assert ai.should_relay_throw(fielder_time=1.0, runner_time=1.1)
 
 
 def test_tag_slop_affects_choice():
     cfg = PlayBalanceConfig()
     ai = FieldingAI(cfg)
-    assert not ai.should_tag_runner(fielder_time=10, runner_time=20)
+    assert not ai.should_tag_runner(fielder_time=1.0, runner_time=1.05)
 
     cfg = PlayBalanceConfig()
     cfg.tagTimeSlop = -10
     ai = FieldingAI(cfg)
-    assert ai.should_tag_runner(fielder_time=10, runner_time=20)
+    assert ai.should_tag_runner(fielder_time=1.0, runner_time=1.05)
 
 
 def test_run_to_bag_slop_affects_choice():
     cfg = PlayBalanceConfig()
     ai = FieldingAI(cfg)
-    assert ai.should_run_to_bag(fielder_time=10, runner_time=20)
+    assert ai.should_run_to_bag(fielder_time=1.0, runner_time=1.05)
 
     cfg = PlayBalanceConfig()
     cfg.stepOnBagSlop = 15
     ai = FieldingAI(cfg)
-    assert not ai.should_run_to_bag(fielder_time=10, runner_time=20)
+    assert not ai.should_run_to_bag(fielder_time=1.0, runner_time=1.05)
 
 
 def test_higher_fa_reduces_throw_errors():


### PR DESCRIPTION
## Summary
- convert relay, tag, and bag-slop timing to seconds in FieldingAI
- update fielding AI tests for second-based timings

## Testing
- `pytest tests/test_fielding_ai.py -q`
- `pytest tests/test_runner_advancement.py -q`
- `pytest tests/test_simulation_double_play_rate.py -q`
- `pytest -q` *(fails: Team ABU does not have enough position players, UI window flag attribute errors, multiple other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b9935d10832e9258d812e3db0a5a